### PR TITLE
fix: capture streaming usage stats for responses and chat completions

### DIFF
--- a/backend/internal/api/gateway_handler.go
+++ b/backend/internal/api/gateway_handler.go
@@ -290,8 +290,9 @@ func (h *GatewayHandler) serveStream(ctx context.Context, w http.ResponseWriter,
 		}
 
 		copyResponseHeaders(w.Header(), resp.Header)
+		collector := newChatCompletionsUsageCollector(account.ID)
 		w.WriteHeader(resp.StatusCode)
-		err = copyResponseStream(w, resp.Body)
+		err = copyResponseStreamWithObserver(w, resp.Body, collector.Observe)
 		_ = resp.Body.Close()
 		if err != nil {
 			logFailureSummary("gateway", conversationID, account.ID, account.AccountName, "read_stream", startedAt, err)
@@ -299,7 +300,7 @@ func (h *GatewayHandler) serveStream(ctx context.Context, w http.ResponseWriter,
 			return
 		}
 		logResultSummary("gateway", conversationID, account.ID, resp.StatusCode, startedAt, "")
-		persistUsageEvent(h.usage, account, "chat_completions", req.Model, "completed", usage.Snapshot{AccountID: account.ID}, startedAt)
+		persistUsageEvent(h.usage, account, "chat_completions", req.Model, "completed", collector.snapshotOrDefault(), startedAt)
 		if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
 			h.publishAccountRoutingStateChanged()
 		}

