### PR TITLE
Fix chat completions streaming passthrough

### DIFF
--- a/backend/internal/api/gateway_handler.go
+++ b/backend/internal/api/gateway_handler.go
@@ -1,14 +1,11 @@
 package api
 
 import (
-	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
@@ -19,7 +16,6 @@ import (
 	provideropenai "github.com/gcssloop/codex-router/backend/internal/providers/openai"
 	"github.com/gcssloop/codex-router/backend/internal/routing"
 	"github.com/gcssloop/codex-router/backend/internal/settings"
-	streamproxy "github.com/gcssloop/codex-router/backend/internal/streaming"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
 )
 
@@ -213,41 +209,41 @@ func (h *GatewayHandler) serveStream(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.WriteHeader(http.StatusOK)
+	var lastErr error
 
-	flusher, _ := w.(http.Flusher)
-	writeChunk := func(delta string) error {
-		payload := map[string]any{
-			"choices": []map[string]any{
-				{"delta": map[string]string{"content": delta}},
-			},
+	for _, candidate := range orderedCandidates {
+		if !routing.IsFeasible(routing.TokenBudget{
+			ProjectedInputTokens:  float64(len(req.Messages) * 500),
+			ProjectedOutputTokens: 1500,
+			SafetyFactor:          1.3,
+			EstimatedCost:         0.01,
+		}, candidate.Snapshot) && !candidate.Account.IsActive {
+			continue
 		}
-		data, err := json.Marshal(payload)
-		if err != nil {
-			return err
-		}
-		if _, err := w.Write([]byte("data: " + string(data) + "\n\n")); err != nil {
-			return err
-		}
-		if flusher != nil {
-			flusher.Flush()
-		}
-		return nil
-	}
 
-	proxy := streamproxy.NewProxy(noopRunRecorder{}, func(ctx context.Context, attempt streamproxy.Attempt) error {
-		account := attempt.Candidate.Account
+		account := candidate.Account
 		startedAt := time.Now()
 		logUpstreamSummary("gateway", conversationID, account, "/chat/completions", req.Model)
 		if err := ensureOfficialAccountSession(ctx, h.client, h.accounts, &account); err != nil {
 			logFailureSummary("gateway", conversationID, account.ID, account.AccountName, "ensure_session", startedAt, err)
-			return err
+			persistUsageEvent(h.usage, account, "chat_completions", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+			lastErr = err
+			if shouldFailoverOnGatewayStreamError(err) {
+				continue
+			}
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
 		}
 		credential, err := resolveCredential(account)
 		if err != nil {
 			logFailureSummary("gateway", conversationID, account.ID, account.AccountName, "resolve_credential", startedAt, err)
-			return err
+			persistUsageEvent(h.usage, account, "chat_completions", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+			lastErr = err
+			if shouldFailoverOnGatewayStreamError(err) {
+				continue
+			}
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
 		}
 
 		adapter := provideropenai.NewAdapter(resolveAccountBaseURL(account))
@@ -259,81 +255,66 @@ func (h *GatewayHandler) serveStream(ctx context.Context, w http.ResponseWriter,
 		})
 		if err != nil {
 			logFailureSummary("gateway", conversationID, account.ID, account.AccountName, "build_request", startedAt, err)
-			return err
+			persistUsageEvent(h.usage, account, "chat_completions", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+			lastErr = err
+			if shouldFailoverOnGatewayStreamError(err) {
+				continue
+			}
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
 		}
 
 		resp, err := h.client.Do(upstreamReq)
 		if err != nil {
 			logFailureSummary("gateway", conversationID, account.ID, account.AccountName, "upstream_request", startedAt, err)
-			return err
+			persistUsageEvent(h.usage, account, "chat_completions", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+			lastErr = err
+			if shouldFailoverOnGatewayStreamError(err) {
+				continue
+			}
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode >= 400 {
+			_ = resp.Body.Close()
 			logFailureSummary("gateway", conversationID, account.ID, account.AccountName, "upstream_status", startedAt, providers.HTTPError{StatusCode: resp.StatusCode})
-			return providers.HTTPError{StatusCode: resp.StatusCode}
-		}
-
-		scanner := bufio.NewScanner(resp.Body)
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-			if line == "" {
+			err = providers.HTTPError{StatusCode: resp.StatusCode}
+			persistUsageEvent(h.usage, account, "chat_completions", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+			lastErr = err
+			if shouldFailoverOnGatewayStreamError(err) {
 				continue
 			}
-			if !strings.HasPrefix(line, "data: ") {
-				return errors.New("invalid stream frame")
-			}
-			payload := strings.TrimPrefix(line, "data: ")
-			if payload == "[DONE]" {
-				return nil
-			}
-
-			var frame struct {
-				Choices []struct {
-					Delta struct {
-						Content string `json:"content"`
-					} `json:"delta"`
-				} `json:"choices"`
-			}
-			if err := json.Unmarshal([]byte(payload), &frame); err != nil {
-				return err
-			}
-			if len(frame.Choices) == 0 {
-				continue
-			}
-			if err := attempt.Emit(frame.Choices[0].Delta.Content); err != nil {
-				return err
-			}
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
 		}
-		if err := scanner.Err(); err != nil {
+
+		copyResponseHeaders(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		err = copyResponseStream(w, resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
 			logFailureSummary("gateway", conversationID, account.ID, account.AccountName, "read_stream", startedAt, err)
-			persistUsageEvent(h.usage, account, "chat_completions", req.Model, "failed", usage.Snapshot{AccountID: account.ID}, startedAt)
-			return err
+			persistUsageEvent(h.usage, account, "chat_completions", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+			return
 		}
 		logResultSummary("gateway", conversationID, account.ID, resp.StatusCode, startedAt, "")
 		persistUsageEvent(h.usage, account, "chat_completions", req.Model, "completed", usage.Snapshot{AccountID: account.ID}, startedAt)
 		if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
 			h.publishAccountRoutingStateChanged()
 		}
-		return nil
-	})
-
-	output, err := proxy.Execute(ctx, conversationID, req.Model, orderedCandidates, routing.TokenBudget{
-		ProjectedInputTokens:  float64(len(req.Messages) * 500),
-		ProjectedOutputTokens: 1500,
-		SafetyFactor:          1.3,
-		EstimatedCost:         0.01,
-	})
-	if err != nil {
-		_ = writeChunk("[stream failed over and exhausted candidates]")
 		return
 	}
-	_ = writeChunk(output)
 
-	_, _ = w.Write([]byte("data: [DONE]\n\n"))
-	if flusher != nil {
-		flusher.Flush()
+	if lastErr == nil {
+		lastErr = errors.New("no candidate succeeded")
 	}
+	http.Error(w, lastErr.Error(), http.StatusBadGateway)
+}
+
+func shouldFailoverOnGatewayStreamError(err error) bool {
+	class := classifyRunError(err)
+	return class == providers.ErrorClassCapacity || class == providers.ErrorClassRateLimit || class == providers.ErrorClassSoft
 }
 
 func (h *GatewayHandler) publishAccountRoutingStateChanged() {

--- a/backend/internal/api/gateway_handler_test.go
+++ b/backend/internal/api/gateway_handler_test.go
@@ -578,22 +578,19 @@ func TestGatewayHandlerSyncsActiveAccountAfterFailover(t *testing.T) {
 	}
 }
 
-func TestGatewayHandlerStreamsWithFailover(t *testing.T) {
+func TestGatewayHandlerStreamsRawFramesWithoutRewriting(t *testing.T) {
 	t.Parallel()
 
-	firstHit := true
+	const upstreamStream = "" +
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"lookup\",\"arguments\":\"{}\"}}]}}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":3,\"total_tokens\":15}}\n\n" +
+		"data: [DONE]\n\n"
+
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-
-		if firstHit {
-			firstHit = false
-			_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n"))
-			_, _ = w.Write([]byte("data: {broken\n\n"))
-			return
-		}
-
-		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hello world\"}}]}\n\n"))
-		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		_, _ = w.Write([]byte(upstreamStream))
 	}))
 	defer upstream.Close()
 
@@ -604,17 +601,102 @@ func TestGatewayHandlerStreamsWithFailover(t *testing.T) {
 	t.Cleanup(func() { _ = store.Close() })
 
 	accountRepo := accounts.NewSQLiteRepository(store.DB())
-	for i, name := range []string{"ppchat-a", "ppchat-b"} {
-		if err := accountRepo.Create(accounts.Account{
+	if err := accountRepo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "ppchat-main",
+		AuthMode:      accounts.AuthModeAPIKey,
+		BaseURL:       upstream.URL + "/v1",
+		CredentialRef: "sk-test",
+		Status:        accounts.StatusActive,
+		Priority:      100,
+	}); err != nil {
+		t.Fatalf("Create(account) returned error: %v", err)
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:      1,
+		Balance:        100,
+		QuotaRemaining: 100000,
+		RPMRemaining:   100,
+		TPMRemaining:   100000,
+		HealthScore:    0.9,
+	}); err != nil {
+		t.Fatalf("Save(snapshot) returned error: %v", err)
+	}
+
+	handler := api.NewGatewayHandler(accountRepo, usageRepo, conversations.NewSQLiteRepository(store.DB()))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{
+		"model":"gpt-5.2-codex",
+		"stream":true,
+		"messages":[{"role":"user","content":"ping"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gateway status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("content type = %q, want %q", got, "text/event-stream")
+	}
+	if rec.Body.String() != upstreamStream {
+		t.Fatalf("stream body = %s, want exact passthrough %s", rec.Body.String(), upstreamStream)
+	}
+}
+
+func TestGatewayHandlerStreamsFailoverBeforeFirstByte(t *testing.T) {
+	t.Parallel()
+
+	primaryCalls := 0
+	primaryUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryCalls++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer primaryUpstream.Close()
+
+	const fallbackStream = "" +
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"Hello world\"}}]}\n\n" +
+		"data: [DONE]\n\n"
+	fallbackUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(fallbackStream))
+	}))
+	defer fallbackUpstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	for _, item := range []accounts.Account{
+		{
 			ProviderType:  accounts.ProviderOpenAICompatible,
-			AccountName:   name,
+			AccountName:   "ppchat-primary",
 			AuthMode:      accounts.AuthModeAPIKey,
-			BaseURL:       upstream.URL + "/v1",
-			CredentialRef: "sk-test",
+			BaseURL:       primaryUpstream.URL + "/v1",
+			CredentialRef: "sk-primary",
 			Status:        accounts.StatusActive,
-			Priority:      100 - i,
-		}); err != nil {
-			t.Fatalf("Create(account %d) returned error: %v", i, err)
+			Priority:      100,
+		},
+		{
+			ProviderType:  accounts.ProviderOpenAICompatible,
+			AccountName:   "ppchat-fallback",
+			AuthMode:      accounts.AuthModeAPIKey,
+			BaseURL:       fallbackUpstream.URL + "/v1",
+			CredentialRef: "sk-fallback",
+			Status:        accounts.StatusActive,
+			Priority:      90,
+		},
+	} {
+		if err := accountRepo.Create(item); err != nil {
+			t.Fatalf("Create(account) returned error: %v", err)
 		}
 	}
 
@@ -632,8 +714,7 @@ func TestGatewayHandlerStreamsWithFailover(t *testing.T) {
 		}
 	}
 
-	conversationRepo := conversations.NewSQLiteRepository(store.DB())
-	handler := api.NewGatewayHandler(accountRepo, usageRepo, conversationRepo)
+	handler := api.NewGatewayHandler(accountRepo, usageRepo, conversations.NewSQLiteRepository(store.DB()))
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{
 		"model":"gpt-5.2-codex",
@@ -646,17 +727,13 @@ func TestGatewayHandlerStreamsWithFailover(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Fatalf("gateway status = %d, want %d", rec.Code, http.StatusOK)
+		t.Fatalf("gateway status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
-		t.Fatalf("content type = %q, want %q", got, "text/event-stream")
+	if primaryCalls != 1 {
+		t.Fatalf("primaryCalls = %d, want 1", primaryCalls)
 	}
-	body := rec.Body.String()
-	if !bytes.Contains(rec.Body.Bytes(), []byte(`"content":"Hello world"`)) {
-		t.Fatalf("stream body missing failover output: %s", body)
-	}
-	if !bytes.Contains(rec.Body.Bytes(), []byte(`[DONE]`)) {
-		t.Fatalf("stream body missing done marker: %s", body)
+	if rec.Body.String() != fallbackStream {
+		t.Fatalf("stream body = %s, want exact failover passthrough %s", rec.Body.String(), fallbackStream)
 	}
 }
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -203,7 +203,73 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
-    expect(await screen.findByLabelText("打开更新")).toBeInTheDocument();
+    const updateButton = await screen.findByLabelText("打开更新");
+    expect(updateButton).toBeInTheDocument();
+    expect(updateButton.querySelector(".top-home-update-dot")).not.toBeNull();
+  });
+
+  it("checks for home updates every hour when the indicator is enabled", async () => {
+    vi.useFakeTimers();
+    mockedUpdateService.check.mockResolvedValue({ supported: true, update: null });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/proxy/status") {
+          return Promise.resolve(new Response(JSON.stringify({ enabled: false }), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/app") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                launch_at_login: false,
+                silent_start: false,
+                close_to_tray: true,
+                show_proxy_switch_on_home: true,
+                show_home_update_indicator: true,
+                proxy_host: "127.0.0.1",
+                proxy_port: 6789,
+                auto_failover_enabled: false,
+                auto_backup_interval_hours: 24,
+                backup_retention_count: 10,
+                audit_limit_message: 200,
+                audit_limit_function_call: 100,
+                audit_limit_function_call_output: 100,
+                audit_limit_reasoning: 40,
+                audit_limit_custom_tool_call: 100,
+                audit_limit_custom_tool_call_output: 100,
+                language: "zh-CN",
+                theme_mode: "system",
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts/usage") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        return Promise.resolve(new Response(null, { status: 404 }));
+      }),
+    );
+    vi.mocked(subscribeDesktopBackendStateChanged).mockResolvedValue(() => {});
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/accounts-sync:0/)).toBeInTheDocument();
+    expect(mockedUpdateService.check).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(60 * 60 * 1_000);
+      await Promise.resolve();
+    });
+
+    expect(mockedUpdateService.check).toHaveBeenCalledTimes(2);
   });
 
   it("switches to the stats page from the top navigation", async () => {
@@ -424,7 +490,7 @@ describe("App", () => {
     expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:6789/ai-router/api/settings/proxy/status");
   });
 
-  it("opens the about tab when the home update indicator is clicked", async () => {
+  it("opens an update modal when the home update indicator is clicked", async () => {
     mockedUpdateService.check.mockResolvedValue({
       supported: true,
       update: {
@@ -483,7 +549,71 @@ describe("App", () => {
 
     fireEvent.click(await screen.findByLabelText("打开更新"));
 
-    expect(await screen.findByText("settings-page:about")).toBeInTheDocument();
+    expect(await screen.findByRole("dialog", { name: "应用更新" })).toBeInTheDocument();
+    expect(screen.queryByText("settings-page:about")).not.toBeInTheDocument();
+  });
+
+  it("checks once more when the user switches back to the accounts page", async () => {
+    mockedUpdateService.check.mockResolvedValue({ supported: true, update: null });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/proxy/status") {
+          return Promise.resolve(new Response(JSON.stringify({ enabled: false }), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/app") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                launch_at_login: false,
+                silent_start: false,
+                close_to_tray: true,
+                show_proxy_switch_on_home: true,
+                show_home_update_indicator: true,
+                proxy_host: "127.0.0.1",
+                proxy_port: 6789,
+                auto_failover_enabled: false,
+                auto_backup_interval_hours: 24,
+                backup_retention_count: 10,
+                audit_limit_message: 200,
+                audit_limit_function_call: 100,
+                audit_limit_function_call_output: 100,
+                audit_limit_reasoning: 40,
+                audit_limit_custom_tool_call: 100,
+                audit_limit_custom_tool_call_output: 100,
+                language: "zh-CN",
+                theme_mode: "system",
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts/usage") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        return Promise.resolve(new Response(null, { status: 404 }));
+      }),
+    );
+    vi.mocked(subscribeDesktopBackendStateChanged).mockResolvedValue(() => {});
+
+    render(<App />);
+
+    expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
+    expect(mockedUpdateService.check).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("tab", { name: "设置" }));
+    expect(await screen.findByText("settings-page:general")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "账户" }));
+    expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockedUpdateService.check).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("hides the home proxy switch when app settings disable it", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,12 @@
 import { CloudDownloadOutlined, PlusOutlined } from "@ant-design/icons";
 import { App as AntApp, Button, ConfigProvider, Dropdown, Modal, Spin, Switch, message, theme as antdTheme } from "antd";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 
 import { AccountsPage } from "./features/accounts/AccountsPage";
 import { SettingsPage } from "./features/settings/SettingsPage";
 import { StatsPage } from "./features/stats/StatsPage";
+import { UpdateCard } from "./features/updates/UpdateCard";
 import { createDesktopUpdateService, type DesktopUpdateInfo } from "./features/updates/updateService";
 import appLogo from "./assets/aigate_1024_1024.png";
 import { type AppSettings, disableProxy, enableProxy, getAppSettings, getProxyStatus, subscribeAccountRoutingStateChanged } from "./lib/api";
@@ -15,7 +16,7 @@ import { setAPIBase } from "./lib/paths";
 import "./styles.css";
 
 const appSettingsBootstrapRetryDelays = [0, 150, 300, 600, 1_000];
-const homeUpdateCheckIntervalMs = 6 * 60 * 60 * 1_000;
+const homeUpdateCheckIntervalMs = 60 * 60 * 1_000;
 const defaultStatusRefreshIntervalSeconds = 60;
 
 type AppView = "accounts" | "stats" | "settings";
@@ -38,7 +39,9 @@ export function App() {
   const [shellReady, setShellReady] = useState(false);
   const [systemPrefersDark, setSystemPrefersDark] = useState(false);
   const [homeUpdate, setHomeUpdate] = useState<DesktopUpdateInfo | null>(null);
+  const [homeUpdateModalOpen, setHomeUpdateModalOpen] = useState(false);
   const updateService = useMemo(() => createDesktopUpdateService(), []);
+  const previousViewRef = useRef<AppView>("accounts");
   const language = normalizeLanguage(appSettings?.language);
   const t = createTranslator(language);
   const themeMode = appSettings?.theme_mode ?? "system";
@@ -73,6 +76,15 @@ export function App() {
     }
     throw lastError instanceof Error ? lastError : new Error("failed to fetch app settings");
   }
+
+  const checkForHomeUpdate = useCallback(async () => {
+    try {
+      const result = await updateService.check();
+      setHomeUpdate(result.update);
+    } catch {
+      setHomeUpdate(null);
+    }
+  }, [updateService]);
 
   useEffect(() => {
     let disposed = false;
@@ -186,31 +198,26 @@ export function App() {
       return;
     }
 
-    let disposed = false;
-
-    async function checkForHomeUpdate() {
-      try {
-        const result = await updateService.check();
-        if (!disposed) {
-          setHomeUpdate(result.update);
-        }
-      } catch {
-        if (!disposed) {
-          setHomeUpdate(null);
-        }
-      }
-    }
-
     void checkForHomeUpdate();
     const timer = window.setInterval(() => {
       void checkForHomeUpdate();
     }, homeUpdateCheckIntervalMs);
 
     return () => {
-      disposed = true;
       window.clearInterval(timer);
     };
-  }, [appSettings?.show_home_update_indicator, updateService]);
+  }, [appSettings?.show_home_update_indicator, checkForHomeUpdate]);
+
+  useEffect(() => {
+    const previousView = previousViewRef.current;
+    previousViewRef.current = view;
+    if (!appSettings?.show_home_update_indicator) {
+      return;
+    }
+    if (view === "accounts" && previousView !== "accounts") {
+      void checkForHomeUpdate();
+    }
+  }, [appSettings?.show_home_update_indicator, checkForHomeUpdate, view]);
 
   useEffect(() => {
     const translate = createTranslator(language);
@@ -368,13 +375,15 @@ export function App() {
                   {showHomeUpdateIndicator ? (
                     <Button
                       type="text"
-                      icon={<CloudDownloadOutlined />}
+                      icon={
+                        <span className="top-home-update-icon" aria-hidden="true">
+                          <CloudDownloadOutlined />
+                          <span className="top-home-update-dot" />
+                        </span>
+                      }
                       aria-label={t("打开更新")}
                       className="top-home-update-button"
-                      onClick={() => {
-                        setSettingsInitialTab("about");
-                        setView("settings");
-                      }}
+                      onClick={() => setHomeUpdateModalOpen(true)}
                     />
                   ) : null}
                   {showProxySwitch ? (
@@ -422,6 +431,21 @@ export function App() {
                   />
                 )}
               </div>
+              <Modal
+                open={homeUpdateModalOpen}
+                title={t("应用更新")}
+                footer={null}
+                onCancel={() => setHomeUpdateModalOpen(false)}
+                destroyOnHidden
+                width={720}
+              >
+                <UpdateCard
+                  currentVersion={homeUpdate?.currentVersion ?? ""}
+                  language={language}
+                  t={t}
+                  service={updateService}
+                />
+              </Modal>
             </div>
           )}
         </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -222,22 +222,55 @@ body {
 .top-home-update-button {
   width: 32px;
   height: 32px;
-  border-radius: 10px;
+  min-width: 32px;
+  border-radius: 999px;
   color: #3e5be8;
-  background: rgba(62, 91, 232, 0.08);
-  border: none;
+  background: rgba(62, 91, 232, 0.02);
+  border: 1px solid rgba(62, 91, 232, 0.14);
   box-shadow: none;
   padding: 0;
 }
 
-.top-home-update-button .anticon {
-  font-size: 1.2em;
+.top-home-update-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.top-home-update-icon > .anticon {
+  font-size: 1.05em;
+}
+
+.top-home-update-dot {
+  position: absolute;
+  top: -1px;
+  right: -3px;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #3e5be8;
+  box-shadow: 0 0 0 2px var(--app-bg);
 }
 
 .top-home-update-button:hover,
 .top-home-update-button:focus {
   color: #2f49c8 !important;
-  background: var(--interactive-soft) !important;
+  background: rgba(62, 91, 232, 0.06) !important;
+  border-color: rgba(62, 91, 232, 0.24) !important;
+}
+
+.app-theme-shell[data-theme-mode="dark"] .top-home-update-button,
+body[data-theme-mode="dark"] .top-home-update-button,
+html[data-theme-mode="dark"] .top-home-update-button {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.app-theme-shell[data-theme-mode="dark"] .top-home-update-dot,
+body[data-theme-mode="dark"] .top-home-update-dot,
+html[data-theme-mode="dark"] .top-home-update-dot {
+  box-shadow: 0 0 0 2px #0b1324;
 }
 
 .top-menu-right {


### PR DESCRIPTION
## Summary
- transparently proxy /chat/completions streaming SSE frames without rewriting delta payloads
- add gateway regression tests for raw streaming passthrough and pre-first-byte failover
- surface the home update indicator in a modal and refresh the check when returning to the accounts tab

## Test Plan
- go test ./... -count=1
- go build ./cmd/routerd
- npm --prefix frontend run test -- src/App.test.tsx
- npm --prefix frontend run build