### PR TITLE
Release: responses stats and accounts usage fixes

### DIFF
--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -16,15 +16,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gcssloop/codex-router/backend/internal/accountdrv"
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
 	"github.com/gcssloop/codex-router/backend/internal/auth"
 	"github.com/gcssloop/codex-router/backend/internal/providers"
 	providercodex "github.com/gcssloop/codex-router/backend/internal/providers/codex"
 	provideropenai "github.com/gcssloop/codex-router/backend/internal/providers/openai"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
-	"github.com/gcssloop/codex-router/backend/internal/usage/normalize"
-	"github.com/gcssloop/codex-router/backend/internal/usagedrv/builtin"
 )
 
 const officialOpenAIBaseURL = "https://api.openai.com/v1"
@@ -36,6 +33,8 @@ type AccountsHandler struct {
 	stateStore  *auth.StateStore
 	client      *http.Client
 	stateEvents *StateEventBus
+	refresher   AccountsUsageRefresher
+	refreshTTL  time.Duration
 }
 
 type AccountsHandlerOption func(*AccountsHandler)
@@ -46,13 +45,30 @@ func WithAccountsStateEvents(bus *StateEventBus) AccountsHandlerOption {
 	}
 }
 
+func WithAccountsUsageRefresher(refresher AccountsUsageRefresher) AccountsHandlerOption {
+	return func(handler *AccountsHandler) {
+		handler.refresher = refresher
+	}
+}
+
 type AccountsUsage interface {
 	ListLatest() ([]usage.Snapshot, error)
 	Save(snapshot usage.Snapshot) error
 }
 
