### PR TITLE
Release v1.1.6

### DIFF
--- a/backend/internal/api/account_routing_state.go
+++ b/backend/internal/api/account_routing_state.go
@@ -35,6 +35,25 @@ func orderCandidatesByPriority(candidates []routing.Candidate) []routing.Candida
 	return ordered
 }
 
+func orderCandidatesActiveFirst(candidates []routing.Candidate) []routing.Candidate {
+	ordered := orderCandidatesByPriority(candidates)
+	activeIndex := -1
+	for index, candidate := range ordered {
+		if candidate.Account.IsActive {
+			activeIndex = index
+			break
+		}
+	}
+	if activeIndex <= 0 {
+		return ordered
+	}
+
+	active := ordered[activeIndex]
+	copy(ordered[1:activeIndex+1], ordered[0:activeIndex])
+	ordered[0] = active
+	return ordered
+}
+
 func activeCandidate(candidates []routing.Candidate) (routing.Candidate, bool) {
 	for _, candidate := range candidates {
 		if candidate.Account.IsActive {

--- a/backend/internal/api/dashboard_handler.go
+++ b/backend/internal/api/dashboard_handler.go
@@ -14,6 +14,7 @@ type DashboardUsageSummary interface {
 	SummarizeEvents(filter usage.EventFilter) (usage.EventSummary, error)
 	TrendEventsByHour(filter usage.EventFilter) ([]usage.TrendPoint, error)
 	ListRecentEvents(filter usage.EventFilter) ([]usage.Event, error)
+	ModelDistribution(filter usage.EventFilter) ([]usage.ModelDistributionPoint, error)
 }
 
 type DashboardHandler struct {
@@ -65,6 +66,13 @@ func (h *DashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeJSON(w, http.StatusOK, events)
+	case r.Method == http.MethodGet && r.URL.Path == "/dashboard/model-distribution":
+		distribution, err := h.usage.ModelDistribution(filter)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, distribution)
 	default:
 		http.NotFound(w, r)
 	}

--- a/backend/internal/api/dashboard_handler_test.go
+++ b/backend/internal/api/dashboard_handler_test.go
@@ -101,10 +101,40 @@ func TestDashboardHandlerRecentEvents(t *testing.T) {
 	}
 }
 
+func TestDashboardHandlerModelDistribution(t *testing.T) {
+	t.Parallel()
+
+	handler := api.NewDashboardHandler(dashboardUsageStub{
+		modelDistribution: []usage.ModelDistributionPoint{
+			{Model: "gpt-5.2", RequestCount: 8},
+			{Model: "gpt-5.4", RequestCount: 4},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/model-distribution?hours=24&account_id=9&model=gpt-5.2", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /dashboard/model-distribution status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var got []usage.ModelDistributionPoint
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].Model != "gpt-5.2" || got[0].RequestCount != 8 {
+		t.Fatalf("distribution[0] = %+v, want gpt-5.2 with count 8", got[0])
+	}
+}
+
 type dashboardUsageStub struct {
-	summary usage.EventSummary
-	trends  []usage.TrendPoint
-	recent  []usage.Event
+	summary           usage.EventSummary
+	trends            []usage.TrendPoint
+	recent            []usage.Event
+	modelDistribution []usage.ModelDistributionPoint
 }
 
 func (s dashboardUsageStub) SummarizeEvents(_ usage.EventFilter) (usage.EventSummary, error) {
@@ -117,4 +147,8 @@ func (s dashboardUsageStub) TrendEventsByHour(_ usage.EventFilter) ([]usage.Tren
 
 func (s dashboardUsageStub) ListRecentEvents(_ usage.EventFilter) ([]usage.Event, error) {
 	return s.recent, nil
+}
+
+func (s dashboardUsageStub) ModelDistribution(_ usage.EventFilter) ([]usage.ModelDistributionPoint, error) {
+	return s.modelDistribution, nil
 }

--- a/backend/internal/api/gateway_handler.go
+++ b/backend/internal/api/gateway_handler.go
@@ -330,7 +330,7 @@ func (h *GatewayHandler) orderedCandidates(candidates []routing.Candidate) ([]ro
 		}
 		return orderCandidatesByPriority(candidates), nil
 	}
-	return orderCandidatesByPriority(candidates), nil
+	return orderCandidatesActiveFirst(candidates), nil
 }
 
 func resolveCredential(account accounts.Account) (string, error) {

--- a/backend/internal/api/gateway_handler_test.go
+++ b/backend/internal/api/gateway_handler_test.go
@@ -818,3 +818,113 @@ func TestGatewayHandlerPrefersActiveAccountOverPriority(t *testing.T) {
 		t.Fatalf("gateway status = %d, want %d", rec.Code, http.StatusOK)
 	}
 }
+
+func TestGatewayHandlerPrefersActiveAccountWhenAutoFailoverEnabled(t *testing.T) {
+	t.Parallel()
+
+	highPriorityCalls := 0
+	highPriorityUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		highPriorityCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "chat.completion",
+			"model":  "gpt-5.2-codex",
+			"choices": []map[string]any{
+				{"message": map[string]any{"role": "assistant", "content": "should-not-run"}},
+			},
+		})
+	}))
+	defer highPriorityUpstream.Close()
+
+	activeCalls := 0
+	activeUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		activeCalls++
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-active" {
+			t.Fatalf("Authorization = %q, want %q", got, "Bearer sk-active")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "chat.completion",
+			"model":  "gpt-5.2-codex",
+			"choices": []map[string]any{
+				{"message": map[string]any{"role": "assistant", "content": "active-first"}},
+			},
+		})
+	}))
+	defer activeUpstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	for _, item := range []accounts.Account{
+		{
+			ProviderType:  accounts.ProviderOpenAICompatible,
+			AccountName:   "higher-priority",
+			AuthMode:      accounts.AuthModeAPIKey,
+			BaseURL:       highPriorityUpstream.URL + "/v1",
+			CredentialRef: "sk-high",
+			Status:        accounts.StatusActive,
+			Priority:      100,
+		},
+		{
+			ProviderType:  accounts.ProviderOpenAICompatible,
+			AccountName:   "manual-active",
+			AuthMode:      accounts.AuthModeAPIKey,
+			BaseURL:       activeUpstream.URL + "/v1",
+			CredentialRef: "sk-active",
+			Status:        accounts.StatusActive,
+			Priority:      10,
+			IsActive:      true,
+		},
+	} {
+		if err := accountRepo.Create(item); err != nil {
+			t.Fatalf("Create(account) returned error: %v", err)
+		}
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	for id := int64(1); id <= 2; id++ {
+		if err := usageRepo.Save(usage.Snapshot{
+			AccountID:      id,
+			Balance:        100,
+			QuotaRemaining: 100000,
+			RPMRemaining:   100,
+			TPMRemaining:   100000,
+			HealthScore:    0.9,
+		}); err != nil {
+			t.Fatalf("Save(snapshot %d) returned error: %v", id, err)
+		}
+	}
+
+	settingsRepo := settings.NewSQLiteRepository(store.DB())
+	current := settings.DefaultAppSettings()
+	current.AutoFailoverEnabled = true
+	if err := settingsRepo.SaveAppSettings(current); err != nil {
+		t.Fatalf("SaveAppSettings returned error: %v", err)
+	}
+
+	handler := api.NewGatewayHandler(accountRepo, usageRepo, conversations.NewSQLiteRepository(store.DB()), api.WithGatewaySettings(settingsRepo))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{
+		"model":"gpt-5.2-codex",
+		"stream":false,
+		"messages":[{"role":"user","content":"ping"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gateway status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if activeCalls != 1 {
+		t.Fatalf("activeCalls = %d, want 1", activeCalls)
+	}
+	if highPriorityCalls != 0 {
+		t.Fatalf("highPriorityCalls = %d, want 0", highPriorityCalls)
+	}
+}

--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -433,18 +433,13 @@ func (h *ResponsesHandler) orderedThinGatewayCandidates() ([]routing.Candidate, 
 		}
 	}
 
-	ordered := orderCandidatesByPriority(candidates)
-	for _, candidate := range candidates {
-		if !candidate.Account.IsActive {
-			continue
-		}
+	if candidate, ok := activeCandidate(candidates); ok {
 		if !candidate.Account.NativeResponsesCapable() {
 			logThinGatewayCandidate(candidate.Account, "reject", "active_account_missing_responses_capability")
 			return nil, errThinGatewayActiveAccountUnsupported
 		}
-		break
 	}
-	return ordered, nil
+	return orderCandidatesActiveFirst(candidates), nil
 }
 
 func (h *ResponsesHandler) nextThinFailoverTarget(candidates []routing.Candidate, currentIndex int) (routing.Candidate, bool) {

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -264,6 +264,106 @@ func TestResponsesHandlerThinModeUsesPriorityOrderWhenAutoFailoverEnabled(t *tes
 	}
 }
 
+func TestResponsesHandlerThinModePrefersActiveAccountWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	highPriorityCalls := 0
+	highPriorityUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		highPriorityCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_high","object":"response","status":"completed","output_text":"should-not-run"}`)
+	}))
+	defer highPriorityUpstream.Close()
+
+	activeCalls := 0
+	activeUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		activeCalls++
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-active" {
+			t.Fatalf("authorization = %q, want Bearer sk-active", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_active","object":"response","status":"completed","output_text":"active-first"}`)
+	}))
+	defer activeUpstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	for _, item := range []accounts.Account{
+		{
+			ProviderType:      accounts.ProviderOpenAICompatible,
+			AccountName:       "higher-priority",
+			AuthMode:          accounts.AuthModeAPIKey,
+			BaseURL:           highPriorityUpstream.URL + "/v1",
+			CredentialRef:     "sk-high",
+			Status:            accounts.StatusActive,
+			Priority:          100,
+			SupportsResponses: true,
+		},
+		{
+			ProviderType:      accounts.ProviderOpenAICompatible,
+			AccountName:       "manual-active",
+			AuthMode:          accounts.AuthModeAPIKey,
+			BaseURL:           activeUpstream.URL + "/v1",
+			CredentialRef:     "sk-active",
+			Status:            accounts.StatusActive,
+			Priority:          10,
+			SupportsResponses: true,
+			IsActive:          true,
+		},
+	} {
+		if err := accountRepo.Create(item); err != nil {
+			t.Fatalf("Create returned error: %v", err)
+		}
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	for _, snapshot := range []usage.Snapshot{
+		{AccountID: 1, Balance: 100, QuotaRemaining: 100000, RPMRemaining: 100, TPMRemaining: 100000, HealthScore: 0.95},
+		{AccountID: 2, Balance: 100, QuotaRemaining: 100000, RPMRemaining: 100, TPMRemaining: 100000, HealthScore: 0.8},
+	} {
+		if err := usageRepo.Save(snapshot); err != nil {
+			t.Fatalf("Save returned error: %v", err)
+		}
+	}
+
+	settingsRepo := settings.NewSQLiteRepository(store.DB())
+	current := settings.DefaultAppSettings()
+	current.AutoFailoverEnabled = true
+	if err := settingsRepo.SaveAppSettings(current); err != nil {
+		t.Fatalf("SaveAppSettings returned error: %v", err)
+	}
+
+	handler := api.NewResponsesHandler(
+		accountRepo,
+		usageRepo,
+		conversations.NewSQLiteRepository(store.DB()),
+		api.WithResponsesSettings(settingsRepo),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-5.4","input":"ping"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if activeCalls != 1 {
+		t.Fatalf("activeCalls = %d, want 1", activeCalls)
+	}
+	if highPriorityCalls != 0 {
+		t.Fatalf("highPriorityCalls = %d, want 0", highPriorityCalls)
+	}
+	if !strings.Contains(rec.Body.String(), `"output_text":"active-first"`) {
+		t.Fatalf("body = %s, want active-selected output", rec.Body.String())
+	}
+}
+
 func TestResponsesHandlerThinModeUsesOnlyActiveAccountWhenAutoFailoverDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -82,6 +82,7 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 	apiMux.Handle("/dashboard/summary", dashboardHandler)
 	apiMux.Handle("/dashboard/trends", dashboardHandler)
 	apiMux.Handle("/dashboard/recent-events", dashboardHandler)