--- a/backend/internal/api/gateway_handler_test.go
+++ b/backend/internal/api/gateway_handler_test.go
@@ -646,6 +646,17 @@ func TestGatewayHandlerStreamsRawFramesWithoutRewriting(t *testing.T) {
 	if rec.Body.String() != upstreamStream {
 		t.Fatalf("stream body = %s, want exact passthrough %s", rec.Body.String(), upstreamStream)
 	}
+
+	events, err := usageRepo.ListRecentEvents(usage.EventFilter{Limit: 5})
+	if err != nil {
+		t.Fatalf("ListRecentEvents returned error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if events[0].InputTokens != 12 || events[0].OutputTokens != 3 || events[0].TotalTokens != 15 {
+		t.Fatalf("event tokens = in:%d out:%d total:%d, want in:12 out:3 total:15", events[0].InputTokens, events[0].OutputTokens, events[0].TotalTokens)
+	}
 }
 
 func TestGatewayHandlerStreamsFailoverBeforeFirstByte(t *testing.T) {

--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -494,9 +494,9 @@ func copyResponseStreamWithObserver(w http.ResponseWriter, body io.Reader, obser
 	reader := bufio.NewReader(body)
 	var dataLines []string
 
-	flush := func() error {
+	flush := func() {
 		if len(dataLines) == 0 {
-			return nil
+			return
 		}
 		payload := strings.Join(dataLines, "\n")
 		dataLines = dataLines[:0]
@@ -507,35 +507,16 @@ func copyResponseStreamWithObserver(w http.ResponseWriter, body io.Reader, obser
 				observe(frame)
 			}
 		}
-
-		if _, err := io.WriteString(w, "data: "+payload+"\n\n"); err != nil {
-			return err
-		}
-		if flusher != nil {
-			flusher.Flush()
-		}
-		return nil
 	}
 
 	for {
-		line, err := reader.ReadString('\n')
+		line, err := reader.ReadBytes('\n')
 		if err != nil && !errors.Is(err, io.EOF) {
 			return err
 		}
-		line = strings.TrimRight(line, "\r\n")
 
-		if line == "" {
-			if flushErr := flush(); flushErr != nil {
-				return flushErr
-			}
-		} else if strings.HasPrefix(line, "data:") {
-			payload := strings.TrimPrefix(line, "data:")
-			if strings.HasPrefix(payload, " ") {
-				payload = payload[1:]
-			}
-			dataLines = append(dataLines, payload)
-		} else {
-			if _, writeErr := io.WriteString(w, line+"\n"); writeErr != nil {
+		if len(line) > 0 {
+			if _, writeErr := w.Write(line); writeErr != nil {
 				return writeErr
 			}
 			if flusher != nil {
@@ -543,10 +524,20 @@ func copyResponseStreamWithObserver(w http.ResponseWriter, body io.Reader, obser
 			}
 		}
 
-		if errors.Is(err, io.EOF) {
-			if flushErr := flush(); flushErr != nil {
-				return flushErr
+		trimmed := strings.TrimRight(string(line), "\r\n")
+
+		if trimmed == "" {
+			flush()
+		} else if strings.HasPrefix(trimmed, "data:") {
+			payload := strings.TrimPrefix(trimmed, "data:")
+			if strings.HasPrefix(payload, " ") {
+				payload = payload[1:]
 			}
+			dataLines = append(dataLines, payload)
+		}
+
+		if errors.Is(err, io.EOF) {
+			flush()
 			return nil
 		}
 	}

--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -259,8 +259,9 @@ func (h *ResponsesHandler) handleResponsesThin(w http.ResponseWriter, r *http.Re
 		copyResponseHeaders(w.Header(), resp.Header)
 		w.Header().Set("OpenAI-Model", req.Model)
 		if isEventStreamResponse(resp.Header) {
+			collector := newResponsesUsageCollector(account.ID)
 			w.WriteHeader(resp.StatusCode)
-			if err := copyResponseStream(w, resp.Body); err != nil {
+			if err := copyResponseStreamWithObserver(w, resp.Body, collector.Observe); err != nil {
 				runStatus = runStatusForErrorClass(classifyRunError(err))
 				logFailureSummary("responses", conversationID, account.ID, account.AccountName, "read_stream", startedAt, err)
 				persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, usage.Snapshot{AccountID: account.ID}, startedAt)
@@ -270,7 +271,8 @@ func (h *ResponsesHandler) handleResponsesThin(w http.ResponseWriter, r *http.Re
 			}
 			_ = resp.Body.Close()
 			logResultSummary("responses", conversationID, account.ID, resp.StatusCode, startedAt, "")
-			persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, usage.Snapshot{AccountID: account.ID}, startedAt)
+			collector.Save(h.usage)
+			persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, collector.snapshotOrDefault(), startedAt)
 			if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
 				h.publishAccountRoutingStateChanged()
 			}
@@ -483,6 +485,69 @@ func copyResponseStream(w http.ResponseWriter, body io.Reader) error {
 				return nil
 			}
 			return err
+		}
+	}
+}
+
+func copyResponseStreamWithObserver(w http.ResponseWriter, body io.Reader, observe func(map[string]any)) error {
+	flusher, _ := w.(http.Flusher)
+	reader := bufio.NewReader(body)
+	var dataLines []string
+
+	flush := func() error {
+		if len(dataLines) == 0 {
+			return nil
+		}
+		payload := strings.Join(dataLines, "\n")
+		dataLines = dataLines[:0]
+
+		if payload != "" && payload != "[DONE]" && observe != nil {
+			var frame map[string]any
+			if err := json.Unmarshal([]byte(payload), &frame); err == nil {
+				observe(frame)
+			}
+		}
+
+		if _, err := io.WriteString(w, "data: "+payload+"\n\n"); err != nil {
+			return err
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return nil
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+		line = strings.TrimRight(line, "\r\n")
+
+		if line == "" {
+			if flushErr := flush(); flushErr != nil {
+				return flushErr
+			}
+		} else if strings.HasPrefix(line, "data:") {
+			payload := strings.TrimPrefix(line, "data:")
+			if strings.HasPrefix(payload, " ") {
+				payload = payload[1:]
+			}
+			dataLines = append(dataLines, payload)
+		} else {
+			if _, writeErr := io.WriteString(w, line+"\n"); writeErr != nil {
+				return writeErr
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			if flushErr := flush(); flushErr != nil {
+				return flushErr
+			}
+			return nil
 		}
 	}
 }

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -150,6 +150,85 @@ func TestResponsesHandlerThinModeRecordsUsageEventWithoutAuditRows(t *testing.T)
 	}
 }
 
+func TestResponsesHandlerThinModeStreamCapturesUsageTokens(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ""+
+			"data: {\"type\":\"response.output_text.delta\",\"delta\":\"tp-pong\"}\n\n"+
+			"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_tp_usage_stream_1\",\"usage\":{\"input_tokens\":1200,\"input_tokens_details\":{\"cached_tokens\":100},\"output_tokens\":300,\"total_tokens\":1500}}}\n\n"+
+			"data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	if err := accountRepo.Create(accounts.Account{
+		ProviderType:      accounts.ProviderOpenAICompatible,
+		AccountName:       "team3-stream",
+		AuthMode:          accounts.AuthModeAPIKey,
+		BaseURL:           upstream.URL + "/v1",
+		CredentialRef:     "sk-third-party",
+		Status:            accounts.StatusActive,
+		Priority:          100,
+		SupportsResponses: true,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:      1,
+		Balance:        100,
+		QuotaRemaining: 100000,
+		RPMRemaining:   100,
+		TPMRemaining:   100000,
+		HealthScore:    0.9,
+	}); err != nil {
+		t.Fatalf("Save(snapshot) returned error: %v", err)
+	}
+
+	settingsRepo := settings.NewSQLiteRepository(store.DB())
+	current := settings.DefaultAppSettings()
+	current.AutoFailoverEnabled = true
+	if err := settingsRepo.SaveAppSettings(current); err != nil {
+		t.Fatalf("SaveAppSettings returned error: %v", err)
+	}
+
+	handler := api.NewResponsesHandler(
+		accountRepo,
+		usageRepo,
+		conversations.NewSQLiteRepository(store.DB()),
+		api.WithResponsesSettings(settingsRepo),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-5.4","input":"ping","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	events, err := usageRepo.ListRecentEvents(usage.EventFilter{Limit: 5})
+	if err != nil {
+		t.Fatalf("ListRecentEvents returned error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if events[0].InputTokens != 1300 || events[0].OutputTokens != 300 || events[0].TotalTokens != 1500 {
+		t.Fatalf("event tokens = in:%d out:%d total:%d, want in:1300 out:300 total:1500", events[0].InputTokens, events[0].OutputTokens, events[0].TotalTokens)
+	}
+}
+
 func TestResponsesHandlerThinModeRejectsUnsupportedActiveAccount(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/usage_capture.go
+++ b/backend/internal/api/usage_capture.go
@@ -18,8 +18,23 @@ type responsesUsageCollector struct {
 	outputs  []map[string]any
 }
 
+type chatCompletionsUsageCollector struct {
+	snapshot usage.Snapshot
+	hasData  bool
+}
+
 func newResponsesUsageCollector(accountID int64) *responsesUsageCollector {
 	return &responsesUsageCollector{
+		snapshot: usage.Snapshot{
+			AccountID:   accountID,
+			CheckedAt:   time.Now().UTC(),
+			HealthScore: 1,
+		},
+	}
+}
+
+func newChatCompletionsUsageCollector(accountID int64) *chatCompletionsUsageCollector {
+	return &chatCompletionsUsageCollector{
 		snapshot: usage.Snapshot{
 			AccountID:   accountID,
 			CheckedAt:   time.Now().UTC(),
@@ -52,6 +67,27 @@ func (c *responsesUsageCollector) Save(repo usageSaver) {
 		c.snapshot.HealthScore = 1
 	}
 	_ = repo.Save(c.snapshot)
+}
+
+func (c *chatCompletionsUsageCollector) snapshotOrDefault() usage.Snapshot {
+	if !c.hasData {
+		return emptyResponsesUsageSnapshot()
+	}
+	return c.snapshot
+}
+
+func (c *chatCompletionsUsageCollector) Observe(frame map[string]any) {
+	if frame == nil {
+		return
+	}
+	usagePayload, ok := frame["usage"].(map[string]any)
+	if !ok {
+		return
+	}
+	c.hasData = true
+	c.snapshot.LastInputTokens = asFloat(usagePayload["prompt_tokens"])
+	c.snapshot.LastOutputTokens = asFloat(usagePayload["completion_tokens"])
+	c.snapshot.LastTotalTokens = asFloat(usagePayload["total_tokens"])
 }
 
 func (c *responsesUsageCollector) snapshotOrDefault() usage.Snapshot {


### PR DESCRIPTION
## Summary
- capture usage from successful streaming /v1/responses responses
- capture usage from successful streaming /v1/chat/completions responses
- preserve exact SSE passthrough bytes while collecting usage frames

## Testing
- go test ./...
- go test ./internal/api/contracts -run TestThinGatewayPassthroughSSEContract -count=1