+type AccountsUsageRefresher interface {
+	Run(ctx context.Context, runAt time.Time) error
+}
+
 func NewAccountsHandler(repo accounts.Repository, usage AccountsUsage, connector *auth.OAuthConnector, stateStore *auth.StateStore, opts ...AccountsHandlerOption) *AccountsHandler {
-	handler := &AccountsHandler{repo: repo, usage: usage, connector: connector, stateStore: stateStore, client: http.DefaultClient}
+	handler := &AccountsHandler{
+		repo:       repo,
+		usage:      usage,
+		connector:  connector,
+		stateStore: stateStore,
+		client:     http.DefaultClient,
+		refreshTTL: 5 * time.Second,
+	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(handler)
@@ -65,6 +81,8 @@ func (h *AccountsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.Method == http.MethodPost && r.URL.Path == "/accounts":
 		h.createAccount(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/accounts/usage/refresh":
+		h.refreshAccountsUsage(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/accounts/usage":
 		h.listAccountsUsage(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/accounts":
@@ -267,7 +285,6 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	h.refreshOfficialUsage(context.Background(), accountList)
 
 	type responseItem struct {
 		AccountID            int64      `json:"account_id"`
@@ -321,42 +338,23 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 	writeJSON(w, http.StatusOK, response)
 }
 
-func (h *AccountsHandler) refreshOfficialUsage(ctx context.Context, accountList []accounts.Account) {
-	if h.usage == nil {
+func (h *AccountsHandler) refreshAccountsUsage(w http.ResponseWriter, r *http.Request) {
+	if h.refresher == nil {
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	officialUsageDriver := builtin.NewOpenAIOfficialDriver(h.client)
-	for i := range accountList {
-		account := &accountList[i]
-		if !usesOfficialCodexAdapter(*account) {
-			continue
-		}
-		if err := ensureOfficialAccountSession(ctx, h.client, h.repo, account); err != nil {
-			continue
-		}
-		credential, err := resolveCredential(*account)
-		if err != nil {
-			continue
-		}
-		accountID, err := resolveLocalAccountID(*account)
-		if err != nil {
-			continue
-		}
-		usageAccount := *account
-		usageAccount.BaseURL = resolveAccountBaseURL(*account)
-		result, err := officialUsageDriver.Fetch(ctx, usageAccount, accountdrv.ResolvedCredential{
-			Kind:        "bearer",
-			AccessToken: credential,
-			Metadata: map[string]any{
-				"account_id": accountID,
-			},
-		})
-		if err != nil {
-			continue
-		}
-		snapshot := normalize.FromRaw(account.ID, result, time.Now().UTC())
-		_ = h.usage.Save(snapshot)
+	timeout := h.refreshTTL
+	if timeout <= 0 {
+		timeout = 5 * time.Second
 	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	if err := h.refresher.Run(ctx, time.Now().UTC()); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *AccountsHandler) createAuthSession(w http.ResponseWriter, _ *http.Request) {

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"mime/multipart"
@@ -13,11 +14,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gcssloop/codex-router/backend/internal/accountdrv"
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
 	"github.com/gcssloop/codex-router/backend/internal/api"
 	"github.com/gcssloop/codex-router/backend/internal/auth"
 	sqlitestore "github.com/gcssloop/codex-router/backend/internal/store/sqlite"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
+	"github.com/gcssloop/codex-router/backend/internal/usage/refresh"
+	"github.com/gcssloop/codex-router/backend/internal/usagedrv"
+	"github.com/gcssloop/codex-router/backend/internal/usagedrv/builtin"
+	"github.com/gcssloop/codex-router/backend/internal/usagedrv/registry"
 )
 
 func TestAccountsHandler(t *testing.T) {
@@ -587,30 +593,11 @@ func TestAccountsHandlerDuplicateAccountCreatesInactiveCopyWithIncrementedName(t
 	}
 }
 
-func TestAccountsHandlerListAccountsFetchesOfficialWhamUsage(t *testing.T) {
+func TestAccountsHandlerListUsageReadsCachedSnapshotsOnly(t *testing.T) {
 	t.Parallel()
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/backend-api/wham/usage" {
-			t.Fatalf("path = %q, want /backend-api/wham/usage", r.URL.Path)
-		}
-		if got := r.Header.Get("Authorization"); got != "Bearer token-1" {
-			t.Fatalf("authorization = %q, want Bearer token-1", got)
-		}
-		if got := r.Header.Get("ChatGPT-Account-Id"); got != "acct-1" {
-			t.Fatalf("ChatGPT-Account-Id = %q, want acct-1", got)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{
-			"plan_type":"plus",
-			"rate_limit":{
-				"allowed":true,
-				"limit_reached":false,
-				"primary_window":{"used_percent":34,"limit_window_seconds":18000,"reset_after_seconds":1200,"reset_at":1772895924},
-				"secondary_window":{"used_percent":58,"limit_window_seconds":604800,"reset_after_seconds":86400,"reset_at":1773332429}
-			},
-			"credits":{"has_credits":true,"unlimited":false,"balance":"5.39"}
-		}`)
+		t.Fatalf("unexpected outbound usage refresh: %s", r.URL.Path)
 	}))
 	defer upstream.Close()
 
@@ -636,6 +623,20 @@ func TestAccountsHandlerListAccountsFetchesOfficialWhamUsage(t *testing.T) {
 		Status: accounts.StatusActive,
 	}); err != nil {
 		t.Fatalf("Create returned error: %v", err)
+	}
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:            1,
+		Balance:              5.39,
+		PrimaryUsedPercent:   34,
+		SecondaryUsedPercent: 58,
+		RPMRemaining:         66,
+		TPMRemaining:         42,
+		CheckedAt:            time.Now().UTC(),
+		Source:               "remote",
+		Confidence:           "high",
+		ProviderSnapshotJSON: `{"cached":true}`,
+	}); err != nil {
+		t.Fatalf("Save returned error: %v", err)
 	}
 
 	listReq := httptest.NewRequest(http.MethodGet, "/accounts/usage", nil)
@@ -666,7 +667,7 @@ func TestAccountsHandlerListAccountsFetchesOfficialWhamUsage(t *testing.T) {
 	}
 }
 
-func TestAccountsHandlerListAccountsKeepsOfficialSnapshotWhenAllowedWithZeroUsage(t *testing.T) {
+func TestAccountsHandlerRefreshUsage(t *testing.T) {
 	t.Parallel()
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -694,7 +695,27 @@ func TestAccountsHandlerListAccountsKeepsOfficialSnapshotWhenAllowedWithZeroUsag
 
 	repo := accounts.NewSQLiteRepository(store.DB())
 	usageRepo := usage.NewSQLiteRepository(store.DB())
-	handler := api.NewAccountsHandler(repo, usageRepo, auth.NewOAuthConnector(auth.Config{}), auth.NewStateStore(5*time.Minute))
+	client := upstream.Client()
+	driverRegistry, err := registry.New(
+		[]accountdrv.AccountDriver{
+			accountdrv.NewOfficialDriver(client, repo),
+			accountdrv.NewAPIKeyDriver(),
+		},
+		[]usagedrv.UsageDriver{
+			builtin.NewOpenAIOfficialDriver(client),
+		},
+	)
+	if err != nil {
+		t.Fatalf("registry.New returned error: %v", err)
+	}
+	refresher := refresh.NewOrchestrator(repo, usageRepo, driverRegistry)
+	handler := api.NewAccountsHandler(
+		repo,
+		usageRepo,
+		auth.NewOAuthConnector(auth.Config{}),
+		auth.NewStateStore(5*time.Minute),
+		api.WithAccountsUsageRefresher(refresher),
+	)
 
 	if err := repo.Create(accounts.Account{
 		ProviderType: accounts.ProviderOpenAIOfficial,
@@ -710,6 +731,14 @@ func TestAccountsHandlerListAccountsKeepsOfficialSnapshotWhenAllowedWithZeroUsag
 		t.Fatalf("Create returned error: %v", err)
 	}
 
+	refreshReq := httptest.NewRequest(http.MethodPost, "/accounts/usage/refresh", nil)
+	refreshReq = refreshReq.WithContext(context.Background())
+	refreshRec := httptest.NewRecorder()
+	handler.ServeHTTP(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusNoContent {
+		t.Fatalf("POST /accounts/usage/refresh status = %d, want %d", refreshRec.Code, http.StatusNoContent)
+	}
+
 	listReq := httptest.NewRequest(http.MethodGet, "/accounts/usage", nil)
 	listRec := httptest.NewRecorder()
 	handler.ServeHTTP(listRec, listReq)
@@ -717,12 +746,18 @@ func TestAccountsHandlerListAccountsKeepsOfficialSnapshotWhenAllowedWithZeroUsag
 		t.Fatalf("GET /accounts/usage status = %d, want %d", listRec.Code, http.StatusOK)
 	}
 
-	var snapshotRows int
-	if err := store.DB().QueryRow(`SELECT COUNT(*) FROM account_usage_snapshots`).Scan(&snapshotRows); err != nil {
-		t.Fatalf("count snapshots returned error: %v", err)
+	var listed []map[string]any
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
 	}
-	if snapshotRows != 1 {
-		t.Fatalf("snapshot rows = %d, want 1", snapshotRows)
+	if listed[0]["balance"].(float64) != 0 {
+		t.Fatalf("balance = %v, want 0", listed[0]["balance"])
+	}
+	if listed[0]["rpm_remaining"].(float64) != 100 {
+		t.Fatalf("rpm_remaining = %v, want 100", listed[0]["rpm_remaining"])
+	}
+	if listed[0]["tpm_remaining"].(float64) != 100 {
+		t.Fatalf("tpm_remaining = %v, want 100", listed[0]["tpm_remaining"])
 	}
 }
 

--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -259,7 +259,11 @@ func (h *ResponsesHandler) handleResponsesThin(w http.ResponseWriter, r *http.Re
 		runStatus := "completed"
 		copyResponseHeaders(w.Header(), resp.Header)
 		w.Header().Set("OpenAI-Model", req.Model)
-		if isEventStreamResponse(resp.Header) {
+		// Some upstream official /responses streams arrive as SSE payloads without a
+		// reliable text/event-stream content type. When the caller requested
+		// stream=true, prefer the SSE path so response.completed usage is not lost.
+		streamResponse := req.Stream || isEventStreamResponse(resp.Header)
+		if streamResponse {
 			collector := newResponsesUsageCollector(account.ID)
 			w.WriteHeader(resp.StatusCode)
 			if err := copyResponseStreamWithObserver(w, resp.Body, collector.Observe); err != nil {

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -229,6 +229,89 @@ func TestResponsesHandlerThinModeStreamCapturesUsageTokens(t *testing.T) {
 	}
 }
 
+func TestResponsesHandlerThinModeOfficialStreamCapturesWrappedTokenCount(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ""+
+			"data: {\"msg\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":1200,\"cached_input_tokens\":100,\"output_tokens\":300,\"total_tokens\":1600},\"model_context_window\":200000}}}\n\n"+
+			"data: {\"type\":\"response.output_text.delta\",\"delta\":\"official-pong\"}\n\n"+
+			"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_official_usage_stream_1\",\"output\":[]}}\n\n"+
+			"data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	if err := accountRepo.Create(accounts.Account{
+		ProviderType: accounts.ProviderOpenAIOfficial,
+		AccountName:  "official-stream",
+		AuthMode:     accounts.AuthModeLocalImport,
+		BaseURL:      upstream.URL + "/backend-api/codex",
+		CredentialRef: `{
+			"auth_mode":"chatgpt",
+			"tokens":{"access_token":"token-1","account_id":"acct-1"}
+		}`,
+		Status:            accounts.StatusActive,
+		Priority:          100,
+		SupportsResponses: true,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:      1,
+		Balance:        100,
+		QuotaRemaining: 100000,
+		RPMRemaining:   100,
+		TPMRemaining:   100000,
+		HealthScore:    0.9,
+	}); err != nil {
+		t.Fatalf("Save(snapshot) returned error: %v", err)
+	}
+
+	settingsRepo := settings.NewSQLiteRepository(store.DB())
+	current := settings.DefaultAppSettings()
+	current.AutoFailoverEnabled = true
+	if err := settingsRepo.SaveAppSettings(current); err != nil {
+		t.Fatalf("SaveAppSettings returned error: %v", err)
+	}
+
+	handler := api.NewResponsesHandler(
+		accountRepo,
+		usageRepo,
+		conversations.NewSQLiteRepository(store.DB()),
+		api.WithResponsesSettings(settingsRepo),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-5.4","input":"ping","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	events, err := usageRepo.ListRecentEvents(usage.EventFilter{Limit: 5})
+	if err != nil {
+		t.Fatalf("ListRecentEvents returned error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if events[0].InputTokens != 1300 || events[0].OutputTokens != 300 || events[0].TotalTokens != 1600 {
+		t.Fatalf("event tokens = in:%d out:%d total:%d, want in:1300 out:300 total:1600", events[0].InputTokens, events[0].OutputTokens, events[0].TotalTokens)
+	}
+}
+
 func TestResponsesHandlerThinModeRejectsUnsupportedActiveAccount(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -312,6 +312,88 @@ func TestResponsesHandlerThinModeOfficialStreamCapturesWrappedTokenCount(t *test
 	}
 }
 
+func TestResponsesHandlerThinModeOfficialStreamWithoutContentTypeStillCapturesUsage(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, ""+
+			"event: response.created\n"+
+			"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_missing_header_1\",\"usage\":null}}\n\n"+
+			"event: response.completed\n"+
+			"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_missing_header_1\",\"output\":[],\"usage\":{\"input_tokens\":17,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":5,\"total_tokens\":22}}}\n\n")
+	}))
+	defer upstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	if err := accountRepo.Create(accounts.Account{
+		ProviderType: accounts.ProviderOpenAIOfficial,
+		AccountName:  "official-stream-no-header",
+		AuthMode:     accounts.AuthModeLocalImport,
+		BaseURL:      upstream.URL + "/backend-api/codex",
+		CredentialRef: `{
+			"auth_mode":"chatgpt",
+			"tokens":{"access_token":"token-1","account_id":"acct-1"}
+		}`,
+		Status:            accounts.StatusActive,
+		Priority:          100,
+		SupportsResponses: true,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:      1,
+		Balance:        100,
+		QuotaRemaining: 100000,
+		RPMRemaining:   100,
+		TPMRemaining:   100000,
+		HealthScore:    0.9,
+	}); err != nil {
+		t.Fatalf("Save(snapshot) returned error: %v", err)
+	}
+
+	settingsRepo := settings.NewSQLiteRepository(store.DB())
+	current := settings.DefaultAppSettings()
+	current.AutoFailoverEnabled = true
+	if err := settingsRepo.SaveAppSettings(current); err != nil {
+		t.Fatalf("SaveAppSettings returned error: %v", err)
+	}
+
+	handler := api.NewResponsesHandler(
+		accountRepo,
+		usageRepo,
+		conversations.NewSQLiteRepository(store.DB()),
+		api.WithResponsesSettings(settingsRepo),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-5.4","input":"ping","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	events, err := usageRepo.ListRecentEvents(usage.EventFilter{Limit: 5})
+	if err != nil {
+		t.Fatalf("ListRecentEvents returned error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if events[0].InputTokens != 17 || events[0].OutputTokens != 5 || events[0].TotalTokens != 22 {
+		t.Fatalf("event tokens = in:%d out:%d total:%d, want in:17 out:5 total:22", events[0].InputTokens, events[0].OutputTokens, events[0].TotalTokens)
+	}
+}
+
 func TestResponsesHandlerThinModeRejectsUnsupportedActiveAccount(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/usage_capture.go
+++ b/backend/internal/api/usage_capture.go
@@ -154,7 +154,6 @@ func (c *responsesUsageCollector) observeCompletedResponse(payload map[string]an
 	if !ok {
 		return
 	}
-
 	usagePayload, ok := response["usage"].(map[string]any)
 	if ok {
 		c.hasData = true

--- a/backend/internal/api/usage_capture.go
+++ b/backend/internal/api/usage_capture.go
@@ -50,6 +50,8 @@ func (c *responsesUsageCollector) Observe(frame map[string]any) {
 	case "token_count":
 		c.observeTokenCount(payload)
 		c.applyPayloadRateLimits(payload)
+	case "thread/tokenUsage/updated", "thread.token_usage.updated":
+		c.observeThreadTokenUsageUpdated(payload)
 	case "response.completed":
 		c.observeCompletedResponse(payload)
 		c.applyPayloadRateLimits(payload)
@@ -117,15 +119,32 @@ func (c *responsesUsageCollector) observeTokenCount(payload map[string]any) {
 
 	if info, ok := payload["info"].(map[string]any); ok {
 		if total, ok := info["total_token_usage"].(map[string]any); ok {
-			c.snapshot.LastTotalTokens = asFloat(total["total_tokens"])
-			c.snapshot.LastInputTokens = asFloat(total["input_tokens"])
-			c.snapshot.LastOutputTokens = asFloat(total["output_tokens"])
+			c.applyTokenUsageBreakdown(total)
 		}
 		if contextWindow := asFloat(info["model_context_window"]); contextWindow > 0 {
 			c.snapshot.ModelContextWindow = contextWindow
 			if c.snapshot.LastTotalTokens > 0 {
 				c.snapshot.QuotaRemaining = math.Max(contextWindow-c.snapshot.LastTotalTokens, 0)
 			}
+		}
+	}
+}
+
+func (c *responsesUsageCollector) observeThreadTokenUsageUpdated(payload map[string]any) {
+	tokenUsage, ok := payload["token_usage"].(map[string]any)
+	if !ok {
+		return
+	}
+	total, ok := tokenUsage["total"].(map[string]any)
+	if !ok {
+		return
+	}
+	c.hasData = true
+	c.applyTokenUsageBreakdown(total)
+	if contextWindow := asFloat(tokenUsage["model_context_window"]); contextWindow > 0 {
+		c.snapshot.ModelContextWindow = contextWindow
+		if c.snapshot.LastTotalTokens > 0 {
+			c.snapshot.QuotaRemaining = math.Max(contextWindow-c.snapshot.LastTotalTokens, 0)
 		}
 	}
 }
@@ -158,6 +177,23 @@ func (c *responsesUsageCollector) observeCompletedResponse(payload map[string]an
 			c.outputs = append(c.outputs, cloneJSONMap(item))
 		}
 	}
+}
+
+func (c *responsesUsageCollector) applyTokenUsageBreakdown(total map[string]any) {
+	if total == nil {
+		return
+	}
+	inputTokens := asFloat(total["input_tokens"])
+	cachedInputTokens := asFloat(total["cached_input_tokens"])
+	outputTokens := asFloat(total["output_tokens"])
+	totalTokens := asFloat(total["total_tokens"])
+	c.snapshot.LastInputTokens = inputTokens + cachedInputTokens
+	c.snapshot.LastOutputTokens = outputTokens
+	if totalTokens > 0 {
+		c.snapshot.LastTotalTokens = totalTokens
+		return
+	}
+	c.snapshot.LastTotalTokens = c.snapshot.LastInputTokens + c.snapshot.LastOutputTokens
 }
 
 func (c *responsesUsageCollector) applyPayloadRateLimits(payload map[string]any) {
@@ -201,6 +237,11 @@ func unwrapResponsesFrame(frame map[string]any) map[string]any {
 	if payload, ok := frame["payload"].(map[string]any); ok {
 		if payloadType, _ := payload["type"].(string); payloadType != "" {
 			return payload
+		}
+	}
+	if msg, ok := frame["msg"].(map[string]any); ok {
+		if msgType, _ := msg["type"].(string); msgType != "" {
+			return msg
 		}
 	}
 	return frame

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -76,7 +76,30 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 	authConnector := auth.NewOAuthConnector(auth.Config{})
 	stateStore := auth.NewStateStore(5 * time.Minute)
 	stateEvents := api.NewStateEventBus()
-	accountsHandler := api.NewAccountsHandler(accountRepo, usageRepo, authConnector, stateStore, api.WithAccountsStateEvents(stateEvents))
+	driverRegistry, err := registry.New(
+		[]accountdrv.AccountDriver{
+			accountdrv.NewOfficialDriver(http.DefaultClient, accountRepo),
+			accountdrv.NewAPIKeyDriver(),
+		},
+		[]usagedrv.UsageDriver{
+			builtin.NewOpenAIOfficialDriver(http.DefaultClient),
+			builtin.NewPPChatDriver(http.DefaultClient),
+			luadrv.NewDriver(http.DefaultClient, ""),
+		},
+	)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+	refreshOrchestrator := refresh.NewOrchestrator(accountRepo, usageRepo, driverRegistry)
+	accountsHandler := api.NewAccountsHandler(
+		accountRepo,
+		usageRepo,
+		authConnector,
+		stateStore,
+		api.WithAccountsStateEvents(stateEvents),
+		api.WithAccountsUsageRefresher(refreshOrchestrator),
+	)
 	conversationsHandler := api.NewConversationsHandler(conversationRepo)
 
 	apiMux := http.NewServeMux()
@@ -152,22 +175,6 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 	compactionJob := scheduler.NewUsageCompactionJob(func(_ context.Context, now time.Time) error {
 		return usageRepo.CompactEvents(now.UTC())
 	})
-	driverRegistry, err := registry.New(
-		[]accountdrv.AccountDriver{
-			accountdrv.NewOfficialDriver(http.DefaultClient, accountRepo),
-			accountdrv.NewAPIKeyDriver(),
-		},
-		[]usagedrv.UsageDriver{
-			builtin.NewOpenAIOfficialDriver(http.DefaultClient),
-			builtin.NewPPChatDriver(http.DefaultClient),
-			luadrv.NewDriver(http.DefaultClient, ""),
-		},
-	)
-	if err != nil {
-		_ = store.Close()
-		return nil, err
-	}
-	refreshOrchestrator := refresh.NewOrchestrator(accountRepo, usageRepo, driverRegistry)
 	app.background.Add(1)
 	go func() {
 		defer app.background.Done()

--- a/docs/plans/2026-03-18-accounts-usage-latency.md
+++ b/docs/plans/2026-03-18-accounts-usage-latency.md
@@ -1,0 +1,96 @@
+# Accounts Usage Latency Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `GET /ai-router/api/accounts/usage` return quickly by reading cached snapshots only, and move online refresh to an explicit refresh path.
+
+**Architecture:** Remove synchronous official usage refresh from the read endpoint. Keep the existing snapshot repository as the source of truth for list reads, and add a dedicated refresh action that reuses the driver-based usage refresh flow with a bounded request context.
+
+**Tech Stack:** Go, net/http, SQLite repository layer, existing usage refresh orchestrator, handler tests.
+
+---
+
+### Task 1: Lock in non-blocking list behavior
+
+**Files:**
+- Modify: `backend/internal/api/accounts_handler_test.go`
+
+**Step 1: Write the failing test**
+
+Add a handler test proving `GET /accounts/usage` returns cached snapshot data without making any outbound usage refresh request.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/api -run TestAccountsHandlerListUsageReadsCachedSnapshotsOnly -count=1`
+Expected: FAIL because the handler currently refreshes official usage inline.
+
+**Step 3: Write minimal implementation**
+
+Remove the inline refresh call from `listAccountsUsage`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/api -run TestAccountsHandlerListUsageReadsCachedSnapshotsOnly -count=1`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add backend/internal/api/accounts_handler.go backend/internal/api/accounts_handler_test.go
+git commit -m "fix(accounts): avoid synchronous refresh in usage list"
+```
+
+### Task 2: Add explicit refresh endpoint
+
+**Files:**
+- Modify: `backend/internal/api/accounts_handler.go`
+- Modify: `backend/internal/api/accounts_handler_test.go`
+
+**Step 1: Write the failing test**
+
+Add a handler test for `POST /accounts/usage/refresh` that refreshes snapshots and returns quickly with updated usage data.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/api -run TestAccountsHandlerRefreshUsage -count=1`
+Expected: FAIL because the route does not exist.
+
+**Step 3: Write minimal implementation**
+
+Add a refresh endpoint that:
+- lists accounts
+- refreshes snapshots through a shared refresh helper
+- uses `context.WithTimeout`
+- returns `204 No Content`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/api -run TestAccountsHandlerRefreshUsage -count=1`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add backend/internal/api/accounts_handler.go backend/internal/api/accounts_handler_test.go
+git commit -m "feat(accounts): add explicit usage refresh endpoint"
+```
+
+### Task 3: Final verification
+
+**Files:**
+- No code changes required unless verification finds regressions
+
+**Step 1: Run backend API tests**
+
+Run: `cd backend && go test ./internal/api -count=1`
+Expected: PASS
+
+**Step 2: Run full backend tests**
+
+Run: `cd backend && go test ./... -count=1`
+Expected: PASS
+
+**Step 3: Review worktree**
+
+Run: `git status --short --branch`
+Expected: only intended files changed

--- a/docs/plans/2026-03-18-responses-stream-content-type.md
+++ b/docs/plans/2026-03-18-responses-stream-content-type.md
@@ -1,0 +1,37 @@
+# Responses Stream Content-Type Regression
+
+## Context
+
+On March 18, 2026, `/v1/responses` token statistics were missing in the dashboard even though request counts continued to grow.
+
+The live OpenAI official upstream returned a valid SSE body with `response.completed.response.usage`, but the HTTP response did not include a reliable `Content-Type: text/event-stream` header. The router treated that response as a normal JSON body, skipped the SSE observer path, and persisted `0/0/0` tokens.
+
+## Root Cause
+
+The thin `/responses` path used `isEventStreamResponse(resp.Header)` as the only signal for stream parsing.
+
+That assumption is unsafe for this upstream:
+
+- request was `stream=true`
+- body was SSE
+- `Content-Type` was empty or fell back to plain text
+- usage parsing never ran
+
+## Permanent Rule
+
+For `/responses`, when the client request is `stream=true`, prefer the SSE parsing path on successful upstream responses even if the upstream `Content-Type` is missing or incorrect.
+
+Do not rely on `Content-Type` alone to decide whether stream telemetry should be observed.
+
+## Guardrail
+
+Keep a regression test that covers:
+
+- `stream=true`
+- SSE body with `response.completed.response.usage`
+- missing or incorrect upstream `Content-Type`
+
+Expected result:
+
+- recent usage event stores non-zero `input_tokens`, `output_tokens`, and `total_tokens`
+


### PR DESCRIPTION
## Summary
- fix `/responses` and `/v1/responses` token stats when official upstream returns SSE body without a usable `Content-Type`
- capture Codex wrapped usage data and keep recent dashboard token statistics visible again
- decouple accounts usage listing from refresh work to reduce `/ai-router/api/accounts/usage` latency

## Test Plan
- `cd backend && go test ./...`
- `npm --prefix frontend test`
- `bash scripts/test/desktop_updater_config_test.sh && bash scripts/test/release_updater_signing_key_test.sh && bash scripts/test/release_version_helpers_test.sh && bash scripts/test/sync_release_metadata_test.sh && bash scripts/test/collect_release_assets_test.sh && bash scripts/test/release_updater_manifest_test.sh && bash scripts/test/package_local_release_test.sh`