### PR TITLE
feat: add github link to about page

### DIFF
--- a/docs/plans/2026-03-14-about-github-link-design.md
+++ b/docs/plans/2026-03-14-about-github-link-design.md
@@ -1,0 +1,71 @@
+# 关于页 GitHub 链接设计
+
+## 目标
+
+在程序的关于页面增加项目 GitHub 仓库链接，指向：
+
+- https://github.com/GcsSloop/ai-gate
+
+## 现状
+
+关于页位于设置页面的 `about` tab，当前已经展示：
+
+- 应用图标与名称
+- 版本号
+- 作者
+- 更新卡片
+
+但没有项目主页入口。
+
+## 方案对比
+
+### 方案 A：在关于页元信息区域新增 GitHub 行
+
+优点：
+- 与作者、版本信息保持同一视觉层级
+- 改动最小，不破坏当前布局
+- 用户能直接在 About 中找到仓库地址
+
+缺点：
+- 入口显眼程度适中，不是强按钮样式
+
+### 方案 B：在 About 顶部加单独按钮
+
+优点：
+- 更醒目
+
+缺点：
+- 会打破当前极简信息卡片布局
+- 容易与更新卡片争夺视觉焦点
+
+### 方案 C：把 GitHub 链接塞进更新卡片附近
+
+优点：
+- 和发布、版本来源相关
+
+缺点：
+- 语义不如放在 About 元信息区直接
+- 位置不够稳定
+
+## 选择
+
+采用方案 A。
+
+## 详细设计
+
+- 在关于页 `about-meta` 中增加一行 `GitHub`
+- 右侧展示可点击链接文本，优先显示 `GcsSloop/ai-gate`
+- 使用标准外链：
+  - `href="https://github.com/GcsSloop/ai-gate"`
+  - `target="_blank"`
+  - `rel="noreferrer"`
+- 桌面端和浏览器端都复用浏览器跳转行为，不新增 Tauri 专属调用
+- 补一个前端测试，验证：
+  - 关于页存在 `GitHub` 文本
+  - 链接 `href` 正确
+
+## 影响范围
+
+- `frontend/src/features/settings/SettingsPage.tsx`
+- `frontend/src/features/settings/SettingsPage.test.tsx`
+- 如有必要，补 `frontend/src/styles.css` 细节样式

--- a/docs/plans/2026-03-14-about-github-link.md
+++ b/docs/plans/2026-03-14-about-github-link.md
@@ -1,0 +1,84 @@
+# About GitHub Link Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add the GitHub repository link to the About page and carry the change through the repository release flow.
+
+**Architecture:** Keep the About page structure intact and add one new metadata row for GitHub. Use TDD by adding a focused SettingsPage test first, then implement the minimal JSX and style needed, verify locally, commit, and then run the existing release-rebase-pr-tag-loop workflow.
+
+**Tech Stack:** React, Vitest, Ant Design, GitHub Actions, existing release workflow
+
+---
+
+### Task 1: Add the failing About-page test
+
+**Files:**
+- Modify: `frontend/src/features/settings/SettingsPage.test.tsx`
+- Test: `frontend/src/features/settings/SettingsPage.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add a test that opens the `关于` tab and asserts:
+- text `GitHub` exists
+- a link with name `GcsSloop/ai-gate` exists
+- `href` equals `https://github.com/GcsSloop/ai-gate`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npm test -- --run src/features/settings/SettingsPage.test.tsx`
+Expected: FAIL because the About page does not render the GitHub link yet.
+
+**Step 3: Write minimal implementation**
+
+Add one `about-meta-row` in `frontend/src/features/settings/SettingsPage.tsx` containing the GitHub label and anchor.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npm test -- --run src/features/settings/SettingsPage.test.tsx`
+Expected: PASS.
+
+### Task 2: Verify touched frontend scope
+
+**Files:**
+- Modify: `frontend/src/features/settings/SettingsPage.tsx`
+- Modify: `frontend/src/features/settings/SettingsPage.test.tsx`
+- Create: `docs/plans/2026-03-14-about-github-link-design.md`
+- Create: `docs/plans/2026-03-14-about-github-link.md`
+
+**Step 1: Run broader frontend verification**
+
+Run: `cd frontend && npm test -- --run src/App.test.tsx src/features/settings/SettingsPage.test.tsx src/features/updates/UpdateCard.test.tsx src/features/updates/updateService.test.ts`
+Expected: PASS.
+
+**Step 2: Run diff hygiene check**
+
+Run: `git diff --check`
+Expected: no output.
+
+**Step 3: Commit**
+
+```bash
+git add frontend/src/features/settings/SettingsPage.tsx frontend/src/features/settings/SettingsPage.test.tsx docs/plans/2026-03-14-about-github-link-design.md docs/plans/2026-03-14-about-github-link.md
+git commit -m "feat: add github link to about page"
+```
+
+### Task 3: Run the software release flow
+
+**Files:**
+- No code changes required if CI passes
+
+**Step 1: Rebase branch onto remote main**
+
+Run the repository release loop skill so the branch is rebased onto `origin/main` before integration.
+
+**Step 2: Push and monitor CI**
+
+Ensure branch CI succeeds before PR merge.
+
+**Step 3: Create PR and merge with rebase**
+
+Use the repository's required rebase merge path.
+
+**Step 4: Tag and monitor release workflow**
+
+Create the next version tag and monitor the release workflow until terminal success or the first concrete failure.

--- a/frontend/src/features/settings/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/SettingsPage.test.tsx
@@ -183,6 +183,8 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByRole("tab", { name: "关于" }));
     expect(await screen.findByText("GcsSloop")).toBeInTheDocument();
     expect(screen.getByText("桌面代理与路由控制台")).toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "GcsSloop/ai-gate" })).toHaveAttribute("href", "https://github.com/GcsSloop/ai-gate");
     expect(screen.getByText("应用更新")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "检查更新" })).toBeInTheDocument();
   });

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -752,6 +752,12 @@ export function SettingsPage({
                         <span>{language === "en-US" ? "Version" : "程序版本"}</span>
                         <strong>{metadata.version}</strong>
                       </div>
+                      <div className="about-meta-row">
+                        <span>GitHub</span>
+                        <a href="https://github.com/GcsSloop/ai-gate" target="_blank" rel="noreferrer">
+                          GcsSloop/ai-gate
+                        </a>
+                      </div>
                     </div>
                     <UpdateCard currentVersion={metadata.version} language={language} t={t} />
                   </div>


### PR DESCRIPTION
## Summary
- add the project GitHub repository link to the About page
- cover the new About-page link in SettingsPage tests
- document the design and implementation plan for this small UI change

## Test Plan
- `cd frontend && npm test -- --run src/features/settings/SettingsPage.test.tsx`
- `cd frontend && npm test -- --run src/App.test.tsx src/features/settings/SettingsPage.test.tsx src/features/updates/UpdateCard.test.tsx src/features/updates/updateService.test.ts`
- `git diff --check`