### PR TITLE
fix: transparently proxy chat completions payloads

### DIFF
--- a/backend/internal/api/gateway_handler.go
+++ b/backend/internal/api/gateway_handler.go
@@ -89,18 +89,18 @@ func (h *GatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req, err := gatewayopenai.ParseChatCompletionRequest(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	req, err := gatewayopenai.ParseChatCompletionRequest(bytes.NewReader(body))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	logRequestSummary("gateway", r.URL.Path, r.Method, req.Model, r.RemoteAddr, summarizeChatRequestLog(req.Messages, req.Stream))
-
-	body, err := json.Marshal(req)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	accountList, err := h.accounts.List()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/internal/api/gateway_handler_test.go
+++ b/backend/internal/api/gateway_handler_test.go
@@ -115,6 +115,101 @@ func TestGatewayHandlerProxiesToConfiguredAccount(t *testing.T) {
 	}
 }
 
+func TestGatewayHandlerTransparentlyProxiesArrayMessageContent(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode returned error: %v", err)
+		}
+
+		messages, ok := payload["messages"].([]any)
+		if !ok || len(messages) != 1 {
+			t.Fatalf("messages = %#v, want one message", payload["messages"])
+		}
+		message, ok := messages[0].(map[string]any)
+		if !ok {
+			t.Fatalf("message = %#v, want object", messages[0])
+		}
+		content, ok := message["content"].([]any)
+		if !ok || len(content) != 2 {
+			t.Fatalf("content = %#v, want two-item array", message["content"])
+		}
+
+		first, _ := content[0].(map[string]any)
+		second, _ := content[1].(map[string]any)
+		if first["text"] != "ping" || second["text"] != "pong" {
+			t.Fatalf("content text = %#v, want ping/pong", content)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "chat.completion",
+			"model":  "gpt-5.2-codex",
+			"choices": []map[string]any{
+				{"message": map[string]any{"role": "assistant", "content": "ok"}},
+			},
+		})
+	}))
+	defer upstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	if err := accountRepo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "ppchat-main",
+		AuthMode:      accounts.AuthModeAPIKey,
+		BaseURL:       upstream.URL + "/v1",
+		CredentialRef: "sk-test",
+		Status:        accounts.StatusActive,
+		Priority:      100,
+	}); err != nil {
+		t.Fatalf("Create(account) returned error: %v", err)
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:      1,
+		Balance:        100,
+		QuotaRemaining: 100000,
+		RPMRemaining:   100,
+		TPMRemaining:   100000,
+		HealthScore:    0.9,
+	}); err != nil {
+		t.Fatalf("Save(snapshot) returned error: %v", err)
+	}
+
+	handler := api.NewGatewayHandler(accountRepo, usageRepo, conversations.NewSQLiteRepository(store.DB()))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{
+		"model":"gpt-5.2-codex",
+		"stream":false,
+		"messages":[
+			{
+				"role":"user",
+				"content":[
+					{"type":"text","text":"ping"},
+					{"type":"text","text":"pong"}
+				]
+			}
+		]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gateway status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
 func TestGatewayHandlerRecordsUsageEventWithoutAuditRows(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/request_logging.go
+++ b/backend/internal/api/request_logging.go
@@ -59,10 +59,11 @@ func summarizeChatRequestLog(messages []gatewayopenai.Message, stream bool) stri
 			role = "user"
 		}
 		roles = append(roles, role)
-		content := strings.TrimSpace(message.Content)
-		if content != "" {
-			textParts = append(textParts, content)
-			totalChars += len([]rune(content))
+		for _, content := range gatewayopenai.ExtractMessageText(message.Content) {
+			if content != "" {
+				textParts = append(textParts, content)
+				totalChars += len([]rune(content))
+			}
 		}
 	}
 	return fmt.Sprintf(

--- a/backend/internal/gateway/openai/request.go
+++ b/backend/internal/gateway/openai/request.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 )
 
 type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
 }
 
 type ChatCompletionRequest struct {
@@ -26,4 +27,35 @@ func ParseChatCompletionRequest(reader io.Reader) (ChatCompletionRequest, error)
 		return ChatCompletionRequest{}, fmt.Errorf("model is required")
 	}
 	return req, nil
+}
+
+func ExtractMessageText(raw json.RawMessage) []string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil
+	}
+
+	var plain string
+	if err := json.Unmarshal(raw, &plain); err == nil {
+		plain = strings.TrimSpace(plain)
+		if plain == "" {
+			return nil
+		}
+		return []string{plain}
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal(raw, &items); err == nil {
+		texts := make([]string, 0, len(items))
+		for _, item := range items {
+			text, _ := item["text"].(string)
+			text = strings.TrimSpace(text)
+			if text != "" {
+				texts = append(texts, text)
+			}
+		}
+		return texts
+	}
+
+	return nil
 }

--- a/backend/internal/gateway/openai/request_test.go
+++ b/backend/internal/gateway/openai/request_test.go
@@ -41,3 +41,36 @@ func TestParseChatCompletionRequestRejectsMalformedPayload(t *testing.T) {
 		t.Fatal("ParseChatCompletionRequest returned nil error, want parse error")
 	}
 }
+
+func TestParseChatCompletionRequestAcceptsArrayContent(t *testing.T) {
+	t.Parallel()
+
+	req, err := gatewayopenai.ParseChatCompletionRequest(strings.NewReader(`{
+		"model":"gpt-4.1",
+		"stream":false,
+		"messages":[
+			{
+				"role":"user",
+				"content":[
+					{"type":"text","text":"hello"},
+					{"type":"text","text":"world"}
+				]
+			}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ParseChatCompletionRequest returned error: %v", err)
+	}
+	if req.Model != "gpt-4.1" {
+		t.Fatalf("Model = %q, want %q", req.Model, "gpt-4.1")
+	}
+	if req.Stream {
+		t.Fatal("Stream = true, want false")
+	}
+	if len(req.Messages) != 1 {
+		t.Fatalf("Messages len = %d, want 1", len(req.Messages))
+	}
+	if got := strings.TrimSpace(string(req.Messages[0].Content)); got == "" || got[0] != '[' {
+		t.Fatalf("Content raw = %q, want raw array payload", got)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve the original /chat/completions request body when proxying upstream
- accept array-form message content without rewriting it
- keep request logging readable without mutating forwarded payloads

## Verification
- cd backend && go test ./... -count=1