+	apiMux.Handle("/dashboard/model-distribution", dashboardHandler)
 	apiMux.Handle("/dashboard/state-events", dashboardHandler)
 	apiMux.Handle("/conversations", conversationsHandler)
 	apiMux.Handle("/conversations/", conversationsHandler)

--- a/backend/internal/usage/repository.go
+++ b/backend/internal/usage/repository.go
@@ -14,6 +14,7 @@ type Repository interface {
 	ListRecentEvents(filter EventFilter) ([]Event, error)
 	SummarizeEvents(filter EventFilter) (EventSummary, error)
 	TrendEventsByHour(filter EventFilter) ([]TrendPoint, error)
+	ModelDistribution(filter EventFilter) ([]ModelDistributionPoint, error)
 }
 
 type SQLiteRepository struct {
@@ -331,6 +332,32 @@ func (r *SQLiteRepository) TrendEventsByHour(filter EventFilter) ([]TrendPoint, 
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate usage trends by hour: %w", err)
+	}
+	return points, nil
+}
+
+func (r *SQLiteRepository) ModelDistribution(filter EventFilter) ([]ModelDistributionPoint, error) {
+	query := `SELECT model, COUNT(*)
+		FROM usage_events`
+	where, args := eventFilterWhere(filter)
+	query += where + ` GROUP BY model ORDER BY COUNT(*) DESC, model ASC`
+
+	rows, err := r.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query usage model distribution: %w", err)
+	}
+	defer rows.Close()
+
+	points := make([]ModelDistributionPoint, 0)
+	for rows.Next() {
+		var point ModelDistributionPoint
+		if err := rows.Scan(&point.Model, &point.RequestCount); err != nil {
+			return nil, fmt.Errorf("scan usage model distribution: %w", err)
+		}
+		points = append(points, point)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate usage model distribution: %w", err)
 	}
 	return points, nil
 }

--- a/backend/internal/usage/repository_test.go
+++ b/backend/internal/usage/repository_test.go
@@ -313,6 +313,92 @@ func TestSQLiteRepositoryTrendEventsByHour(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepositoryModelDistribution(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	repo := usage.NewSQLiteRepository(store.DB())
+	from := time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	accountID := int64(9)
+
+	for _, event := range []usage.Event{
+		{
+			AccountID:     9,
+			ProviderType:  "openai",
+			RequestKind:   "responses",
+			Model:         "gpt-5.2",
+			Status:        "completed",
+			TotalTokens:   1500,
+			EstimatedCost: 0.42,
+			LatencyMS:     321,
+			CreatedAt:     time.Date(2026, 3, 15, 10, 5, 0, 0, time.UTC),
+		},
+		{
+			AccountID:     9,
+			ProviderType:  "openai",
+			RequestKind:   "responses",
+			Model:         "gpt-5.4",
+			Status:        "completed",
+			TotalTokens:   800,
+			EstimatedCost: 0.24,
+			LatencyMS:     280,
+			CreatedAt:     time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC),
+		},
+		{
+			AccountID:     9,
+			ProviderType:  "openai",
+			RequestKind:   "responses",
+			Model:         "gpt-5.2",
+			Status:        "rate_limited",
+			TotalTokens:   200,
+			EstimatedCost: 0.01,
+			LatencyMS:     99,
+			CreatedAt:     time.Date(2026, 3, 15, 11, 0, 0, 0, time.UTC),
+		},
+		{
+			AccountID:     7,
+			ProviderType:  "openai",
+			RequestKind:   "responses",
+			Model:         "gpt-4.1",
+			Status:        "completed",
+			TotalTokens:   999,
+			EstimatedCost: 0.5,
+			LatencyMS:     100,
+			CreatedAt:     time.Date(2026, 3, 15, 10, 45, 0, 0, time.UTC),
+		},
+	} {
+		if err := repo.SaveEvent(event); err != nil {
+			t.Fatalf("SaveEvent(%s) returned error: %v", event.Model, err)
+		}
+	}
+
+	distribution, err := repo.ModelDistribution(usage.EventFilter{
+		From:      &from,
+		To:        &to,
+		AccountID: &accountID,
+	})
+	if err != nil {
+		t.Fatalf("ModelDistribution returned error: %v", err)
+	}
+	if len(distribution) != 2 {
+		t.Fatalf("len(distribution) = %d, want 2", len(distribution))
+	}
+	if distribution[0].Model != "gpt-5.2" || distribution[0].RequestCount != 2 {
+		t.Fatalf("distribution[0] = %+v, want gpt-5.2 with 2 requests", distribution[0])
+	}
+	if distribution[1].Model != "gpt-5.4" || distribution[1].RequestCount != 1 {
+		t.Fatalf("distribution[1] = %+v, want gpt-5.4 with 1 request", distribution[1])
+	}
+}
+
 func ptrTime(value time.Time) *time.Time {
 	return &value
 }

--- a/backend/internal/usage/types.go
+++ b/backend/internal/usage/types.go
@@ -73,3 +73,8 @@ type TrendPoint struct {
 	BalanceDelta  float64   `json:"balance_delta"`
 	QuotaDelta    float64   `json:"quota_delta"`
 }
+
+type ModelDistributionPoint struct {
+	Model        string `json:"model"`
+	RequestCount int64  `json:"request_count"`
+}

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.1.2",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.1.2",
+      "version": "1.1.6",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.6",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.1.2"
+version = "1.1.6"
 dependencies = [
  "once_cell",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.1.2"
+version = "1.1.6"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.1.2",
+  "version": "1.1.6",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/docs/plans/2026-03-17-active-account-first-routing-design.md
+++ b/docs/plans/2026-03-17-active-account-first-routing-design.md
@@ -1,0 +1,35 @@
+# Active Account First Routing Design
+
+**Context**
+- Current thin `/v1/responses` routing iterates candidates by persisted `priority DESC`.
+- When auto failover is enabled and the current account is still healthy, requests can still start from the manually sorted first account instead of the current account.
+- The same routing expectation should apply to all request entry points, including `/v1/responses` and `/v1/chat/completions`.
+- The user does not want backend routing changes to mutate the homepage drag order or the stored `priority` values.
+
+**Decision**
+- Keep the persisted account order unchanged. `priority` continues to represent the user-managed manual order.
+- During request routing only, if there is an active account, place that account at the front of the candidate list.
+- Keep the remaining candidates in their existing manual order: `priority DESC`, then `id ASC`.
+- If auto failover is disabled, continue to route only through the active account.
+- If auto failover is enabled, try the active account first. Only fail over when that account is not usable for the request.
+- After a successful failover, persist the newly used account as active so later requests keep preferring the account that actually works.
+
+**Non-Goals**
+- Do not rewrite stored account priorities.
+- Do not change frontend account ordering or drag behavior.
+- Do not change the meaning of the failover switch.
+
+**Backend Impact**
+- Introduce one shared helper that returns routing order as: active account first, then the rest by priority.
+- Use the helper in both thin `/responses` handling and `/chat/completions` handling so the rule stays consistent across APIs.
+- Continue to reject an active account that lacks required capabilities, such as `/responses` support in thin mode.
+
+**Error Handling**
+- A healthy active account remains first even if another account has higher persisted priority.
+- Failover continues to happen only for the same error classes that already trigger it today.
+- If there is no active account, routing falls back to the persisted manual order.
+
+**Testing**
+- Add a thin responses test proving an active but lower-priority account is attempted before a higher-priority account.
+- Add a gateway test proving the same active-account-first rule for `/chat/completions`.
+- Keep coverage proving successful failover still updates the active account.

--- a/docs/plans/2026-03-17-active-account-first-routing.md
+++ b/docs/plans/2026-03-17-active-account-first-routing.md
@@ -1,0 +1,47 @@
+# Active Account First Routing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make all request routing prefer the current active account first without changing persisted manual account order.
+
+**Architecture:** Backend routing will keep user-managed `priority` values unchanged and build request-time candidate order as active account first plus the remaining accounts in manual order. Both `/v1/responses` and `/v1/chat/completions` will use the same helper so successful failover updates the active account, and subsequent requests keep preferring that account until it becomes unusable.
+
+**Tech Stack:** Go, SQLite, `net/http`, Go tests.
+
+---
+
+### Task 1: Lock active-account-first behavior with failing tests
+
+**Files:**
+- Modify: `backend/internal/api/responses_handler_test.go`
+- Modify: `backend/internal/api/gateway_handler_test.go`
+
+**Step 1: Write the failing tests**
+- Add a thin responses test where a lower-priority active account succeeds and a higher-priority account must not be called.
+- Add a gateway test with the same shape for `/v1/chat/completions`.
+
+**Step 2: Run tests to verify they fail**
+Run: `go test ./backend/internal/api -run 'TestResponsesHandlerThinModePrefersActiveAccountWhenAvailable|TestGatewayHandlerPrefersActiveAccountWhenAutoFailoverEnabled' -count=1`
+Expected: FAIL because current auto-failover ordering still starts from persisted priority.
+
+**Step 3: Write minimal implementation**
+- Update shared routing helpers in `backend/internal/api/account_routing_state.go`.
+- Switch `backend/internal/api/responses_handler.go` and `backend/internal/api/gateway_handler.go` to use the new helper.
+
+**Step 4: Run tests to verify they pass**
+Run: `go test ./backend/internal/api -run 'TestResponsesHandlerThinModePrefersActiveAccountWhenAvailable|TestGatewayHandlerPrefersActiveAccountWhenAutoFailoverEnabled' -count=1`
+Expected: PASS.
+
+### Task 2: Verify existing failover semantics still hold
+
+**Files:**
+- Verify: `backend/internal/api/responses_handler_test.go`
+- Verify: `backend/internal/api/gateway_handler_test.go`
+
+**Step 1: Run targeted regression coverage**
+Run: `go test ./backend/internal/api -run 'TestResponsesHandlerThinMode|TestGatewayHandler' -count=1`
+Expected: PASS.
+
+**Step 2: Check workspace status**
+Run: `git status --short`
+Expected: only the intended backend test, code, and docs changes.

--- a/docs/plans/2026-03-17-stats-visual-refresh-design.md
+++ b/docs/plans/2026-03-17-stats-visual-refresh-design.md
@@ -1,0 +1,34 @@
+# Stats Visual Refresh Design
+
+**Context**
+- The current statistics page still uses a compact list-based trend view and a plain status list.
+- The user wants the top summary to separate input and output token counts, remove quota change, replace the trend list with a dual-line chart, and replace the right-side status list with a model-share donut chart.
+- The donut chart must reflect the full current filter window, not only the most recent 20 records already loaded for the event list.
+- The frontend currently has no ECharts dependency, and the backend currently exposes summary, trends, and recent-events endpoints only.
+
+**Decision**
+- Keep the overall stats page layout intact, but refresh the summary row and both chart panels.
+- Summary cards become: request count, input tokens, output tokens, estimated cost, and balance delta.
+- Replace the list-based `Token 趋势` panel with an ECharts two-line chart for input and output tokens over time.
+- Replace `状态分布` with `模型分布`, rendered as an ECharts donut chart using request-count share by model.
+- Add a new backend endpoint that returns model distribution aggregated across the full filtered time window.
+
+**Backend Scope**
+- Extend the usage repository with a model-distribution aggregation method using the same `hours`, `account_id`, and `model` filter semantics as the other dashboard endpoints.
+- Expose a new dashboard endpoint dedicated to model distribution so the frontend can render the donut chart from complete filtered data.
+
+**Frontend Scope**
+- Add ECharts as a frontend dependency.
+- Introduce small chart wrappers rather than embedding chart setup directly inside `StatsPage`.
+- Keep the page style restrained and modern: soft panel chrome, muted axes, two clearly distinct line colors, and a low-noise donut chart.
+- Preserve the recent-events list below the charts.
+
+**Non-Goals**
+- Do not redesign the entire stats page layout.
+- Do not add extra dashboard filters or drill-down behavior.
+- Do not change the meaning of the existing filter controls.
+
+**Testing**
+- Add backend tests for the new model-distribution endpoint and repository aggregation.
+- Update the stats page test to assert the new summary cards and chart sections.
+- Keep the chart tests focused on rendered labels and chart containers rather than pixel output.

--- a/docs/plans/2026-03-17-stats-visual-refresh.md
+++ b/docs/plans/2026-03-17-stats-visual-refresh.md
@@ -1,0 +1,69 @@
+# Stats Visual Refresh Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Modernize the statistics page with split input/output token summaries, an ECharts dual-line trend chart, and a full-window model-distribution donut chart.
+
+**Architecture:** Add one backend dashboard aggregation endpoint for model distribution, then update the stats page to consume summary, trends, recent events, and model-share data in parallel. The frontend will keep the existing page structure but replace list-based visuals with dedicated ECharts wrappers so the charts remain isolated and testable.
+
+**Tech Stack:** Go, SQLite, React, TypeScript, Ant Design, ECharts, Vitest.
+
+---
+
+### Task 1: Add failing backend tests for model distribution
+
+**Files:**
+- Modify: `backend/internal/usage/repository_test.go`
+- Modify: `backend/internal/api/dashboard_handler_test.go`
+
+**Step 1: Write the failing tests**
+- Add a usage repository test proving the filtered window aggregates request counts by model across all matching events.
+- Add a dashboard handler test proving `GET /dashboard/model-distribution` returns the aggregated model rows.
+
+**Step 2: Run tests to verify they fail**
+Run: `cd backend && go test ./internal/usage ./internal/api -run 'TestSQLiteRepositoryModelDistribution|TestDashboardHandlerModelDistribution' -count=1`
+Expected: FAIL because the repository and handler do not expose model distribution yet.
+
+**Step 3: Write minimal implementation**
+- Extend `backend/internal/usage/types.go`, `backend/internal/usage/repository.go`, `backend/internal/api/dashboard_handler.go`, and `backend/internal/bootstrap/bootstrap.go`.
+
+**Step 4: Run tests to verify they pass**
+Run: `cd backend && go test ./internal/usage ./internal/api -run 'TestSQLiteRepositoryModelDistribution|TestDashboardHandlerModelDistribution' -count=1`
+Expected: PASS.
+
+### Task 2: Add failing frontend tests for the refreshed stats page
+
+**Files:**
+- Modify: `frontend/src/features/stats/StatsPage.test.tsx`
+- Modify: `frontend/src/lib/api.ts`
+
+**Step 1: Write the failing test**
+- Assert the page renders `输入 Token` and `输出 Token`, no longer renders `总 Token` or `额度变化`, shows `模型分布`, and renders explicit chart containers for the line chart and donut chart.
+
+**Step 2: Run test to verify it fails**
+Run: `npm --prefix frontend test -- src/features/stats/StatsPage.test.tsx`
+Expected: FAIL because the old cards and non-chart panels are still rendered.
+
+**Step 3: Write minimal implementation**
+- Add the frontend API call for model distribution.
+- Add ECharts dependency and chart wrapper components.
+- Update `frontend/src/features/stats/StatsPage.tsx` and `frontend/src/styles.css`.
+
+**Step 4: Run test to verify it passes**
+Run: `npm --prefix frontend test -- src/features/stats/StatsPage.test.tsx`
+Expected: PASS.
+
+### Task 3: Verify the full slices stay green
+
+**Files:**
+- Verify: `backend/internal/usage/repository_test.go`
+- Verify: `backend/internal/api/dashboard_handler_test.go`
+- Verify: `frontend/src/features/stats/StatsPage.test.tsx`
+
+**Step 1: Run backend coverage**
+Run: `cd backend && go test ./internal/usage ./internal/api -count=1`
+Expected: PASS.
+
+**Step 2: Run frontend coverage**
+Run: `npm --prefix frontend test`
+Expected: PASS.

--- a/docs/plans/2026-03-17-update-modal-minimal-design.md
+++ b/docs/plans/2026-03-17-update-modal-minimal-design.md
@@ -1,0 +1,26 @@
+# Update Modal Minimal Design
+
+**Context**
+- The home-page update modal currently renders the shared `UpdateCard` component.
+- That shared card is also used inside the Settings `关于` tab, so direct edits would change both surfaces.
+- The modal currently duplicates the outer modal title with an inner card title, shows explanatory copy that is unnecessary in-context, and uses an extra bordered card that feels heavier than the surrounding modal shell.
+
+**Decision**
+- Create a separate update-summary component for the home-page modal instead of reusing the existing about-page `UpdateCard`.
+- Keep the Settings `关于` tab unchanged and continue to render the existing `UpdateCard`.
+- Make the modal body visually quieter: no inner card border, no duplicated inner title, no descriptive GitHub Release sentence, no manual `检查更新` button.
+- Preserve the remaining update content: current version, status, target version or latest version, publish time, release notes, download progress, and action buttons that are still relevant for the current state.
+
+**Visual Direction**
+- Match the existing settings and modal language: restrained spacing, clear hierarchy, no extra ornament.
+- Keep a comfortable content inset inside the modal so the update data does not press against the modal edges.
+- Avoid introducing a new visual style system; stay within the current token palette and typography.
+
+**Non-Goals**
+- Do not change the about-page update card.
+- Do not change update-service behavior or the underlying desktop update flow.
+- Do not remove action buttons other than the manual `检查更新` entry point requested for the modal.
+
+**Testing**
+- Add an app test proving the home update modal hides the duplicated title, description, and check button while still showing the update details.
+- Keep the existing Settings test proving the `关于` tab still shows the original `UpdateCard` with its title and `检查更新` button.

--- a/docs/plans/2026-03-17-update-modal-minimal.md
+++ b/docs/plans/2026-03-17-update-modal-minimal.md
@@ -1,0 +1,47 @@
+# Update Modal Minimal Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Simplify the home update modal so it matches the surrounding modal style while leaving the about-page update card unchanged.
+
+**Architecture:** Introduce a dedicated modal-only update component that reuses the existing update service contract and state rendering rules but presents them with lighter layout chrome. The modal in `App.tsx` will switch to that new component, while `SettingsPage.tsx` keeps the original `UpdateCard`.
+
+**Tech Stack:** React, TypeScript, Ant Design, Vitest, existing app styles.
+
+---
+
+### Task 1: Lock the modal/about split with failing tests
+
+**Files:**
+- Modify: `frontend/src/App.test.tsx`
+- Verify: `frontend/src/features/settings/SettingsPage.test.tsx`
+
+**Step 1: Write the failing test**
+- Extend the update-modal test so it asserts the dialog does not render the inner `应用更新` heading, the GitHub Release description, or the `检查更新` button.
+- Assert the modal still shows retained content such as current version, target version, publish time, or release notes.
+
+**Step 2: Run test to verify it fails**
+Run: `npm --prefix frontend test -- --runInBand src/App.test.tsx src/features/settings/SettingsPage.test.tsx`
+Expected: FAIL because the modal still uses the shared `UpdateCard`.
+
+**Step 3: Write minimal implementation**
+- Add a dedicated modal update component under `frontend/src/features/updates/`.
+- Point `frontend/src/App.tsx` at the new component.
+- Add any minimal CSS required for padding and border removal while keeping the about-page card untouched.
+
+**Step 4: Run tests to verify they pass**
+Run: `npm --prefix frontend test -- --runInBand src/App.test.tsx src/features/settings/SettingsPage.test.tsx`
+Expected: PASS.
+
+### Task 2: Verify the update feature slice stays green
+
+**Files:**
+- Verify: `frontend/src/features/updates/UpdateCard.test.tsx`
+
+**Step 1: Run focused update tests**
+Run: `npm --prefix frontend test -- --runInBand src/features/updates/UpdateCard.test.tsx`
+Expected: PASS.
+
+**Step 2: Run the full frontend suite**
+Run: `npm --prefix frontend test`
+Expected: PASS.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.1.2",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.1.2",
+      "version": "1.1.6",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "antd": "^6.3.1",
+        "echarts": "^5.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.2.0"
@@ -2882,6 +2883,22 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
@@ -4114,6 +4131,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "antd": "^6.3.1",
+    "echarts": "^5.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.2.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -551,6 +551,15 @@ describe("App", () => {
 
     expect(await screen.findByRole("dialog", { name: "应用更新" })).toBeInTheDocument();
     expect(screen.queryByText("settings-page:about")).not.toBeInTheDocument();
+    expect(screen.getAllByText("应用更新")).toHaveLength(1);
+    expect(screen.queryByText("从 GitHub Release 检查、下载并安装最新桌面版本。")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "检查更新" })).not.toBeInTheDocument();
+    expect(screen.getByText("当前版本")).toBeInTheDocument();
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getByText("目标版本")).toBeInTheDocument();
+    expect(screen.getByText("1.0.1")).toBeInTheDocument();
+    expect(screen.getByText("发布时间")).toBeInTheDocument();
+    expect(screen.getByText("Bug fixes")).toBeInTheDocument();
   });
 
   it("checks once more when the user switches back to the accounts page", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { AccountsPage } from "./features/accounts/AccountsPage";
 import { SettingsPage } from "./features/settings/SettingsPage";
 import { StatsPage } from "./features/stats/StatsPage";
-import { UpdateCard } from "./features/updates/UpdateCard";
+import { HomeUpdatePanel } from "./features/updates/HomeUpdatePanel";
 import { createDesktopUpdateService, type DesktopUpdateInfo } from "./features/updates/updateService";
 import appLogo from "./assets/aigate_1024_1024.png";
 import { type AppSettings, disableProxy, enableProxy, getAppSettings, getProxyStatus, subscribeAccountRoutingStateChanged } from "./lib/api";
@@ -439,8 +439,9 @@ export function App() {
                 destroyOnHidden
                 width={720}
               >
-                <UpdateCard
+                <HomeUpdatePanel
                   currentVersion={homeUpdate?.currentVersion ?? ""}
+                  initialUpdate={homeUpdate}
                   language={language}
                   t={t}
                   service={updateService}

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -560,6 +560,131 @@ describe("AccountsPage", () => {
     expect(document.querySelector('[aria-label="official-main-7D"] .account-usage-mini-fill')).toHaveClass("is-danger");
   });
 
+  it("keeps previous usage visible while a refresh is pending", async () => {
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "codex",
+        account_name: "official-main",
+        source_icon: "openai",
+        auth_mode: "codex_local_import",
+        base_url: "",
+        status: "active",
+        is_active: true,
+        priority: 1,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 1,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    let usageCallCount = 0;
+    let resolveSecondUsage: ((value: Response) => void) | null = null;
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
+        usageCallCount += 1;
+        if (usageCallCount === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify([
+                {
+                  account_id: 1,
+                  balance: 0,
+                  quota_remaining: 0,
+                  rpm_remaining: 0,
+                  tpm_remaining: 0,
+                  health_score: 1,
+                  recent_error_rate: 0,
+                  last_total_tokens: 0,
+                  last_input_tokens: 0,
+                  last_output_tokens: 0,
+                  model_context_window: 0,
+                  primary_used_percent: 75,
+                  secondary_used_percent: 95,
+                },
+              ]),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        return new Promise<Response>((resolve) => {
+          resolveSecondUsage = resolve;
+        });
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = render(
+      <ConfigProvider>
+        <AntApp>
+          <AccountsPage syncToken={0} />
+        </AntApp>
+      </ConfigProvider>,
+    );
+
+    expect(await screen.findByText("official-main")).toBeInTheDocument();
+    expect(await screen.findByText("25%")).toBeInTheDocument();
+    expect(screen.getByText("5%")).toBeInTheDocument();
+
+    rerender(
+      <ConfigProvider>
+        <AntApp>
+          <AccountsPage syncToken={1} />
+        </AntApp>
+      </ConfigProvider>,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    expect(screen.getByText("25%")).toBeInTheDocument();
+    expect(screen.getByText("5%")).toBeInTheDocument();
+    expect(screen.queryByText("100%")).not.toBeInTheDocument();
+
+    resolveSecondUsage?.(
+      new Response(
+        JSON.stringify([
+          {
+            account_id: 1,
+            balance: 0,
+            quota_remaining: 0,
+            rpm_remaining: 0,
+            tpm_remaining: 0,
+            health_score: 1,
+            recent_error_rate: 0,
+            last_total_tokens: 0,
+            last_input_tokens: 0,
+            last_output_tokens: 0,
+            model_context_window: 0,
+            primary_used_percent: 20,
+            secondary_used_percent: 10,
+          },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    expect(await screen.findByText("80%")).toBeInTheDocument();
+    expect(screen.getByText("90%")).toBeInTheDocument();
+  });
+
   it("renders ppchat daily remaining usage meter on the card", async () => {
     const accountList = [
       {

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -137,6 +137,29 @@ function sortAccountsByPriority(items: AccountRecord[]): AccountRecord[] {
   });
 }
 
+function mergeDisplayUsage(previous: AccountRecord, next: AccountRecord): AccountRecord {
+  return {
+    ...next,
+    balance: previous.balance,
+    quota_remaining: previous.quota_remaining,
+    rpm_remaining: previous.rpm_remaining,
+    tpm_remaining: previous.tpm_remaining,
+    health_score: previous.health_score,
+    recent_error_rate: previous.recent_error_rate,
+    last_total_tokens: previous.last_total_tokens,
+    last_input_tokens: previous.last_input_tokens,
+    last_output_tokens: previous.last_output_tokens,
+    model_context_window: previous.model_context_window,
+    primary_used_percent: previous.primary_used_percent,
+    secondary_used_percent: previous.secondary_used_percent,
+    primary_resets_at: previous.primary_resets_at,
+    secondary_resets_at: previous.secondary_resets_at,
+    ppchat_today_used_quota: previous.ppchat_today_used_quota,
+    ppchat_today_added_quota: previous.ppchat_today_added_quota,
+    ppchat_today_remaining_quota: previous.ppchat_today_remaining_quota,
+  };
+}
+
 function formatResetAt(value: string | undefined, language: AppLanguage) {
   if (!value) {
     return "--";
@@ -354,7 +377,13 @@ export function AccountsPage({
   }, [detailAccount]);
 
   async function refreshAll() {
-    const accountItems = sortAccountsByPriority(await listAccounts());
+    const previousByID = new Map(accountsRef.current.map((item) => [item.id, item]));
+    const accountItems = sortAccountsByPriority(
+      (await listAccounts()).map((item) => {
+        const previous = previousByID.get(item.id);
+        return previous ? mergeDisplayUsage(previous, item) : item;
+      }),
+    );
     accountsRef.current = accountItems;
     setAccounts(accountItems);
     void refreshUsage();

--- a/frontend/src/features/stats/StatsCharts.tsx
+++ b/frontend/src/features/stats/StatsCharts.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useMemo, useRef } from "react";
+import * as echarts from "echarts";
+
+import type { AppLanguage } from "../../lib/i18n";
+import type { UsageModelDistributionPoint, UsageTrendPoint } from "../../lib/api";
+
+type ChartTheme = {
+  textPrimary: string;
+  textSecondary: string;
+  border: string;
+  panelSurface: string;
+};
+
+type TokenTrendChartProps = {
+  data: UsageTrendPoint[];
+  language: AppLanguage;
+};
+
+type ModelDistributionChartProps = {
+  data: UsageModelDistributionPoint[];
+  language: AppLanguage;
+};
+
+function formatCompactNumber(language: AppLanguage, value: number): string {
+  return new Intl.NumberFormat(language, { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+function formatBucket(language: AppLanguage, bucket: string): string {
+  return new Date(bucket).toLocaleString(language, {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function readChartTheme(): ChartTheme {
+  const styles = window.getComputedStyle(document.documentElement);
+  return {
+    textPrimary: styles.getPropertyValue("--text-primary").trim() || "#111827",
+    textSecondary: styles.getPropertyValue("--text-secondary").trim() || "#6a7c73",
+    border: styles.getPropertyValue("--panel-border").trim() || "#e5e7eb",
+    panelSurface: styles.getPropertyValue("--panel-strong").trim() || "#f8fbff",
+  };
+}
+
+function useEChart(option: echarts.EChartsCoreOption | null) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (import.meta.env.MODE === "test") {
+      return;
+    }
+    if (!option || !containerRef.current) {
+      return;
+    }
+
+    const chart = echarts.getInstanceByDom(containerRef.current) ?? echarts.init(containerRef.current, undefined, { renderer: "canvas" });
+    chart.setOption(option, true);
+
+    const resize = () => chart.resize();
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(containerRef.current);
+    window.addEventListener("resize", resize);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", resize);
+      chart.dispose();
+    };
+  }, [option]);
+
+  return containerRef;
+}
+
+export function TokenTrendChart({ data, language }: TokenTrendChartProps) {
+  const option = useMemo<echarts.EChartsCoreOption | null>(() => {
+    if (data.length === 0) {
+      return null;
+    }
+    const theme = readChartTheme();
+    const inputLabel = language === "zh-CN" ? "输入" : "Input";
+    const outputLabel = language === "zh-CN" ? "输出" : "Output";
+    return {
+      animationDuration: 280,
+      color: ["#3b82f6", "#14b8a6"],
+      grid: {
+        top: 34,
+        right: 18,
+        bottom: 24,
+        left: 12,
+        containLabel: true,
+      },
+      legend: {
+        top: 0,
+        right: 0,
+        icon: "circle",
+        itemWidth: 8,
+        itemHeight: 8,
+        textStyle: {
+          color: theme.textSecondary,
+          fontSize: 12,
+        },
+        data: [inputLabel, outputLabel],
+      },
+      tooltip: {
+        trigger: "axis",
+        backgroundColor: theme.panelSurface,
+        borderColor: theme.border,
+        borderWidth: 1,
+        textStyle: {
+          color: theme.textPrimary,
+        },
+        formatter: (params: unknown) => {
+          const series = Array.isArray(params) ? (params as Array<{ axisValue: string; seriesName: string; value: number; color: string }>) : [];
+          if (series.length === 0) {
+            return "";
+          }
+          const rows = series
+            .map((item) => `${item.seriesName}: ${formatCompactNumber(language, Number(item.value ?? 0))}`)
+            .join("<br/>");
+          return `${series[0].axisValue}<br/>${rows}`;
+        },
+      },
+      xAxis: {
+        type: "category",
+        boundaryGap: false,
+        data: data.map((point) => formatBucket(language, point.bucket)),
+        axisLabel: {
+          color: theme.textSecondary,
+          fontSize: 11,
+          margin: 14,
+        },
+        axisLine: {
+          lineStyle: {
+            color: theme.border,
+          },
+        },
+        axisTick: {
+          show: false,
+        },
+      },
+      yAxis: {
+        type: "value",
+        axisLabel: {
+          color: theme.textSecondary,
+          fontSize: 11,
+          formatter: (value: number) => formatCompactNumber(language, value),
+        },
+        splitLine: {
+          lineStyle: {
+            color: theme.border,
+            opacity: 0.7,
+          },
+        },
+      },
+      series: [
+        {
+          name: inputLabel,
+          type: "line",
+          smooth: true,
+          symbol: "none",
+          lineStyle: { width: 3 },
+          areaStyle: {
+            color: "rgba(59, 130, 246, 0.10)",
+          },
+          data: data.map((point) => point.input_tokens),
+        },
+        {
+          name: outputLabel,
+          type: "line",
+          smooth: true,
+          symbol: "none",
+          lineStyle: { width: 3 },
+          areaStyle: {
+            color: "rgba(20, 184, 166, 0.10)",
+          },
+          data: data.map((point) => point.output_tokens),
+        },
+      ],
+    };
+  }, [data, language]);
+
+  const chartRef = useEChart(option);
+
+  return <div ref={chartRef} className="stats-chart-shell stats-chart-shell-lg" data-testid="stats-token-trend-chart" />;
+}
+
+export function ModelDistributionChart({ data, language }: ModelDistributionChartProps) {
+  const option = useMemo<echarts.EChartsCoreOption | null>(() => {
+    if (data.length === 0) {
+      return null;
+    }
+    const theme = readChartTheme();
+    const total = data.reduce((sum, item) => sum + item.request_count, 0);
+    const requestLabel = language === "zh-CN" ? "请求" : "Requests";
+    return {
+      animationDuration: 280,
+      color: ["#3b82f6", "#14b8a6", "#f59e0b", "#8b5cf6", "#ef4444", "#06b6d4"],
+      tooltip: {
+        trigger: "item",
+        backgroundColor: theme.panelSurface,
+        borderColor: theme.border,
+        borderWidth: 1,
+        textStyle: {
+          color: theme.textPrimary,
+        },
+        formatter: ({ name, value, percent }: { name: string; value: number; percent: number }) =>
+          `${name}<br/>${formatCompactNumber(language, value)} 次请求 · ${percent}%`,
+      },
+      legend: {
+        bottom: 0,
+        left: "center",
+        icon: "circle",
+        itemWidth: 8,
+        itemHeight: 8,
+        textStyle: {
+          color: theme.textSecondary,
+          fontSize: 12,
+        },
+      },
+      graphic: [
+        {
+          type: "text",
+          left: "center",
+          top: "40%",
+          style: {
+            text: formatCompactNumber(language, total),
+            fill: theme.textPrimary,
+            fontSize: 20,
+            fontWeight: 700,
+          },
+        },
+        {
+          type: "text",
+          left: "center",
+          top: "52%",
+          style: {
+            text: requestLabel,
+            fill: theme.textSecondary,
+            fontSize: 11,
+          },
+        },
+      ],
+      series: [
+        {
+          type: "pie",
+          radius: ["54%", "76%"],
+          center: ["50%", "42%"],
+          avoidLabelOverlap: true,
+          padAngle: 1.5,
+          itemStyle: {
+            borderColor: theme.panelSurface,
+            borderWidth: 2,
+            borderRadius: 8,
+          },
+          label: { show: false },
+          labelLine: { show: false },
+          data: data.map((item) => ({
+            name: item.model,
+            value: item.request_count,
+          })),
+        },
+      ],
+    };
+  }, [data, language]);
+
+  const chartRef = useEChart(option);
+
+  return <div ref={chartRef} className="stats-chart-shell stats-chart-shell-sm" data-testid="stats-model-distribution-chart" />;
+}

--- a/frontend/src/features/stats/StatsPage.test.tsx
+++ b/frontend/src/features/stats/StatsPage.test.tsx
@@ -6,10 +6,11 @@ vi.mock("../../lib/api", () => ({
   listAccounts: vi.fn(),
   getDashboardSummary: vi.fn(),
   getDashboardTrends: vi.fn(),
+  getDashboardModelDistribution: vi.fn(),
   getDashboardRecentEvents: vi.fn(),
 }));
 
-import { getDashboardRecentEvents, getDashboardSummary, getDashboardTrends, listAccounts } from "../../lib/api";
+import { getDashboardModelDistribution, getDashboardRecentEvents, getDashboardSummary, getDashboardTrends, listAccounts } from "../../lib/api";
 
 describe("StatsPage", () => {
   const t = (value: string) => value;
@@ -59,22 +60,34 @@ describe("StatsPage", () => {
         created_at: "2026-03-15T10:05:00Z",
       },
     ] as never);
+    vi.mocked(getDashboardModelDistribution).mockResolvedValue([
+      { model: "gpt-5.2", request_count: 9 },
+      { model: "gpt-5.4", request_count: 3 },
+    ] as never);
   });
 
-  it("renders summary, trends, and recent event rows", async () => {
+  it("renders refreshed summary cards, charts, and recent event rows", async () => {
     render(<StatsPage language="zh-CN" t={t} />);
 
     expect(await screen.findByText("Token 与费用统计")).toBeInTheDocument();
     expect(screen.getByText("请求数")).toBeInTheDocument();
+    expect(screen.getByText("输入 Token")).toBeInTheDocument();
+    expect(screen.getByText("输出 Token")).toBeInTheDocument();
     expect(screen.getByText("预估费用")).toBeInTheDocument();
-    expect(screen.getByText("状态分布")).toBeInTheDocument();
+    expect(screen.getByText("余额变化")).toBeInTheDocument();
+    expect(screen.queryByText("总 Token")).not.toBeInTheDocument();
+    expect(screen.queryByText("额度变化")).not.toBeInTheDocument();
+    expect(screen.getByText("模型分布")).toBeInTheDocument();
     expect(screen.getByText("最近记录")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.2")).toBeInTheDocument();
     expect(screen.getByText("Alpha · #1")).toBeInTheDocument();
+    expect(screen.getByTestId("stats-token-trend-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("stats-model-distribution-chart")).toBeInTheDocument();
 
     await waitFor(() => {
       expect(getDashboardSummary).toHaveBeenCalledWith(24, undefined, "");
       expect(getDashboardTrends).toHaveBeenCalledWith(24, undefined, "");
+      expect(getDashboardModelDistribution).toHaveBeenCalledWith(24, undefined, "");
       expect(getDashboardRecentEvents).toHaveBeenCalledWith(24, undefined, "", 20);
     });
   });

--- a/frontend/src/features/stats/StatsPage.tsx
+++ b/frontend/src/features/stats/StatsPage.tsx
@@ -4,14 +4,17 @@ import { useEffect, useMemo, useState } from "react";
 import {
   type AccountRecord,
   type UsageDashboardSummary,
+  type UsageModelDistributionPoint,
   type UsageEventRecord,
   type UsageTrendPoint,
+  getDashboardModelDistribution,
   getDashboardRecentEvents,
   getDashboardSummary,
   getDashboardTrends,
   listAccounts,
 } from "../../lib/api";
 import type { AppLanguage, Translator } from "../../lib/i18n";
+import { ModelDistributionChart, TokenTrendChart } from "./StatsCharts";
 
 type StatsPageProps = {
   language: AppLanguage;
@@ -58,6 +61,7 @@ export function StatsPage({ language, t }: StatsPageProps) {
   const [accounts, setAccounts] = useState<AccountRecord[]>([]);
   const [summary, setSummary] = useState<UsageDashboardSummary | null>(null);
   const [trends, setTrends] = useState<UsageTrendPoint[]>([]);
+  const [modelDistribution, setModelDistribution] = useState<UsageModelDistributionPoint[]>([]);
   const [events, setEvents] = useState<UsageEventRecord[]>([]);
   const [error, setError] = useState<string | null>(null);
 
@@ -68,10 +72,11 @@ export function StatsPage({ language, t }: StatsPageProps) {
       setLoading(true);
       setError(null);
       try {
-        const [accountList, nextSummary, nextTrends, nextEvents] = await Promise.all([
+        const [accountList, nextSummary, nextTrends, nextModelDistribution, nextEvents] = await Promise.all([
           listAccounts(),
           getDashboardSummary(rangeHours, accountID, model),
           getDashboardTrends(rangeHours, accountID, model),
+          getDashboardModelDistribution(rangeHours, accountID, model),
           getDashboardRecentEvents(rangeHours, accountID, model, 20),
         ]);
         if (disposed) {
@@ -80,6 +85,7 @@ export function StatsPage({ language, t }: StatsPageProps) {
         setAccounts(accountList);
         setSummary(nextSummary);
         setTrends(nextTrends);
+        setModelDistribution(nextModelDistribution);
         setEvents(nextEvents);
       } catch (loadError) {
         if (!disposed) {
@@ -98,22 +104,13 @@ export function StatsPage({ language, t }: StatsPageProps) {
     };
   }, [accountID, model, rangeHours, t]);
 
-  const maxTrendTokens = useMemo(
-    () => Math.max(...trends.map((item) => item.total_tokens), 1),
-    [trends],
-  );
-
-  const statusSummary = useMemo(() => {
-    const counts = new Map<string, number>();
-    events.forEach((event) => {
-      counts.set(event.status, (counts.get(event.status) ?? 0) + 1);
-    });
-    return Array.from(counts.entries());
-  }, [events]);
-
   const accountNameByID = useMemo(() => {
     return new Map(accounts.map((account) => [account.id, account.account_name]));
   }, [accounts]);
+
+  const totalTokens = summary?.total_tokens ?? 0;
+  const inputShare = totalTokens > 0 ? (summary?.input_tokens ?? 0) / totalTokens : 0;
+  const outputShare = totalTokens > 0 ? (summary?.output_tokens ?? 0) / totalTokens : 0;
 
   const summaryCards = [
     {
@@ -122,9 +119,14 @@ export function StatsPage({ language, t }: StatsPageProps) {
       hint: summary ? `${summary.success_count} ${t("成功")} / ${summary.failure_count} ${t("失败")}` : "--",
     },
     {
-      label: t("总 Token"),
-      value: summary ? formatCompactNumber(language, summary.total_tokens) : "--",
-      hint: summary ? `${formatCompactNumber(language, summary.input_tokens)} in · ${formatCompactNumber(language, summary.output_tokens)} out` : "--",
+      label: t("输入 Token"),
+      value: summary ? formatCompactNumber(language, summary.input_tokens) : "--",
+      hint: summary ? `${Math.round(inputShare * 100)}% ${t("占总 Token")}` : "--",
+    },
+    {
+      label: t("输出 Token"),
+      value: summary ? formatCompactNumber(language, summary.output_tokens) : "--",
+      hint: summary ? `${Math.round(outputShare * 100)}% ${t("占总 Token")}` : "--",
     },
     {
       label: t("预估费用"),
@@ -136,11 +138,6 @@ export function StatsPage({ language, t }: StatsPageProps) {
       value: summary ? formatSigned(language, summary.balance_delta) : "--",
       hint: t("与费用视角分开展示"),
     },
-    {
-      label: t("额度变化"),
-      value: summary ? formatSigned(language, summary.quota_delta) : "--",
-      hint: t("适合 quota 型账户"),
-    },
   ];
 
   return (
@@ -148,7 +145,7 @@ export function StatsPage({ language, t }: StatsPageProps) {
       <div className="stats-header">
         <div>
           <div className="stats-title">{t("Token 与费用统计")}</div>
-          <div className="stats-subtitle">{t("聚焦请求量、Token 消耗、预估费用与余额/额度变化。")}</div>
+          <div className="stats-subtitle">{t("聚焦请求量、输入输出 Token、预估费用与余额变化。")}</div>
         </div>
         <div className="stats-filters">
           <Segmented
@@ -203,41 +200,15 @@ export function StatsPage({ language, t }: StatsPageProps) {
               {trends.length === 0 ? (
                 <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无趋势数据")} />
               ) : (
-                <div className="stats-trend-list">
-                  {trends.map((point) => (
-                    <div key={point.bucket} className="stats-trend-row">
-                      <div className="stats-trend-meta">
-                        <span>{new Date(point.bucket).toLocaleString(language, { month: "numeric", day: "numeric", hour: "2-digit", hour12: false })}</span>
-                        <span>{formatCompactNumber(language, point.total_tokens)}</span>
-                      </div>
-                      <div className="stats-trend-bar-shell">
-                        <div
-                          className="stats-trend-bar"
-                          style={{ width: `${Math.max((point.total_tokens / maxTrendTokens) * 100, 8)}%` }}
-                        />
-                      </div>
-                      <div className="stats-trend-foot">
-                        <span>{formatCurrency(language, point.estimated_cost)}</span>
-                        <span>{point.request_count} {t("次请求")}</span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                <TokenTrendChart data={trends} language={language} />
               )}
             </Card>
 
-            <Card className="stats-panel" variant="borderless" title={t("状态分布")}>
-              {statusSummary.length === 0 ? (
-                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无状态数据")} />
+            <Card className="stats-panel" variant="borderless" title={t("模型分布")}>
+              {modelDistribution.length === 0 ? (
+                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无模型数据")} />
               ) : (
-                <div className="stats-status-list">
-                  {statusSummary.map(([status, count]) => (
-                    <div key={status} className="stats-status-row">
-                      <Tag color={eventStatusColor(status)}>{status}</Tag>
-                      <span>{count}</span>
-                    </div>
-                  ))}
-                </div>
+                <ModelDistributionChart data={modelDistribution} language={language} />
               )}
             </Card>
           </div>

--- a/frontend/src/features/updates/HomeUpdatePanel.tsx
+++ b/frontend/src/features/updates/HomeUpdatePanel.tsx
@@ -1,0 +1,180 @@
+import { CloudDownloadOutlined, ReloadOutlined } from "@ant-design/icons";
+import { Button, Progress, Typography } from "antd";
+import { useEffect, useMemo, useState } from "react";
+
+import type { AppLanguage, Translator } from "../../lib/i18n";
+import { createDesktopUpdateService, type DesktopUpdateInfo, type DesktopUpdateService, type DownloadProgress } from "./updateService";
+
+const { Paragraph, Text } = Typography;
+
+type HomeUpdatePanelProps = {
+  currentVersion: string;
+  initialUpdate: DesktopUpdateInfo | null;
+  language: AppLanguage;
+  t: Translator;
+  service?: DesktopUpdateService;
+};
+
+type HomeUpdateViewState =
+  | { status: "up-to-date"; message: string }
+  | { status: "available"; message: string; update: DesktopUpdateInfo }
+  | { status: "downloading"; message: string; update: DesktopUpdateInfo; progress: DownloadProgress }
+  | { status: "ready"; message: string; update: DesktopUpdateInfo }
+  | { status: "unsupported"; message: string; update?: DesktopUpdateInfo }
+  | { status: "error"; message: string };
+
+function formatDate(value: string | null | undefined, language: AppLanguage) {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString(language, { hour12: false });
+}
+
+function buildInitialState(update: DesktopUpdateInfo | null, t: Translator): HomeUpdateViewState {
+  if (!update) {
+    return { status: "up-to-date", message: t("已是最新版本") };
+  }
+  return {
+    status: "available",
+    message: `${t("发现新版本")} ${update.version}`,
+    update,
+  };
+}
+
+export function HomeUpdatePanel({ currentVersion, initialUpdate, language, t, service }: HomeUpdatePanelProps) {
+  const updateService = useMemo(() => service ?? createDesktopUpdateService(), [service]);
+  const [state, setState] = useState<HomeUpdateViewState>(() => buildInitialState(initialUpdate, t));
+
+  useEffect(() => {
+    setState((current) => {
+      if (current.status === "downloading" || current.status === "ready") {
+        return current;
+      }
+      return buildInitialState(initialUpdate, t);
+    });
+  }, [initialUpdate, t]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function hydrate() {
+      try {
+        const result = await updateService.check(currentVersion);
+        if (cancelled) {
+          return;
+        }
+        if (!result.supported) {
+          setState({
+            status: "unsupported",
+            message: result.update ? t("当前环境不支持自动安装，但已检查到最新版本。") : t("当前仅桌面版支持自动更新。"),
+            update: result.update ?? undefined,
+          });
+          return;
+        }
+        if (!result.update) {
+          setState({ status: "up-to-date", message: t("已是最新版本") });
+          return;
+        }
+        setState({
+          status: "available",
+          message: `${t("发现新版本")} ${result.update.version}`,
+          update: result.update,
+        });
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        setState({ status: "error", message: error instanceof Error ? t(error.message) : t("检查更新失败") });
+      }
+    }
+
+    void hydrate();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentVersion, t, updateService]);
+
+  async function handleDownloadAndInstall(update: DesktopUpdateInfo) {
+    setState({
+      status: "downloading",
+      message: `${t("下载进度")} 0%`,
+      update,
+      progress: { percent: 0, total: 0, transferred: 0 },
+    });
+    try {
+      await updateService.downloadAndInstall(update, (progress) => {
+        setState({
+          status: "downloading",
+          message: `${t("下载进度")} ${Math.round(progress.percent)}%`,
+          update,
+          progress,
+        });
+      });
+      setState({
+        status: "ready",
+        message: t("更新已安装，重启后生效"),
+        update,
+      });
+    } catch (error) {
+      setState({ status: "error", message: error instanceof Error ? t(error.message) : t("安装更新失败") });
+    }
+  }
+
+  return (
+    <div className="home-update-panel">
+      <div className="home-update-panel-body">
+        <div className="home-update-panel-meta">
+          <div className="about-meta-row">
+            <span>{t("当前版本")}</span>
+            <strong>{currentVersion}</strong>
+          </div>
+          <div className="about-meta-row">
+            <span>{t("状态")}</span>
+            <strong className={`update-status-value${state.status === "downloading" ? " is-checking" : ""}`}>{state.message}</strong>
+          </div>
+
+          {"update" in state && state.update ? (
+            <>
+              <div className="about-meta-row">
+                <span>{state.status === "unsupported" ? t("最新版本") : t("目标版本")}</span>
+                <strong>{state.update.version}</strong>
+              </div>
+              {state.update.date ? (
+                <div className="about-meta-row">
+                  <span>{t("发布时间")}</span>
+                  <strong>{formatDate(state.update.date, language)}</strong>
+                </div>
+              ) : null}
+              {state.update.body ? <Paragraph className="update-release-notes">{state.update.body}</Paragraph> : null}
+            </>
+          ) : null}
+        </div>
+
+        {state.status === "downloading" ? <Progress percent={Math.round(state.progress.percent)} showInfo={false} /> : null}
+
+        <div className="update-card-actions">
+          {state.status === "available" ? (
+            <Button
+              aria-label={t("下载并安装")}
+              type="primary"
+              icon={<CloudDownloadOutlined />}
+              onClick={() => void handleDownloadAndInstall(state.update)}
+            >
+              {t("下载并安装")}
+            </Button>
+          ) : null}
+          {state.status === "ready" ? (
+            <Button aria-label={t("立即重启")} type="primary" icon={<ReloadOutlined />} onClick={() => void updateService.relaunch()}>
+              {t("立即重启")}
+            </Button>
+          ) : null}
+          {state.status === "unsupported" && !state.update ? <Text type="secondary">{state.message}</Text> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -86,6 +86,11 @@ export type UsageTrendPoint = {
   quota_delta: number;
 };
 
+export type UsageModelDistributionPoint = {
+  model: string;
+  request_count: number;
+};
+
 export type UsageEventRecord = {
   id: number;
   account_id: number;
@@ -307,6 +312,14 @@ export async function getDashboardRecentEvents(hours = 24, accountID?: number, m
   const response = await fetch(apiPath(`/dashboard/recent-events?${dashboardQuery(hours, accountID, model, limit)}`));
   if (!response.ok) {
     throw new Error("failed to load recent usage events");
+  }
+  return response.json();
+}
+
+export async function getDashboardModelDistribution(hours = 24, accountID?: number, model?: string): Promise<UsageModelDistributionPoint[]> {
+  const response = await fetch(apiPath(`/dashboard/model-distribution?${dashboardQuery(hours, accountID, model)}`));
+  if (!response.ok) {
+    throw new Error("failed to load model distribution");
   }
   return response.json();
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -953,6 +953,34 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   animation: update-status-pulse 1s ease-in-out infinite;
 }
 
+.home-update-panel {
+  padding: 8px;
+}
+
+.home-update-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 12px;
+}
+
+.home-update-panel-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.update-release-notes {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.update-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 @keyframes update-status-pulse {
   0%,
   100% {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -453,25 +453,14 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   gap: 16px;
 }
 
-.stats-trend-list,
-.stats-status-list,
 .stats-events-list {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.stats-trend-row {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.stats-trend-meta,
-.stats-trend-foot,
 .stats-event-meta,
-.stats-event-metrics,
-.stats-status-row {
+.stats-event-metrics {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -480,17 +469,20 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   font-size: 12px;
 }
 
-.stats-trend-bar-shell {
-  height: 10px;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.14);
-  overflow: hidden;
+.stats-chart-shell {
+  width: 100%;
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(248, 251, 255, 0.72), rgba(255, 255, 255, 0.94)),
+    var(--panel-bg);
 }
 
-.stats-trend-bar {
-  height: 100%;
-  border-radius: 999px;
-  background: linear-gradient(90deg, #3e5be8 0%, #6f86ff 100%);
+.stats-chart-shell-lg {
+  min-height: 320px;
+}
+
+.stats-chart-shell-sm {
+  min-height: 320px;
 }
 
 .stats-event-row {
@@ -517,6 +509,14 @@ html[data-theme-mode="dark"] .top-home-update-dot {
 
 .stats-event-main {
   min-width: 0;
+}
+
+.app-theme-shell[data-theme-mode="dark"] .stats-chart-shell,
+body[data-theme-mode="dark"] .stats-chart-shell,
+html[data-theme-mode="dark"] .stats-chart-shell {
+  background:
+    linear-gradient(180deg, rgba(14, 26, 48, 0.82), rgba(11, 20, 36, 0.56)),
+    var(--panel-bg);
 }
 
 .accounts-card,


### PR DESCRIPTION
## Summary
- preserve account usage metrics while a refresh is pending
- refresh the stats dashboard with input/output token cards and ECharts visualizations
- bump desktop and frontend release metadata to v1.1.6

## Test Plan
- cd backend && go test ./...
- npm --prefix frontend test
- npm --prefix frontend run build
- cd desktop/src-tauri && cargo test -q
- bash scripts/test/desktop_updater_config_test.sh && bash scripts/test/release_updater_signing_key_test.sh && bash scripts/test/release_version_helpers_test.sh && bash scripts/test/sync_release_metadata_test.sh && bash scripts/test/collect_release_assets_test.sh && bash scripts/test/release_updater_manifest_test.sh && bash scripts/test/package_local_release_test.sh