### PR TITLE
feat: add desktop-managed updates and account sharing

### DIFF
--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -93,12 +93,16 @@ func (h *AccountsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.importLocalAuth(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/accounts/import-current":
 		h.importCurrentAuth(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/accounts/import-shared":
+		h.importSharedAccount(w, r)
 	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/accounts/") && countPathSegments(r.URL.Path) == 2:
 		h.updateAccount(w, r)
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/accounts/") && countPathSegments(r.URL.Path) == 2:
 		h.deleteAccount(w, r)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/accounts/") && strings.HasSuffix(r.URL.Path, "/duplicate"):
 		h.duplicateAccount(w, r)
+	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/accounts/") && strings.HasSuffix(r.URL.Path, "/share"):
+		h.shareAccount(w, r)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/accounts/") && strings.HasSuffix(r.URL.Path, "/test"):
 		h.testAccount(w, r)
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/accounts/") && strings.HasSuffix(r.URL.Path, "/ppchat-token-logs"):
@@ -133,6 +137,30 @@ type importCurrentAuthRequest struct {
 	AccountName string `json:"account_name"`
 }
 
+type importSharedAccountRequest struct {
+	Payload string `json:"payload"`
+}
+
+type accountShareEnvelope struct {
+	Kind          string               `json:"kind"`
+	SchemaVersion int                  `json:"schema_version"`
+	ExportedAt    string               `json:"exported_at"`
+	Account       accountSharePayload  `json:"account"`
+}
+
+type accountSharePayload struct {
+	ProviderType      accounts.ProviderType `json:"provider_type"`
+	AccountName       string                `json:"account_name"`
+	SourceIcon        string                `json:"source_icon"`
+	AuthMode          accounts.AuthMode     `json:"auth_mode"`
+	BaseURL           string                `json:"base_url"`
+	CredentialRef     string                `json:"credential_ref"`
+	AccountDriver     string                `json:"account_driver"`
+	UsageDriver       string                `json:"usage_driver"`
+	UsageConfigJSON   string                `json:"usage_config_json"`
+	SupportsResponses bool                  `json:"supports_responses"`
+}
+
 type updateAccountRequest struct {
 	AccountName       string          `json:"account_name"`
 	SourceIcon        string          `json:"source_icon"`
@@ -158,6 +186,9 @@ type accountChatTestRequest struct {
 	Model string `json:"model"`
 	Input string `json:"input"`
 }
+
+const accountShareKind = "aigate-account-share"
+const accountShareSchemaVersion = 1
 
 func (h *AccountsHandler) createAccount(w http.ResponseWriter, r *http.Request) {
 	var req createAccountRequest
@@ -444,6 +475,81 @@ func (h *AccountsHandler) importCurrentAuth(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *AccountsHandler) shareAccount(w http.ResponseWriter, r *http.Request) {
+	id, err := accountIDFromPath(strings.TrimSuffix(strings.TrimSuffix(r.URL.Path, "/share"), "/"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	account, err := h.repo.GetByID(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	account = applyBuiltInDriverDefaults(account)
+
+	payload, err := json.Marshal(accountShareEnvelope{
+		Kind:          accountShareKind,
+		SchemaVersion: accountShareSchemaVersion,
+		ExportedAt:    time.Now().UTC().Format(time.RFC3339),
+		Account: accountSharePayload{
+			ProviderType:      account.ProviderType,
+			AccountName:       account.AccountName,
+			SourceIcon:        normalizeAccountSourceIcon(account.SourceIcon),
+			AuthMode:          account.AuthMode,
+			BaseURL:           account.BaseURL,
+			CredentialRef:     account.CredentialRef,
+			AccountDriver:     account.AccountDriver,
+			UsageDriver:       account.UsageDriver,
+			UsageConfigJSON:   account.UsageConfigJSON,
+			SupportsResponses: account.NativeResponsesCapable(),
+		},
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"payload": string(payload)})
+}
+
+func (h *AccountsHandler) importSharedAccount(w http.ResponseWriter, r *http.Request) {
+	var req importSharedAccountRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	envelope, err := parseSharedAccountPayload(req.Payload)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	account := applyBuiltInDriverDefaults(accounts.Account{
+		ProviderType:      envelope.Account.ProviderType,
+		AccountName:       envelope.Account.AccountName,
+		SourceIcon:        normalizeAccountSourceIcon(envelope.Account.SourceIcon),
+		AuthMode:          envelope.Account.AuthMode,
+		BaseURL:           strings.TrimSpace(envelope.Account.BaseURL),
+		CredentialRef:     envelope.Account.CredentialRef,
+		AccountDriver:     strings.TrimSpace(envelope.Account.AccountDriver),
+		UsageDriver:       strings.TrimSpace(envelope.Account.UsageDriver),
+		UsageConfigJSON:   strings.TrimSpace(envelope.Account.UsageConfigJSON),
+		Status:            accounts.StatusActive,
+		Priority:          0,
+		IsActive:          false,
+		SupportsResponses: envelope.Account.SupportsResponses,
+	})
+
+	if err := h.repo.Create(account); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	w.WriteHeader(http.StatusCreated)
 }
 
@@ -1055,12 +1161,96 @@ func accountIDFromPath(path string) (int64, error) {
 	trimmed := strings.TrimPrefix(path, "/accounts/")
 	trimmed = strings.TrimSuffix(trimmed, "/disable")
 	trimmed = strings.TrimSuffix(trimmed, "/duplicate")
+	trimmed = strings.TrimSuffix(trimmed, "/share")
 	trimmed = strings.TrimSuffix(trimmed, "/test")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
 		return 0, errors.New("missing account id")
 	}
 	return strconv.ParseInt(trimmed, 10, 64)
+}
+
+func parseSharedAccountPayload(raw string) (accountShareEnvelope, error) {
+	var envelope accountShareEnvelope
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &envelope); err != nil {
+		return accountShareEnvelope{}, fmt.Errorf("invalid shared account payload: %w", err)
+	}
+	if envelope.Kind != accountShareKind {
+		return accountShareEnvelope{}, fmt.Errorf("invalid shared account kind: %q", envelope.Kind)
+	}
+	if envelope.SchemaVersion != accountShareSchemaVersion {
+		return accountShareEnvelope{}, fmt.Errorf("unsupported shared account schema version: %d", envelope.SchemaVersion)
+	}
+	if err := validateSharedAccount(envelope.Account); err != nil {
+		return accountShareEnvelope{}, err
+	}
+	return envelope, nil
+}
+
+func validateSharedAccount(payload accountSharePayload) error {
+	if !isSupportedProviderType(payload.ProviderType) {
+		return fmt.Errorf("unsupported provider_type: %q", payload.ProviderType)
+	}
+	if strings.TrimSpace(payload.AccountName) == "" {
+		return errors.New("missing account_name")
+	}
+	if !isSupportedAuthMode(payload.AuthMode) {
+		return fmt.Errorf("unsupported auth_mode: %q", payload.AuthMode)
+	}
+	if strings.TrimSpace(payload.CredentialRef) == "" {
+		return errors.New("missing credential_ref")
+	}
+	if err := validateAbsoluteBaseURL(payload.BaseURL); err != nil {
+		return err
+	}
+	if err := validateUsageConfigJSON(payload.UsageConfigJSON); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isSupportedProviderType(value accounts.ProviderType) bool {
+	switch value {
+	case accounts.ProviderOpenAIOfficial, accounts.ProviderOpenAICompatible:
+		return true
+	default:
+		return false
+	}
+}
+
+func isSupportedAuthMode(value accounts.AuthMode) bool {
+	switch value {
+	case accounts.AuthModeOAuth, accounts.AuthModeAPIKey, accounts.AuthModeLocalImport:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateAbsoluteBaseURL(raw string) error {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("invalid base_url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("invalid base_url scheme: %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return errors.New("invalid base_url: missing host")
+	}
+	return nil
+}
+
+func validateUsageConfigJSON(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+		return fmt.Errorf("invalid usage_config_json: %w", err)
+	}
+	return nil
 }
 
 func nextDuplicatedAccountName(baseName string, accountList []accounts.Account) string {

--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -142,10 +142,10 @@ type importSharedAccountRequest struct {
 }
 
 type accountShareEnvelope struct {
-	Kind          string               `json:"kind"`
-	SchemaVersion int                  `json:"schema_version"`
-	ExportedAt    string               `json:"exported_at"`
-	Account       accountSharePayload  `json:"account"`
+	Kind          string              `json:"kind"`
+	SchemaVersion int                 `json:"schema_version"`
+	ExportedAt    string              `json:"exported_at"`
+	Account       accountSharePayload `json:"account"`
 }
 
 type accountSharePayload struct {
@@ -318,21 +318,24 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 	}
 
 	type responseItem struct {
-		AccountID            int64      `json:"account_id"`
-		Balance              float64    `json:"balance"`
-		QuotaRemaining       float64    `json:"quota_remaining"`
-		RPMRemaining         float64    `json:"rpm_remaining"`
-		TPMRemaining         float64    `json:"tpm_remaining"`
-		HealthScore          float64    `json:"health_score"`
-		RecentErrorRate      float64    `json:"recent_error_rate"`
-		LastTotalTokens      float64    `json:"last_total_tokens"`
-		LastInputTokens      float64    `json:"last_input_tokens"`
-		LastOutputTokens     float64    `json:"last_output_tokens"`
-		ModelContextWindow   float64    `json:"model_context_window"`
-		PrimaryUsedPercent   float64    `json:"primary_used_percent"`
-		SecondaryUsedPercent float64    `json:"secondary_used_percent"`
-		PrimaryResetsAt      *time.Time `json:"primary_resets_at,omitempty"`
-		SecondaryResetsAt    *time.Time `json:"secondary_resets_at,omitempty"`
+		AccountID                 int64      `json:"account_id"`
+		Balance                   float64    `json:"balance"`
+		QuotaRemaining            float64    `json:"quota_remaining"`
+		RPMRemaining              float64    `json:"rpm_remaining"`
+		TPMRemaining              float64    `json:"tpm_remaining"`
+		HealthScore               float64    `json:"health_score"`
+		RecentErrorRate           float64    `json:"recent_error_rate"`
+		LastTotalTokens           float64    `json:"last_total_tokens"`
+		LastInputTokens           float64    `json:"last_input_tokens"`
+		LastOutputTokens          float64    `json:"last_output_tokens"`
+		ModelContextWindow        float64    `json:"model_context_window"`
+		PrimaryUsedPercent        float64    `json:"primary_used_percent"`
+		SecondaryUsedPercent      float64    `json:"secondary_used_percent"`
+		PrimaryResetsAt           *time.Time `json:"primary_resets_at,omitempty"`
+		SecondaryResetsAt         *time.Time `json:"secondary_resets_at,omitempty"`
+		PPChatTodayUsedQuota      float64    `json:"ppchat_today_used_quota,omitempty"`
+		PPChatTodayAddedQuota     float64    `json:"ppchat_today_added_quota,omitempty"`
+		PPChatTodayRemainingQuota float64    `json:"ppchat_today_remaining_quota,omitempty"`
 	}
 
 	usageByAccount := map[int64]usage.Snapshot{}
@@ -347,26 +350,61 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 	response := make([]responseItem, 0, len(accountList))
 	for _, account := range accountList {
 		snapshot := usageByAccount[account.ID]
+		ppchatSummary := parsePPChatUsageSummary(snapshot.ProviderSnapshotJSON)
 		response = append(response, responseItem{
-			AccountID:            account.ID,
-			Balance:              snapshot.Balance,
-			QuotaRemaining:       snapshot.QuotaRemaining,
-			RPMRemaining:         snapshot.RPMRemaining,
-			TPMRemaining:         snapshot.TPMRemaining,
-			HealthScore:          snapshot.HealthScore,
-			RecentErrorRate:      snapshot.RecentErrorRate,
-			LastTotalTokens:      snapshot.LastTotalTokens,
-			LastInputTokens:      snapshot.LastInputTokens,
-			LastOutputTokens:     snapshot.LastOutputTokens,
-			ModelContextWindow:   snapshot.ModelContextWindow,
-			PrimaryUsedPercent:   snapshot.PrimaryUsedPercent,
-			SecondaryUsedPercent: snapshot.SecondaryUsedPercent,
-			PrimaryResetsAt:      snapshot.PrimaryResetsAt,
-			SecondaryResetsAt:    snapshot.SecondaryResetsAt,
+			AccountID:                 account.ID,
+			Balance:                   snapshot.Balance,
+			QuotaRemaining:            snapshot.QuotaRemaining,
+			RPMRemaining:              snapshot.RPMRemaining,
+			TPMRemaining:              snapshot.TPMRemaining,
+			HealthScore:               snapshot.HealthScore,
+			RecentErrorRate:           snapshot.RecentErrorRate,
+			LastTotalTokens:           snapshot.LastTotalTokens,
+			LastInputTokens:           snapshot.LastInputTokens,
+			LastOutputTokens:          snapshot.LastOutputTokens,
+			ModelContextWindow:        snapshot.ModelContextWindow,
+			PrimaryUsedPercent:        snapshot.PrimaryUsedPercent,
+			SecondaryUsedPercent:      snapshot.SecondaryUsedPercent,
+			PrimaryResetsAt:           snapshot.PrimaryResetsAt,
+			SecondaryResetsAt:         snapshot.SecondaryResetsAt,
+			PPChatTodayUsedQuota:      ppchatSummary.TodayUsedQuota,
+			PPChatTodayAddedQuota:     ppchatSummary.TodayAddedQuota,
+			PPChatTodayRemainingQuota: ppchatSummary.TodayRemainingQuota,
 		})
 	}
 
 	writeJSON(w, http.StatusOK, response)
+}
+
+type ppchatUsageSummary struct {
+	TodayUsedQuota      float64
+	TodayAddedQuota     float64
+	TodayRemainingQuota float64
+}
+
+func parsePPChatUsageSummary(raw string) ppchatUsageSummary {
+	if strings.TrimSpace(raw) == "" {
+		return ppchatUsageSummary{}
+	}
+	var decoded struct {
+		Payload struct {
+			Data struct {
+				TokenInfo struct {
+					TodayUsedQuota     float64 `json:"today_used_quota"`
+					TodayAddedQuota    float64 `json:"today_added_quota"`
+					RemainQuotaDisplay float64 `json:"remain_quota_display"`
+				} `json:"token_info"`
+			} `json:"data"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return ppchatUsageSummary{}
+	}
+	return ppchatUsageSummary{
+		TodayUsedQuota:      decoded.Payload.Data.TokenInfo.TodayUsedQuota,
+		TodayAddedQuota:     decoded.Payload.Data.TokenInfo.TodayAddedQuota,
+		TodayRemainingQuota: decoded.Payload.Data.TokenInfo.RemainQuotaDisplay,
+	}
 }
 
 func (h *AccountsHandler) refreshAccountsUsage(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -400,11 +400,22 @@ func parsePPChatUsageSummary(raw string) ppchatUsageSummary {
 	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
 		return ppchatUsageSummary{}
 	}
+	addedQuota := decoded.Payload.Data.TokenInfo.TodayAddedQuota
+	if addedQuota <= 0 {
+		addedQuota = decoded.Payload.Data.TokenInfo.TodayUsedQuota + maxFloat64(decoded.Payload.Data.TokenInfo.RemainQuotaDisplay, 0)
+	}
 	return ppchatUsageSummary{
 		TodayUsedQuota:      decoded.Payload.Data.TokenInfo.TodayUsedQuota,
-		TodayAddedQuota:     decoded.Payload.Data.TokenInfo.TodayAddedQuota,
+		TodayAddedQuota:     addedQuota,
 		TodayRemainingQuota: decoded.Payload.Data.TokenInfo.RemainQuotaDisplay,
 	}
+}
+
+func maxFloat64(left, right float64) float64 {
+	if left > right {
+		return left
+	}
+	return right
 }
 
 func (h *AccountsHandler) refreshAccountsUsage(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -869,6 +869,75 @@ func TestAccountsHandlerListUsageReadsCachedSnapshotsOnly(t *testing.T) {
 	}
 }
 
+func TestAccountsHandlerListUsageIncludesPPChatDailySummaryFromCachedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	handler := api.NewAccountsHandler(repo, usageRepo, auth.NewOAuthConnector(auth.Config{}), auth.NewStateStore(5*time.Minute))
+
+	if err := repo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "ppchat-main",
+		SourceIcon:    "ppchat",
+		AuthMode:      accounts.AuthModeAPIKey,
+		BaseURL:       "https://code.ppchat.vip/v1",
+		CredentialRef: "sk-ppchat",
+		Status:        accounts.StatusActive,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:      1,
+		QuotaRemaining: 13931,
+		CheckedAt:      time.Now().UTC(),
+		Source:         "remote",
+		Confidence:     "high",
+		ProviderSnapshotJSON: `{
+			"capacity_model":"quota_rate",
+			"payload":{
+				"success":true,
+				"data":{
+					"token_info":{
+						"today_used_quota":1068,
+						"remain_quota_display":13931,
+						"today_added_quota":14999
+					}
+				}
+			}
+		}`,
+	}); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/accounts/usage", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /accounts/usage status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var listed []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if listed[0]["ppchat_today_used_quota"].(float64) != 1068 {
+		t.Fatalf("ppchat_today_used_quota = %v, want 1068", listed[0]["ppchat_today_used_quota"])
+	}
+	if listed[0]["ppchat_today_remaining_quota"].(float64) != 13931 {
+		t.Fatalf("ppchat_today_remaining_quota = %v, want 13931", listed[0]["ppchat_today_remaining_quota"])
+	}
+	if listed[0]["ppchat_today_added_quota"].(float64) != 14999 {
+		t.Fatalf("ppchat_today_added_quota = %v, want 14999", listed[0]["ppchat_today_added_quota"])
+	}
+}
+
 func TestAccountsHandlerRefreshUsage(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -938,6 +938,68 @@ func TestAccountsHandlerListUsageIncludesPPChatDailySummaryFromCachedSnapshot(t 
 	}
 }
 
+func TestAccountsHandlerListUsageDerivesPPChatAddedQuotaWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	handler := api.NewAccountsHandler(repo, usageRepo, auth.NewOAuthConnector(auth.Config{}), auth.NewStateStore(5*time.Minute))
+
+	if err := repo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "ppchat-main",
+		SourceIcon:    "ppchat",
+		AuthMode:      accounts.AuthModeAPIKey,
+		BaseURL:       "https://code.ppchat.vip/v1",
+		CredentialRef: "sk-ppchat",
+		Status:        accounts.StatusActive,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:      1,
+		QuotaRemaining: 13931,
+		CheckedAt:      time.Now().UTC(),
+		Source:         "remote",
+		Confidence:     "high",
+		ProviderSnapshotJSON: `{
+			"capacity_model":"quota_rate",
+			"payload":{
+				"success":true,
+				"data":{
+					"token_info":{
+						"today_used_quota":1068,
+						"remain_quota_display":13931
+					}
+				}
+			}
+		}`,
+	}); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/accounts/usage", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /accounts/usage status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var listed []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if listed[0]["ppchat_today_added_quota"].(float64) != 14999 {
+		t.Fatalf("ppchat_today_added_quota = %v, want 14999", listed[0]["ppchat_today_added_quota"])
+	}
+}
+
 func TestAccountsHandlerRefreshUsage(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -590,6 +591,207 @@ func TestAccountsHandlerDuplicateAccountCreatesInactiveCopyWithIncrementedName(t
 	}
 	if duplicate.SourceIcon != "ppchat" {
 		t.Fatalf("duplicate source_icon = %q, want ppchat", duplicate.SourceIcon)
+	}
+}
+
+func TestAccountsHandlerShareExportsPortablePayload(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	handler := api.NewAccountsHandler(repo, nil, auth.NewOAuthConnector(auth.Config{}), auth.NewStateStore(5*time.Minute))
+
+	if err := repo.Create(accounts.Account{
+		ProviderType:      accounts.ProviderOpenAICompatible,
+		AccountName:       "mirror-east",
+		SourceIcon:        "ppchat",
+		AuthMode:          accounts.AuthModeAPIKey,
+		BaseURL:           "https://code.ppchat.vip/v1",
+		CredentialRef:     "sk-share-me",
+		AccountDriver:     "builtin_api_key",
+		UsageDriver:       "lua",
+		UsageConfigJSON:   `{"script":"adapters/vendor.lua"}`,
+		Status:            accounts.StatusCooldown,
+		Priority:          9,
+		IsActive:          true,
+		SupportsResponses: true,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/accounts/1/share", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /accounts/1/share status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var response struct {
+		Payload string `json:"payload"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if strings.TrimSpace(response.Payload) == "" {
+		t.Fatal("payload is empty")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(response.Payload), &payload); err != nil {
+		t.Fatalf("Unmarshal payload returned error: %v", err)
+	}
+	if payload["kind"] != "aigate-account-share" {
+		t.Fatalf("kind = %v, want aigate-account-share", payload["kind"])
+	}
+	if payload["schema_version"].(float64) != 1 {
+		t.Fatalf("schema_version = %v, want 1", payload["schema_version"])
+	}
+	if strings.TrimSpace(payload["exported_at"].(string)) == "" {
+		t.Fatal("exported_at is empty")
+	}
+
+	accountPayload, ok := payload["account"].(map[string]any)
+	if !ok {
+		t.Fatalf("account = %#v, want object", payload["account"])
+	}
+	if accountPayload["provider_type"] != "openai-compatible" {
+		t.Fatalf("provider_type = %v, want openai-compatible", accountPayload["provider_type"])
+	}
+	if accountPayload["account_name"] != "mirror-east" {
+		t.Fatalf("account_name = %v, want mirror-east", accountPayload["account_name"])
+	}
+	if accountPayload["credential_ref"] != "sk-share-me" {
+		t.Fatalf("credential_ref = %v, want sk-share-me", accountPayload["credential_ref"])
+	}
+	if accountPayload["usage_driver"] != "lua" {
+		t.Fatalf("usage_driver = %v, want lua", accountPayload["usage_driver"])
+	}
+	if accountPayload["usage_config_json"] != `{"script":"adapters/vendor.lua"}` {
+		t.Fatalf("usage_config_json = %v, want serialized config", accountPayload["usage_config_json"])
+	}
+	if _, exists := accountPayload["priority"]; exists {
+		t.Fatalf("portable payload unexpectedly contains priority: %#v", accountPayload)
+	}
+	if _, exists := accountPayload["is_active"]; exists {
+		t.Fatalf("portable payload unexpectedly contains is_active: %#v", accountPayload)
+	}
+	if _, exists := accountPayload["status"]; exists {
+		t.Fatalf("portable payload unexpectedly contains status: %#v", accountPayload)
+	}
+}
+
+func TestAccountsHandlerImportSharedCreatesFreshAccount(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	handler := api.NewAccountsHandler(repo, nil, auth.NewOAuthConnector(auth.Config{}), auth.NewStateStore(5*time.Minute))
+
+	req := httptest.NewRequest(http.MethodPost, "/accounts/import-shared", bytes.NewBufferString(`{
+		"payload":"{\"kind\":\"aigate-account-share\",\"schema_version\":1,\"exported_at\":\"2026-03-18T15:20:00Z\",\"account\":{\"provider_type\":\"openai-compatible\",\"account_name\":\"shared-mirror\",\"source_icon\":\"ppchat\",\"auth_mode\":\"api_key\",\"base_url\":\"https://code.ppchat.vip/v1\",\"credential_ref\":\"sk-imported\",\"account_driver\":\"builtin_api_key\",\"usage_driver\":\"lua\",\"usage_config_json\":\"{\\\"script\\\":\\\"adapters/vendor.lua\\\"}\",\"supports_responses\":true}}"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST /accounts/import-shared status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+
+	listed, err := repo.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("List returned %d accounts, want 1", len(listed))
+	}
+	if listed[0].AccountName != "shared-mirror" {
+		t.Fatalf("AccountName = %q, want shared-mirror", listed[0].AccountName)
+	}
+	if listed[0].CredentialRef != "sk-imported" {
+		t.Fatalf("CredentialRef = %q, want sk-imported", listed[0].CredentialRef)
+	}
+	if listed[0].Priority != 0 {
+		t.Fatalf("Priority = %d, want 0", listed[0].Priority)
+	}
+	if listed[0].IsActive {
+		t.Fatal("IsActive = true, want false")
+	}
+	if listed[0].Status != accounts.StatusActive {
+		t.Fatalf("Status = %q, want active", listed[0].Status)
+	}
+	if listed[0].UsageDriver != "lua" {
+		t.Fatalf("UsageDriver = %q, want lua", listed[0].UsageDriver)
+	}
+}
+
+func TestAccountsHandlerImportSharedRejectsInvalidPayload(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "invalid kind",
+			payload: `{"kind":"wrong-kind","schema_version":1,"exported_at":"2026-03-18T15:20:00Z","account":{"provider_type":"openai-compatible","account_name":"shared-mirror","source_icon":"ppchat","auth_mode":"api_key","base_url":"https://code.ppchat.vip/v1","credential_ref":"sk-imported","usage_config_json":"{}"}}`,
+		},
+		{
+			name:    "invalid schema version",
+			payload: `{"kind":"aigate-account-share","schema_version":2,"exported_at":"2026-03-18T15:20:00Z","account":{"provider_type":"openai-compatible","account_name":"shared-mirror","source_icon":"ppchat","auth_mode":"api_key","base_url":"https://code.ppchat.vip/v1","credential_ref":"sk-imported","usage_config_json":"{}"}}`,
+		},
+		{
+			name:    "invalid base url",
+			payload: `{"kind":"aigate-account-share","schema_version":1,"exported_at":"2026-03-18T15:20:00Z","account":{"provider_type":"openai-compatible","account_name":"shared-mirror","source_icon":"ppchat","auth_mode":"api_key","base_url":"not-a-url","credential_ref":"sk-imported","usage_config_json":"{}"}}`,
+		},
+		{
+			name:    "invalid usage config json",
+			payload: `{"kind":"aigate-account-share","schema_version":1,"exported_at":"2026-03-18T15:20:00Z","account":{"provider_type":"openai-compatible","account_name":"shared-mirror","source_icon":"ppchat","auth_mode":"api_key","base_url":"https://code.ppchat.vip/v1","credential_ref":"sk-imported","usage_config_json":"{"}}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+			if err != nil {
+				t.Fatalf("Open returned error: %v", err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+
+			repo := accounts.NewSQLiteRepository(store.DB())
+			handler := api.NewAccountsHandler(repo, nil, auth.NewOAuthConnector(auth.Config{}), auth.NewStateStore(5*time.Minute))
+
+			req := httptest.NewRequest(http.MethodPost, "/accounts/import-shared", bytes.NewBufferString(`{"payload":`+strconv.Quote(tc.payload)+`}`))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("POST /accounts/import-shared status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+
+			listed, err := repo.List()
+			if err != nil {
+				t.Fatalf("List returned error: %v", err)
+			}
+			if len(listed) != 0 {
+				t.Fatalf("List returned %d accounts, want 0", len(listed))
+			}
+		})
 	}
 }
 

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -312,6 +312,113 @@ func TestResponsesHandlerThinModeOfficialStreamCapturesWrappedTokenCount(t *test
 	}
 }
 
+func TestResponsesHandlerPreservesExistingWindowUsageWhenResponseLacksRateLimits(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ""+
+			"data: {\"type\":\"response.output_text.delta\",\"delta\":\"official-pong\"}\n\n"+
+			"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_preserve_usage_1\",\"usage\":{\"input_tokens\":100,\"input_tokens_details\":{\"cached_tokens\":20},\"output_tokens\":30,\"total_tokens\":130},\"output\":[]}}\n\n"+
+			"data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	if err := accountRepo.Create(accounts.Account{
+		ProviderType: accounts.ProviderOpenAIOfficial,
+		AccountName:  "official-preserve",
+		AuthMode:     accounts.AuthModeLocalImport,
+		BaseURL:      upstream.URL + "/backend-api/codex",
+		CredentialRef: `{
+			"auth_mode":"chatgpt",
+			"tokens":{"access_token":"token-1","account_id":"acct-1"}
+		}`,
+		Status:            accounts.StatusActive,
+		Priority:          100,
+		SupportsResponses: true,
+		IsActive:          true,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	primaryReset := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
+	secondaryReset := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:            1,
+		Source:               "remote",
+		Confidence:           "high",
+		ProviderSnapshotJSON: `{"capacity_model":"official_window","has_rpm":true,"has_tpm":true}`,
+		Balance:              0,
+		RPMRemaining:         70,
+		TPMRemaining:         3,
+		HealthScore:          0.365,
+		PrimaryUsedPercent:   30,
+		SecondaryUsedPercent: 97,
+		PrimaryResetsAt:      &primaryReset,
+		SecondaryResetsAt:    &secondaryReset,
+		CheckedAt:            time.Now().UTC().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	settingsRepo := settings.NewSQLiteRepository(store.DB())
+	current := settings.DefaultAppSettings()
+	current.AutoFailoverEnabled = true
+	if err := settingsRepo.SaveAppSettings(current); err != nil {
+		t.Fatalf("SaveAppSettings returned error: %v", err)
+	}
+
+	handler := api.NewResponsesHandler(
+		accountRepo,
+		usageRepo,
+		conversations.NewSQLiteRepository(store.DB()),
+		api.WithResponsesSettings(settingsRepo),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-5.4","input":"ping","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	snapshot, err := usageRepo.GetLatest(1)
+	if err != nil {
+		t.Fatalf("GetLatest returned error: %v", err)
+	}
+	if snapshot.LastInputTokens != 120 || snapshot.LastOutputTokens != 30 || snapshot.LastTotalTokens != 130 {
+		t.Fatalf("latest usage tokens = in:%v out:%v total:%v, want in:120 out:30 total:130", snapshot.LastInputTokens, snapshot.LastOutputTokens, snapshot.LastTotalTokens)
+	}
+	if snapshot.PrimaryUsedPercent != 30 {
+		t.Fatalf("PrimaryUsedPercent = %v, want 30", snapshot.PrimaryUsedPercent)
+	}
+	if snapshot.SecondaryUsedPercent != 97 {
+		t.Fatalf("SecondaryUsedPercent = %v, want 97", snapshot.SecondaryUsedPercent)
+	}
+	if snapshot.RPMRemaining != 70 {
+		t.Fatalf("RPMRemaining = %v, want 70", snapshot.RPMRemaining)
+	}
+	if snapshot.TPMRemaining != 3 {
+		t.Fatalf("TPMRemaining = %v, want 3", snapshot.TPMRemaining)
+	}
+	if snapshot.PrimaryResetsAt == nil || !snapshot.PrimaryResetsAt.Equal(primaryReset) {
+		t.Fatalf("PrimaryResetsAt = %v, want %v", snapshot.PrimaryResetsAt, primaryReset)
+	}
+	if snapshot.SecondaryResetsAt == nil || !snapshot.SecondaryResetsAt.Equal(secondaryReset) {
+		t.Fatalf("SecondaryResetsAt = %v, want %v", snapshot.SecondaryResetsAt, secondaryReset)
+	}
+}
+
 func TestResponsesHandlerThinModeOfficialStreamWithoutContentTypeStillCapturesUsage(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/usage_capture.go
+++ b/backend/internal/api/usage_capture.go
@@ -12,10 +12,20 @@ type usageSaver interface {
 	Save(snapshot usage.Snapshot) error
 }
 
+type usageSnapshotReader interface {
+	GetLatest(accountID int64) (usage.Snapshot, error)
+}
+
 type responsesUsageCollector struct {
-	snapshot usage.Snapshot
-	hasData  bool
-	outputs  []map[string]any
+	snapshot                  usage.Snapshot
+	hasData                   bool
+	outputs                   []map[string]any
+	observedBalance           bool
+	observedQuotaRemaining    bool
+	observedModelContext      bool
+	observedPrimaryWindow     bool
+	observedSecondaryWindow   bool
+	observedProviderSnapshot  bool
 }
 
 type chatCompletionsUsageCollector struct {
@@ -65,10 +75,52 @@ func (c *responsesUsageCollector) Save(repo usageSaver) {
 	if c.snapshot.CheckedAt.IsZero() {
 		c.snapshot.CheckedAt = time.Now().UTC()
 	}
-	if c.snapshot.HealthScore == 0 {
+	if reader, ok := repo.(usageSnapshotReader); ok {
+		c.mergeLatestSnapshot(reader)
+	}
+	if c.snapshot.HealthScore == 0 && (c.observedPrimaryWindow || c.observedSecondaryWindow) {
 		c.snapshot.HealthScore = 1
 	}
 	_ = repo.Save(c.snapshot)
+}
+
+func (c *responsesUsageCollector) mergeLatestSnapshot(reader usageSnapshotReader) {
+	latest, err := reader.GetLatest(c.snapshot.AccountID)
+	if err != nil {
+		return
+	}
+	if c.snapshot.Source == "" {
+		c.snapshot.Source = latest.Source
+	}
+	if c.snapshot.Confidence == "" {
+		c.snapshot.Confidence = latest.Confidence
+	}
+	if c.snapshot.ProviderSnapshotJSON == "" {
+		c.snapshot.ProviderSnapshotJSON = latest.ProviderSnapshotJSON
+	}
+	if !c.observedBalance {
+		c.snapshot.Balance = latest.Balance
+	}
+	if !c.observedQuotaRemaining {
+		c.snapshot.QuotaRemaining = latest.QuotaRemaining
+	}
+	if !c.observedModelContext {
+		c.snapshot.ModelContextWindow = latest.ModelContextWindow
+	}
+	if !c.observedPrimaryWindow {
+		c.snapshot.PrimaryUsedPercent = latest.PrimaryUsedPercent
+		c.snapshot.RPMRemaining = latest.RPMRemaining
+		c.snapshot.PrimaryResetsAt = latest.PrimaryResetsAt
+	}
+	if !c.observedSecondaryWindow {
+		c.snapshot.SecondaryUsedPercent = latest.SecondaryUsedPercent
+		c.snapshot.TPMRemaining = latest.TPMRemaining
+		c.snapshot.SecondaryResetsAt = latest.SecondaryResetsAt
+	}
+	if !c.observedPrimaryWindow && !c.observedSecondaryWindow {
+		c.snapshot.HealthScore = latest.HealthScore
+		c.snapshot.ThrottledRecently = latest.ThrottledRecently
+	}
 }
 
 func (c *chatCompletionsUsageCollector) snapshotOrDefault() usage.Snapshot {
@@ -122,8 +174,10 @@ func (c *responsesUsageCollector) observeTokenCount(payload map[string]any) {
 			c.applyTokenUsageBreakdown(total)
 		}
 		if contextWindow := asFloat(info["model_context_window"]); contextWindow > 0 {
+			c.observedModelContext = true
 			c.snapshot.ModelContextWindow = contextWindow
 			if c.snapshot.LastTotalTokens > 0 {
+				c.observedQuotaRemaining = true
 				c.snapshot.QuotaRemaining = math.Max(contextWindow-c.snapshot.LastTotalTokens, 0)
 			}
 		}
@@ -142,8 +196,10 @@ func (c *responsesUsageCollector) observeThreadTokenUsageUpdated(payload map[str
 	c.hasData = true
 	c.applyTokenUsageBreakdown(total)
 	if contextWindow := asFloat(tokenUsage["model_context_window"]); contextWindow > 0 {
+		c.observedModelContext = true
 		c.snapshot.ModelContextWindow = contextWindow
 		if c.snapshot.LastTotalTokens > 0 {
+			c.observedQuotaRemaining = true
 			c.snapshot.QuotaRemaining = math.Max(contextWindow-c.snapshot.LastTotalTokens, 0)
 		}
 	}
@@ -212,14 +268,19 @@ func (c *responsesUsageCollector) applyRateLimits(limits map[string]any) {
 		return
 	}
 	if credits, ok := limits["credits"].(map[string]any); ok {
+		if _, exists := credits["balance"]; exists {
+			c.observedBalance = true
+		}
 		c.snapshot.Balance = asFloat(credits["balance"])
 	}
 	if primary, ok := limits["primary"].(map[string]any); ok {
+		c.observedPrimaryWindow = true
 		c.snapshot.PrimaryUsedPercent = asFloat(primary["used_percent"])
 		c.snapshot.RPMRemaining = math.Max(100-c.snapshot.PrimaryUsedPercent, 0)
 		c.snapshot.PrimaryResetsAt = asUnixTimePtr(primary["resets_at"])
 	}
 	if secondary, ok := limits["secondary"].(map[string]any); ok {
+		c.observedSecondaryWindow = true
 		c.snapshot.SecondaryUsedPercent = asFloat(secondary["used_percent"])
 		c.snapshot.TPMRemaining = math.Max(100-c.snapshot.SecondaryUsedPercent, 0)
 		c.snapshot.SecondaryResetsAt = asUnixTimePtr(secondary["resets_at"])

--- a/backend/internal/bootstrap/background_loop_test.go
+++ b/backend/internal/bootstrap/background_loop_test.go
@@ -1,0 +1,49 @@
+package bootstrap
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBackgroundLoopRecoversFromPanics(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tickCh := make(chan time.Time, 2)
+	var runs atomic.Int32
+	panicOnce := true
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runBackgroundLoop(ctx, tickCh, func(context.Context, time.Time) {
+			runs.Add(1)
+			if panicOnce {
+				panicOnce = false
+				panic("boom")
+			}
+		})
+	}()
+
+	tickCh <- time.Now()
+	tickCh <- time.Now().Add(time.Second)
+
+	deadline := time.After(200 * time.Millisecond)
+	for runs.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("background loop stopped after panic; runs=%d", runs.Load())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("background loop did not stop after cancel")
+	}
+}

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -41,6 +43,8 @@ type App struct {
 	cancel     context.CancelFunc
 	background sync.WaitGroup
 }
+
+type backgroundTask func(context.Context, time.Time)
 
 func NewApp(_ context.Context, cfg Config) (*App, error) {
 	if cfg.ListenAddr == "" {
@@ -180,20 +184,59 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 		defer app.background.Done()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		for {
-			select {
-			case <-appCtx.Done():
-				return
-			case now := <-ticker.C:
-				_ = recoveryJob.Run(appCtx, now.UTC())
-				_ = refreshOrchestrator.Run(appCtx, now.UTC())
-				_ = compactionJob.Run(appCtx, now.UTC())
-				_ = backupJob.Run(appCtx, now.UTC())
-			}
+		startupTasks := []backgroundTask{
+			loggedBackgroundTask("account recovery", recoveryJob.Run),
+			loggedBackgroundTask("usage refresh", refreshOrchestrator.Run),
 		}
+		tasks := []backgroundTask{
+			loggedBackgroundTask("account recovery", recoveryJob.Run),
+			loggedBackgroundTask("usage refresh", refreshOrchestrator.Run),
+			loggedBackgroundTask("usage compaction", compactionJob.Run),
+			loggedBackgroundTask("database backup", backupJob.Run),
+		}
+		runBackgroundCycle(appCtx, time.Now().UTC(), startupTasks...)
+		runBackgroundLoop(appCtx, ticker.C, tasks...)
 	}()
 
 	return app, nil
+}
+
+func loggedBackgroundTask(name string, task func(context.Context, time.Time) error) backgroundTask {
+	return func(ctx context.Context, runAt time.Time) {
+		if task == nil {
+			return
+		}
+		if err := task(ctx, runAt.UTC()); err != nil {
+			log.Printf("%s failed: %v", name, err)
+		}
+	}
+}
+
+func runBackgroundLoop(ctx context.Context, ticks <-chan time.Time, tasks ...backgroundTask) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now, ok := <-ticks:
+			if !ok {
+				return
+			}
+			runBackgroundCycle(ctx, now.UTC(), tasks...)
+		}
+	}
+}
+
+func runBackgroundCycle(ctx context.Context, now time.Time, tasks ...backgroundTask) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Printf("background scheduler panic recovered: %v\n%s", recovered, debug.Stack())
+		}
+	}()
+	for _, task := range tasks {
+		if task != nil {
+			task(ctx, now.UTC())
+		}
+	}
 }
 
 func cleanupLegacyAuditData(db *sql.DB) error {

--- a/backend/internal/bootstrap/bootstrap_test.go
+++ b/backend/internal/bootstrap/bootstrap_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gcssloop/codex-router/backend/internal/accounts"
 	"github.com/gcssloop/codex-router/backend/internal/bootstrap"
+	"github.com/gcssloop/codex-router/backend/internal/store/sqlite"
 )
 
 func TestNewApp(t *testing.T) {
@@ -122,6 +124,7 @@ func TestNewAppSchedulesUsageRefreshOrchestrator(t *testing.T) {
 	defer usageServer.Close()
 
 	dbPath := filepath.Join(t.TempDir(), "router.sqlite")
+	seedUsageAccount(t, dbPath, usageServer.URL, "lua-refresh", "sk-refresh")
 	app, err := bootstrap.NewApp(context.Background(), bootstrap.Config{
 		ListenAddr:        "127.0.0.1:0",
 		DatabasePath:      dbPath,
@@ -133,22 +136,6 @@ func TestNewAppSchedulesUsageRefreshOrchestrator(t *testing.T) {
 	t.Cleanup(func() {
 		_ = app.Close()
 	})
-
-	createReq := httptest.NewRequest(http.MethodPost, "/ai-router/api/accounts", bytes.NewBufferString(`{
-		"provider_type":"openai-compatible",
-		"account_name":"lua-refresh",
-		"auth_mode":"api_key",
-		"base_url":"https://mirror.example.test/v1",
-		"credential_ref":"sk-refresh",
-		"usage_driver":"lua",
-		"usage_config_json":"{\"script\":\"internal/usagedrv/lua/testdata/vendor_x.lua\",\"endpoint\":\"`+usageServer.URL+`/usage\"}"
-	}`))
-	createReq.Header.Set("Content-Type", "application/json")
-	createRec := httptest.NewRecorder()
-	app.Handler().ServeHTTP(createRec, createReq)
-	if createRec.Code != http.StatusCreated {
-		t.Fatalf("POST /ai-router/api/accounts status = %d, want %d", createRec.Code, http.StatusCreated)
-	}
 
 	deadline := time.Now().Add(1 * time.Second)
 	var lastStatus int
@@ -172,5 +159,81 @@ func TestNewAppSchedulesUsageRefreshOrchestrator(t *testing.T) {
 			t.Fatalf("usage refresh did not populate snapshot before deadline: status=%d body=%s", lastStatus, lastBody)
 		}
 		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestNewAppRefreshesUsageImmediatelyOnStartup(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	usageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-immediate" {
+			t.Fatalf("Authorization = %q, want Bearer sk-immediate", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"quota_remaining":654}`))
+	}))
+	defer usageServer.Close()
+
+	dbPath := filepath.Join(t.TempDir(), "router.sqlite")
+	seedUsageAccount(t, dbPath, usageServer.URL, "lua-immediate", "sk-immediate")
+
+	app, err := bootstrap.NewApp(context.Background(), bootstrap.Config{
+		ListenAddr:        "127.0.0.1:0",
+		DatabasePath:      dbPath,
+		SchedulerInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("restart NewApp returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Close()
+	})
+
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for {
+		req := httptest.NewRequest(http.MethodGet, "/ai-router/api/accounts/usage", nil)
+		rec := httptest.NewRecorder()
+		app.Handler().ServeHTTP(rec, req)
+		if rec.Code == http.StatusOK {
+			var items []map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+				t.Fatalf("json.Unmarshal returned error: %v", err)
+			}
+			if len(items) == 1 && items[0]["quota_remaining"] == float64(654) {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("usage refresh did not run immediately on startup: status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func seedUsageAccount(t *testing.T, dbPath, usageServerURL, accountName, credential string) {
+	t.Helper()
+
+	store, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open returned error: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	err = repo.Create(accounts.Account{
+		ProviderType:    accounts.ProviderOpenAICompatible,
+		AccountName:     accountName,
+		AuthMode:        accounts.AuthModeAPIKey,
+		CredentialRef:   credential,
+		UsageDriver:     "lua",
+		UsageConfigJSON: "{\"script\":\"internal/usagedrv/lua/testdata/vendor_x.lua\",\"endpoint\":\"" + usageServerURL + "/usage\"}",
+		BaseURL:         "https://mirror.example.test/v1",
+		Status:          accounts.StatusActive,
+		Priority:        1,
+	})
+	if err != nil {
+		t.Fatalf("seed usage account returned error: %v", err)
 	}
 }

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -21,7 +21,11 @@ dependencies = [
 name = "aigate-desktop"
 version = "1.1.7"
 dependencies = [
+ "base64 0.22.1",
+ "futures-util",
+ "minisign-verify",
  "once_cell",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -312,6 +316,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1017,8 +1027,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1028,9 +1040,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1319,6 +1333,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1743,6 +1758,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2482,6 +2503,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,6 +2604,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,6 +2634,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,6 +2659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2669,6 +2774,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2702,7 +2848,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -2719,6 +2865,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2774,6 +2926,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2820,6 +2973,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3040,6 +3199,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3416,7 +3587,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3543,7 +3714,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -3764,6 +3935,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4289,6 +4475,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -4317,6 +4516,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4371,6 +4580,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -13,6 +13,10 @@ tauri-plugin-updater = "2"
 once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
+futures-util = "0.3"
+minisign-verify = "0.2"
+base64 = "0.22"
 
 [features]
 default = []

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,6 +1,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use base64::Engine;
+use futures_util::StreamExt;
+use minisign_verify::{PublicKey, Signature};
 use once_cell::sync::Lazy;
+use reqwest::header::{HeaderValue, ACCEPT};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::VecDeque;
@@ -8,6 +12,7 @@ use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::thread::JoinHandle;
@@ -16,6 +21,7 @@ use tauri::image::Image;
 use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder};
 use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
+use tauri_plugin_updater::{Update, UpdaterExt};
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -29,6 +35,8 @@ static DESKTOP_RUNTIME: Lazy<Mutex<DesktopRuntime>> =
     Lazy::new(|| Mutex::new(DesktopRuntime::default()));
 static DESKTOP_RECENT_LOGS: Lazy<Mutex<VecDeque<DesktopLogEntry>>> =
     Lazy::new(|| Mutex::new(VecDeque::new()));
+static UPDATE_MANAGER: Lazy<Mutex<UpdateManagerState>> =
+    Lazy::new(|| Mutex::new(UpdateManagerState::default()));
 
 const DEFAULT_PROXY_HOST: &str = "127.0.0.1";
 const DEFAULT_PROXY_PORT: u16 = 6789;
@@ -54,10 +62,12 @@ const RESUME_RECOVERY_GAP_THRESHOLD: Duration = Duration::from_secs(15);
 const DESKTOP_RECENT_LOG_CAPACITY: usize = 200;
 const DESKTOP_RECENT_LOG_DEFAULT_LIMIT: usize = 50;
 const DESKTOP_RECENT_LOG_MAX_LIMIT: usize = 50;
+const UPDATE_POLL_CHUNK_SIZE: usize = 64 * 1024;
 const SIDECAR_MACOS_NAME: &str = "routerd-universal-apple-darwin";
 const SIDECAR_WINDOWS_NAME: &str = "routerd-x86_64-pc-windows-msvc.exe";
 const TRAY_ICON_COLOR_BYTES: &[u8] = include_bytes!("../icons/tray-icon-color.png");
 const TRAY_ICON_TEMPLATE_BYTES: &[u8] = include_bytes!("../icons/tray-icon-template.png");
+const UPDATER_PUBKEY_BASE64: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERGRDUyRkY5NzAzRDJGQzYKUldUR0x6MXcrUy9WMzdDd1VacitqN0JHSUc4UlVkSzB5bncwdUVNOTdhNys2aTIrTy85NXFyd2oK";
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
@@ -188,6 +198,110 @@ struct DesktopLogEntry {
     message: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct UpdateInfoPayload {
+    body: Option<String>,
+    current_version: String,
+    date: Option<String>,
+    version: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct UpdateProgressPayload {
+    percent: f64,
+    total: u64,
+    transferred: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum UpdateStatus {
+    Idle,
+    Checking,
+    UpToDate,
+    Available,
+    Downloading,
+    Ready,
+    Unsupported,
+    Cancelled,
+    Error,
+}
+
+impl Default for UpdateStatus {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct UpdateStatePayload {
+    status: UpdateStatus,
+    update: Option<UpdateInfoPayload>,
+    progress: Option<UpdateProgressPayload>,
+    error: Option<String>,
+}
+
+#[derive(Default)]
+struct UpdateManagerState {
+    snapshot: UpdateStatePayload,
+    active_version: Option<String>,
+    cancel_flag: Option<Arc<AtomicBool>>,
+}
+
+impl UpdateManagerState {
+    fn snapshot(&self) -> UpdateStatePayload {
+        self.snapshot.clone()
+    }
+
+    fn set_snapshot(&mut self, snapshot: UpdateStatePayload) {
+        self.snapshot = snapshot;
+    }
+
+    fn begin_download(
+        &mut self,
+        update: UpdateInfoPayload,
+    ) -> Result<Arc<AtomicBool>, String> {
+        if self.snapshot.status == UpdateStatus::Downloading {
+            if self.active_version.as_deref() == Some(update.version.as_str()) {
+                if let Some(flag) = &self.cancel_flag {
+                    return Ok(flag.clone());
+                }
+            }
+            return Err("Another update download is already in progress.".to_string());
+        }
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        self.active_version = Some(update.version.clone());
+        self.cancel_flag = Some(cancel_flag.clone());
+        self.snapshot = UpdateStatePayload {
+            status: UpdateStatus::Downloading,
+            update: Some(update),
+            progress: Some(UpdateProgressPayload::default()),
+            error: None,
+        };
+        Ok(cancel_flag)
+    }
+
+    fn request_cancel(&mut self) {
+        if let Some(flag) = &self.cancel_flag {
+            flag.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn finish_terminal(&mut self, status: UpdateStatus, update: Option<UpdateInfoPayload>, error: Option<String>) {
+        self.active_version = None;
+        self.cancel_flag = None;
+        self.snapshot = UpdateStatePayload {
+            status,
+            update,
+            progress: None,
+            error,
+        };
+    }
+}
+
 #[derive(Clone, Default)]
 struct DesktopRuntime {
     sidecar_path: PathBuf,
@@ -212,7 +326,11 @@ fn main() {
             get_desktop_shell_context,
             apply_app_settings,
             get_app_metadata,
-            get_recent_desktop_logs
+            get_recent_desktop_logs,
+            get_update_state,
+            check_for_app_update,
+            start_update_download,
+            cancel_update_download
         ])
         .setup(|app| {
             let cache = initialize_runtime(app.handle())?;
@@ -329,6 +447,285 @@ fn get_recent_desktop_logs(limit: Option<usize>) -> Vec<DesktopLogEntry> {
         .lock()
         .map(|entries| entries.iter().rev().take(count).cloned().collect())
         .unwrap_or_default()
+}
+
+#[tauri::command]
+fn get_update_state<R: Runtime>(app: AppHandle<R>) -> Result<UpdateStatePayload, String> {
+    let current_version = app.package_info().version.to_string();
+    Ok(current_update_snapshot(&current_version))
+}
+
+#[tauri::command]
+async fn check_for_app_update<R: Runtime>(app: AppHandle<R>) -> Result<UpdateStatePayload, String> {
+    let current_version = app.package_info().version.to_string();
+    {
+        let mut manager = lock_update_manager()?;
+        let existing_update = manager.snapshot.update.clone();
+        let existing_progress = manager.snapshot.progress.clone();
+        manager.set_snapshot(UpdateStatePayload {
+            status: UpdateStatus::Checking,
+            update: existing_update,
+            progress: existing_progress,
+            error: None,
+        });
+    }
+
+    match fetch_update(&app).await? {
+        Some(update) => {
+            let payload = to_update_info_payload(&current_version, &update)?;
+            let snapshot = UpdateStatePayload {
+                status: UpdateStatus::Available,
+                update: Some(payload),
+                progress: None,
+                error: None,
+            };
+            lock_update_manager()?.set_snapshot(snapshot.clone());
+            Ok(snapshot)
+        }
+        None => {
+            let snapshot = UpdateStatePayload {
+                status: UpdateStatus::UpToDate,
+                update: None,
+                progress: None,
+                error: None,
+            };
+            lock_update_manager()?.set_snapshot(snapshot.clone());
+            Ok(snapshot)
+        }
+    }
+}
+
+#[tauri::command]
+async fn start_update_download<R: Runtime>(
+    app: AppHandle<R>,
+    version: String,
+) -> Result<UpdateStatePayload, String> {
+    let current_version = app.package_info().version.to_string();
+    {
+        let manager = lock_update_manager()?;
+        if manager.snapshot.status == UpdateStatus::Downloading
+            && manager.active_version.as_deref() == Some(version.as_str())
+        {
+            return Ok(manager.snapshot());
+        }
+    }
+
+    let update = fetch_update(&app)
+        .await?
+        .ok_or_else(|| "Update is no longer available. Check again and retry.".to_string())?;
+    let payload = to_update_info_payload(&current_version, &update)?;
+    if payload.version != version {
+        return Err("Update version mismatch. Check again and retry.".to_string());
+    }
+
+    let cancel_flag = {
+        let mut manager = lock_update_manager()?;
+        manager.begin_download(payload.clone())?
+    };
+
+    let app_handle = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let result = download_and_install_update(update, cancel_flag.clone()).await;
+        if cancel_flag.load(Ordering::SeqCst) {
+            if let Ok(mut manager) = lock_update_manager() {
+                manager.finish_terminal(UpdateStatus::Cancelled, Some(payload), None);
+            }
+            return;
+        }
+        match result {
+            Ok(()) => {
+                if let Ok(mut manager) = lock_update_manager() {
+                    manager.finish_terminal(UpdateStatus::Ready, Some(payload), None);
+                }
+            }
+            Err(err) => {
+                if let Ok(mut manager) = lock_update_manager() {
+                    manager.finish_terminal(UpdateStatus::Error, Some(payload), Some(err));
+                }
+            }
+        }
+        let _ = app_handle.emit("aigate-update-state-changed", ());
+    });
+
+    Ok(current_update_snapshot(&current_version))
+}
+
+#[tauri::command]
+fn cancel_update_download<R: Runtime>(app: AppHandle<R>) -> Result<UpdateStatePayload, String> {
+    let _ = app;
+    let mut manager = lock_update_manager()?;
+    manager.request_cancel();
+    Ok(manager.snapshot())
+}
+
+fn lock_update_manager() -> Result<std::sync::MutexGuard<'static, UpdateManagerState>, String> {
+    UPDATE_MANAGER
+        .lock()
+        .map_err(|_| "update manager lock poisoned".to_string())
+}
+
+fn current_update_snapshot(current_version: &str) -> UpdateStatePayload {
+    let snapshot = lock_update_manager()
+        .map(|manager| manager.snapshot())
+        .unwrap_or_default();
+    normalize_update_snapshot(snapshot, current_version)
+}
+
+fn normalize_update_snapshot(
+    mut snapshot: UpdateStatePayload,
+    current_version: &str,
+) -> UpdateStatePayload {
+    if let Some(update) = snapshot.update.as_mut() {
+        if update.current_version.is_empty() {
+            update.current_version = current_version.to_string();
+        }
+    }
+    snapshot
+}
+
+async fn fetch_update<R: Runtime>(app: &AppHandle<R>) -> Result<Option<Update>, String> {
+    app.updater()
+        .map_err(|err| format!("build updater failed: {err}"))?
+        .check()
+        .await
+        .map_err(|err| format!("check update failed: {err}"))
+}
+
+fn to_update_info_payload(current_version: &str, update: &Update) -> Result<UpdateInfoPayload, String> {
+    Ok(UpdateInfoPayload {
+        body: update.body.clone(),
+        current_version: current_version.to_string(),
+        date: update.date.map(|value| value.to_string()),
+        version: update.version.clone(),
+    })
+}
+
+async fn download_and_install_update(
+    update: Update,
+    cancel_flag: Arc<AtomicBool>,
+) -> Result<(), String> {
+    let bytes = download_update_bytes(&update, cancel_flag.clone()).await?;
+    if cancel_flag.load(Ordering::SeqCst) {
+        return Err("download canceled".to_string());
+    }
+    update
+        .install(bytes)
+        .map_err(|err| format!("install update failed: {err}"))
+}
+
+async fn download_update_bytes(
+    update: &Update,
+    cancel_flag: Arc<AtomicBool>,
+) -> Result<Vec<u8>, String> {
+    let mut headers = update.headers.clone();
+    if !headers.contains_key(ACCEPT) {
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/octet-stream"),
+        );
+    }
+
+    let mut request = reqwest::ClientBuilder::new().user_agent("aigate-desktop-updater");
+    if let Some(timeout) = update.timeout {
+        request = request.timeout(timeout);
+    }
+    if update.no_proxy {
+        request = request.no_proxy();
+    } else if let Some(ref proxy) = update.proxy {
+        let parsed = reqwest::Proxy::all(proxy.as_str())
+            .map_err(|err| format!("configure updater proxy failed: {err}"))?;
+        request = request.proxy(parsed);
+    }
+
+    let response = request
+        .build()
+        .map_err(|err| format!("build updater client failed: {err}"))?
+        .get(update.download_url.clone())
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|err| format!("download update failed: {err}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "download request failed with status: {}",
+            response.status()
+        ));
+    }
+
+    let total = response.content_length().unwrap_or(0);
+    let mut transferred = 0_u64;
+    let mut buffer = Vec::with_capacity(total.min(UPDATE_POLL_CHUNK_SIZE as u64) as usize);
+    let mut stream = response.bytes_stream();
+
+    while let Some(next) = stream.next().await {
+        if cancel_flag.load(Ordering::SeqCst) {
+            return Err("download canceled".to_string());
+        }
+        let chunk = next.map_err(|err| format!("read update chunk failed: {err}"))?;
+        transferred += chunk.len() as u64;
+        buffer.extend_from_slice(&chunk);
+        update_download_progress(
+            transferred,
+            total,
+            Some(UpdateInfoPayload {
+                body: update.body.clone(),
+                current_version: update.current_version.clone(),
+                date: update.date.map(|value| value.to_string()),
+                version: update.version.clone(),
+            }),
+        )?;
+    }
+
+    verify_update_signature(&buffer, &update.signature)?;
+    Ok(buffer)
+}
+
+fn update_download_progress(
+    transferred: u64,
+    total: u64,
+    update: Option<UpdateInfoPayload>,
+) -> Result<(), String> {
+    let percent = if total > 0 {
+        ((transferred as f64 / total as f64) * 100.0).clamp(0.0, 100.0)
+    } else {
+        0.0
+    };
+    let mut manager = lock_update_manager()?;
+    let existing_update = manager.snapshot.update.clone();
+    manager.set_snapshot(UpdateStatePayload {
+        status: UpdateStatus::Downloading,
+        update: update.or(existing_update),
+        progress: Some(UpdateProgressPayload {
+            percent,
+            total,
+            transferred,
+        }),
+        error: None,
+    });
+    Ok(())
+}
+
+fn verify_update_signature(data: &[u8], release_signature: &str) -> Result<(), String> {
+    let pub_key = decode_base64_to_string(UPDATER_PUBKEY_BASE64)?;
+    let public_key = PublicKey::decode(&pub_key)
+        .map_err(|err| format!("decode updater public key failed: {err}"))?;
+    let signature_text = decode_base64_to_string(release_signature)?;
+    let signature = Signature::decode(&signature_text)
+        .map_err(|err| format!("decode update signature failed: {err}"))?;
+    public_key
+        .verify(data, &signature, true)
+        .map_err(|err| format!("verify update signature failed: {err}"))?;
+    Ok(())
+}
+
+fn decode_base64_to_string(value: &str) -> Result<String, String> {
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .map_err(|err| format!("decode base64 failed: {err}"))?;
+    std::str::from_utf8(&decoded)
+        .map_err(|_| "decode utf-8 failed".to_string())
+        .map(|text| text.to_string())
 }
 
 fn initialize_runtime(app: &tauri::AppHandle) -> Result<DesktopSettingsCache, String> {
@@ -1346,13 +1743,17 @@ mod tests {
         should_retry_sidecar_request, should_trigger_resume_recovery, sidecar_candidate_paths,
         sidecar_creation_flags, sidecar_request_with_recovery, sidecar_request_with_recovery_hooks,
         sidecar_resource_name, tray_icon_bytes_for_platform, tray_icon_is_template_for_platform,
-        wait_for_backend_ready_with_probe, window_close_action, AppSettingsPayload,
-        DesktopLogEntry, DesktopSettingsCache, HttpResponse, WindowCloseAction, SIDECAR_MACOS_NAME,
-        SIDECAR_WINDOWS_NAME, TRAY_ICON_COLOR_BYTES, TRAY_ICON_TEMPLATE_BYTES,
+        update_download_progress, wait_for_backend_ready_with_probe, window_close_action,
+        AppSettingsPayload, DesktopLogEntry, DesktopSettingsCache, HttpResponse,
+        UpdateInfoPayload, UpdateManagerState, UpdateProgressPayload, UpdateStatePayload,
+        UpdateStatus, WindowCloseAction, SIDECAR_MACOS_NAME, SIDECAR_WINDOWS_NAME,
+        TRAY_ICON_COLOR_BYTES, TRAY_ICON_TEMPLATE_BYTES, UPDATE_MANAGER,
     };
     use std::cell::RefCell;
     use std::collections::VecDeque;
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     #[test]
@@ -1827,5 +2228,93 @@ mod tests {
         let raw = "1d\r\n[{\"id\":1,\"account_name\":\"a\"}]\r\n0\r\n\r\n";
         let decoded = decode_chunked_body(raw).expect("decode chunked body");
         assert_eq!(decoded, "[{\"id\":1,\"account_name\":\"a\"}]");
+    }
+
+    #[test]
+    fn update_manager_initial_state_is_idle() {
+        let manager = UpdateManagerState::default();
+        assert_eq!(manager.snapshot.status, UpdateStatus::Idle);
+        assert!(manager.snapshot.update.is_none());
+        assert!(manager.snapshot.progress.is_none());
+        assert!(manager.active_version.is_none());
+    }
+
+    #[test]
+    fn update_manager_progress_uses_expected_percentages() {
+        UPDATE_MANAGER.lock().expect("update manager").set_snapshot(UpdateStatePayload {
+            status: UpdateStatus::Downloading,
+            update: Some(UpdateInfoPayload {
+                body: None,
+                current_version: "1.1.7".to_string(),
+                date: None,
+                version: "1.1.9".to_string(),
+            }),
+            progress: Some(UpdateProgressPayload::default()),
+            error: None,
+        });
+
+        update_download_progress(25, 100, None).expect("progress update");
+        let snapshot = UPDATE_MANAGER.lock().expect("update manager").snapshot();
+        let progress = snapshot.progress.expect("progress payload");
+        assert_eq!(snapshot.status, UpdateStatus::Downloading);
+        assert_eq!(progress.transferred, 25);
+        assert_eq!(progress.total, 100);
+        assert_eq!(progress.percent, 25.0);
+    }
+
+    #[test]
+    fn update_manager_reuses_existing_task_for_same_version() {
+        let mut manager = UpdateManagerState::default();
+        let first_flag = manager
+            .begin_download(UpdateInfoPayload {
+                body: None,
+                current_version: "1.1.7".to_string(),
+                date: None,
+                version: "1.1.9".to_string(),
+            })
+            .expect("first download");
+
+        let second_flag = manager
+            .begin_download(UpdateInfoPayload {
+                body: None,
+                current_version: "1.1.7".to_string(),
+                date: None,
+                version: "1.1.9".to_string(),
+            })
+            .expect("reuse same version");
+
+        assert!(Arc::ptr_eq(&first_flag, &second_flag));
+        assert_eq!(manager.snapshot.status, UpdateStatus::Downloading);
+    }
+
+    #[test]
+    fn update_manager_cancellation_marks_flag_and_finishes_cancelled() {
+        let mut manager = UpdateManagerState::default();
+        let cancel_flag = manager
+            .begin_download(UpdateInfoPayload {
+                body: None,
+                current_version: "1.1.7".to_string(),
+                date: None,
+                version: "1.1.9".to_string(),
+            })
+            .expect("begin download");
+
+        manager.request_cancel();
+        assert!(cancel_flag.load(Ordering::SeqCst));
+
+        manager.finish_terminal(
+            UpdateStatus::Cancelled,
+            Some(UpdateInfoPayload {
+                body: None,
+                current_version: "1.1.7".to_string(),
+                date: None,
+                version: "1.1.9".to_string(),
+            }),
+            None,
+        );
+
+        assert_eq!(manager.snapshot.status, UpdateStatus::Cancelled);
+        assert!(manager.cancel_flag.is_none());
+        assert!(manager.active_version.is_none());
     }
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -12,8 +12,8 @@ use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -28,6 +28,9 @@ use std::os::windows::process::CommandExt;
 
 static SIDECAR_CHILD: Lazy<Mutex<Option<Child>>> = Lazy::new(|| Mutex::new(None));
 static SIDECAR_HEARTBEAT: Lazy<Mutex<Option<JoinHandle<()>>>> = Lazy::new(|| Mutex::new(None));
+static SIDECAR_EXIT_WATCHER: Lazy<Mutex<Option<JoinHandle<()>>>> = Lazy::new(|| Mutex::new(None));
+static SIDECAR_EXIT_REASON: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
+static SIDECAR_EXIT_WATCHER_STOP: AtomicBool = AtomicBool::new(false);
 static RESUME_RECOVERY_WATCHER: Lazy<Mutex<Option<JoinHandle<()>>>> =
     Lazy::new(|| Mutex::new(None));
 static RESUME_RECOVERY_WATCHER_STOP: AtomicBool = AtomicBool::new(false);
@@ -260,10 +263,7 @@ impl UpdateManagerState {
         self.snapshot = snapshot;
     }
 
-    fn begin_download(
-        &mut self,
-        update: UpdateInfoPayload,
-    ) -> Result<Arc<AtomicBool>, String> {
+    fn begin_download(&mut self, update: UpdateInfoPayload) -> Result<Arc<AtomicBool>, String> {
         if self.snapshot.status == UpdateStatus::Downloading {
             if self.active_version.as_deref() == Some(update.version.as_str()) {
                 if let Some(flag) = &self.cancel_flag {
@@ -290,7 +290,12 @@ impl UpdateManagerState {
         }
     }
 
-    fn finish_terminal(&mut self, status: UpdateStatus, update: Option<UpdateInfoPayload>, error: Option<String>) {
+    fn finish_terminal(
+        &mut self,
+        status: UpdateStatus,
+        update: Option<UpdateInfoPayload>,
+        error: Option<String>,
+    ) {
         self.active_version = None;
         self.cancel_flag = None;
         self.snapshot = UpdateStatePayload {
@@ -342,6 +347,7 @@ fn main() {
                 &cache.backend_addr(),
                 Duration::from_millis(SIDECAR_READY_WAIT_TIMEOUT_MS),
             )?;
+            start_sidecar_exit_watcher()?;
             start_resume_recovery_watcher(app.handle().clone())?;
             setup_tray(app.handle())?;
             if cache.silent_start {
@@ -366,6 +372,7 @@ fn main() {
                             }
                             WindowCloseAction::ExitApp => {
                                 api.prevent_close();
+                                stop_sidecar_exit_watcher();
                                 stop_resume_recovery_watcher();
                                 shutdown_sidecar();
                                 app_handle.exit(0);
@@ -380,6 +387,7 @@ fn main() {
                 show_main_window(app_handle);
             }
             tauri::RunEvent::Exit => {
+                stop_sidecar_exit_watcher();
                 stop_resume_recovery_watcher();
                 shutdown_sidecar();
             }
@@ -397,6 +405,7 @@ fn window_close_action(close_to_tray: bool) -> WindowCloseAction {
 
 #[tauri::command]
 fn force_exit_app<R: Runtime>(app: AppHandle<R>) {
+    stop_sidecar_exit_watcher();
     stop_resume_recovery_watcher();
     shutdown_sidecar();
     app.exit(0);
@@ -591,7 +600,10 @@ async fn fetch_update<R: Runtime>(app: &AppHandle<R>) -> Result<Option<Update>, 
         .map_err(|err| format!("check update failed: {err}"))
 }
 
-fn to_update_info_payload(current_version: &str, update: &Update) -> Result<UpdateInfoPayload, String> {
+fn to_update_info_payload(
+    current_version: &str,
+    update: &Update,
+) -> Result<UpdateInfoPayload, String> {
     Ok(UpdateInfoPayload {
         body: update.body.clone(),
         current_version: current_version.to_string(),
@@ -619,10 +631,7 @@ async fn download_update_bytes(
 ) -> Result<Vec<u8>, String> {
     let mut headers = update.headers.clone();
     if !headers.contains_key(ACCEPT) {
-        headers.insert(
-            ACCEPT,
-            HeaderValue::from_static("application/octet-stream"),
-        );
+        headers.insert(ACCEPT, HeaderValue::from_static("application/octet-stream"));
     }
 
     let mut request = reqwest::ClientBuilder::new().user_agent("aigate-desktop-updater");
@@ -851,6 +860,14 @@ fn configure_sidecar_command(command: &mut Command) {
 fn configure_sidecar_command(_command: &mut Command) {}
 
 fn spawn_sidecar() -> Result<(), String> {
+    {
+        let guard = SIDECAR_CHILD
+            .lock()
+            .map_err(|_| "sidecar child lock poisoned".to_string())?;
+        if guard.is_some() {
+            return Err("sidecar already running".to_string());
+        }
+    }
     let runtime = DESKTOP_RUNTIME
         .lock()
         .map_err(|_| "desktop runtime lock poisoned".to_string())?
@@ -902,6 +919,7 @@ fn spawn_sidecar() -> Result<(), String> {
         .lock()
         .map_err(|_| "sidecar child lock poisoned".to_string())?;
     *guard = Some(child);
+    set_sidecar_exit_reason(None);
     log_desktop_event("info", "sidecar", "spawn success");
     Ok(())
 }
@@ -1298,6 +1316,16 @@ fn should_retry_sidecar_request(restart_worthy: bool, attempted_recovery: bool) 
     restart_worthy && !attempted_recovery
 }
 
+fn should_restart_sidecar_after_exit(reason: Option<&str>, exited: bool) -> bool {
+    if !exited {
+        return false;
+    }
+    !matches!(
+        reason.map(str::trim).filter(|value| !value.is_empty()),
+        Some("shutdown" | "restart" | "quit")
+    )
+}
+
 fn sidecar_request_with_recovery<FRequest, FRestart>(
     mut request: FRequest,
     mut restart: FRestart,
@@ -1636,6 +1664,7 @@ fn shutdown_sidecar() {
 }
 
 fn shutdown_sidecar_with_reason(reason: &str) {
+    set_sidecar_exit_reason(Some(reason));
     let mut guard = match SIDECAR_CHILD.lock() {
         Ok(guard) => guard,
         Err(_) => return,
@@ -1662,11 +1691,7 @@ fn shutdown_sidecar_with_reason(reason: &str) {
     }
     *guard = None;
 
-    if let Ok(mut heartbeat_guard) = SIDECAR_HEARTBEAT.lock() {
-        if let Some(handle) = heartbeat_guard.take() {
-            let _ = handle.join();
-        }
-    }
+    stop_sidecar_heartbeat();
 }
 
 fn should_trigger_resume_recovery(elapsed: Duration, threshold: Duration) -> bool {
@@ -1732,28 +1757,135 @@ fn start_sidecar_heartbeat(mut stdin: ChildStdin) -> Result<(), String> {
     Ok(())
 }
 
+fn stop_sidecar_heartbeat() {
+    if let Ok(mut heartbeat_guard) = SIDECAR_HEARTBEAT.lock() {
+        if let Some(handle) = heartbeat_guard.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn set_sidecar_exit_reason(reason: Option<&str>) {
+    if let Ok(mut guard) = SIDECAR_EXIT_REASON.lock() {
+        *guard = reason.map(str::to_string);
+    }
+}
+
+fn take_sidecar_exit_reason() -> Option<String> {
+    SIDECAR_EXIT_REASON
+        .lock()
+        .ok()
+        .and_then(|mut guard| guard.take())
+}
+
+fn start_sidecar_exit_watcher() -> Result<(), String> {
+    SIDECAR_EXIT_WATCHER_STOP.store(false, Ordering::SeqCst);
+    let handle = std::thread::Builder::new()
+        .name("sidecar-exit-watcher".to_string())
+        .spawn(move || {
+            while !SIDECAR_EXIT_WATCHER_STOP.load(Ordering::SeqCst) {
+                let mut exited = false;
+                let mut status_text = String::new();
+                if let Ok(mut guard) = SIDECAR_CHILD.lock() {
+                    if let Some(child) = guard.as_mut() {
+                        match child.try_wait() {
+                            Ok(Some(status)) => {
+                                exited = true;
+                                status_text = status.to_string();
+                                *guard = None;
+                            }
+                            Ok(None) => {}
+                            Err(err) => {
+                                log_desktop_event(
+                                    "warn",
+                                    "sidecar",
+                                    format!("try_wait failed: {err}"),
+                                );
+                            }
+                        }
+                    }
+                }
+
+                if exited {
+                    stop_sidecar_heartbeat();
+                    let reason = take_sidecar_exit_reason();
+                    log_desktop_event(
+                        "warn",
+                        "sidecar",
+                        format!(
+                            "sidecar exited unexpectedly status={} reason={}",
+                            status_text,
+                            reason.as_deref().unwrap_or("unexpected")
+                        ),
+                    );
+                    if should_restart_sidecar_after_exit(reason.as_deref(), true) {
+                        log_desktop_event("warn", "recovery", "auto restarting sidecar after exit");
+                        match spawn_sidecar() {
+                            Ok(()) => {
+                                if let Err(err) = wait_for_backend_ready(
+                                    &current_backend_addr(),
+                                    Duration::from_millis(SIDECAR_READY_WAIT_TIMEOUT_MS),
+                                ) {
+                                    log_desktop_event(
+                                        "error",
+                                        "recovery",
+                                        format!("sidecar auto restart readiness failed: {err}"),
+                                    );
+                                }
+                            }
+                            Err(err) => log_desktop_event(
+                                "error",
+                                "recovery",
+                                format!("sidecar auto restart failed: {err}"),
+                            ),
+                        }
+                    }
+                }
+
+                std::thread::sleep(Duration::from_millis(500));
+            }
+        })
+        .map_err(|e| format!("start sidecar exit watcher failed: {e}"))?;
+    let mut guard = SIDECAR_EXIT_WATCHER
+        .lock()
+        .map_err(|_| "sidecar exit watcher lock poisoned".to_string())?;
+    if let Some(previous) = guard.replace(handle) {
+        let _ = previous.join();
+    }
+    Ok(())
+}
+
+fn stop_sidecar_exit_watcher() {
+    SIDECAR_EXIT_WATCHER_STOP.store(true, Ordering::SeqCst);
+    if let Ok(mut guard) = SIDECAR_EXIT_WATCHER.lock() {
+        if let Some(handle) = guard.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         append_recent_desktop_log, build_launch_agent_plist, clamp_recent_log_limit,
         decode_chunked_body, format_timeout_error, format_tray_title, map_backend_io_error,
         parse_account_menu_id, parse_accounts_response, parse_proxy_status_response,
-        proxy_menu_enabled_states,
-        should_attempt_sidecar_recovery, should_refresh_tray_after_action,
+        proxy_menu_enabled_states, should_attempt_sidecar_recovery,
+        should_refresh_tray_after_action, should_restart_sidecar_after_exit,
         should_retry_sidecar_request, should_trigger_resume_recovery, sidecar_candidate_paths,
         sidecar_creation_flags, sidecar_request_with_recovery, sidecar_request_with_recovery_hooks,
         sidecar_resource_name, tray_icon_bytes_for_platform, tray_icon_is_template_for_platform,
         update_download_progress, wait_for_backend_ready_with_probe, window_close_action,
-        AppSettingsPayload, DesktopLogEntry, DesktopSettingsCache, HttpResponse,
-        UpdateInfoPayload, UpdateManagerState, UpdateProgressPayload, UpdateStatePayload,
-        UpdateStatus, WindowCloseAction, SIDECAR_MACOS_NAME, SIDECAR_WINDOWS_NAME,
-        TRAY_ICON_COLOR_BYTES, TRAY_ICON_TEMPLATE_BYTES, UPDATE_MANAGER,
+        AppSettingsPayload, DesktopLogEntry, DesktopSettingsCache, HttpResponse, UpdateInfoPayload,
+        UpdateManagerState, UpdateProgressPayload, UpdateStatePayload, UpdateStatus,
+        WindowCloseAction, SIDECAR_MACOS_NAME, SIDECAR_WINDOWS_NAME, TRAY_ICON_COLOR_BYTES,
+        TRAY_ICON_TEMPLATE_BYTES, UPDATE_MANAGER,
     };
     use std::cell::RefCell;
     use std::collections::VecDeque;
     use std::path::{Path, PathBuf};
-    use std::sync::Arc;
     use std::sync::atomic::Ordering;
+    use std::sync::Arc;
     use std::time::Duration;
 
     #[test]
@@ -2020,6 +2152,20 @@ mod tests {
     }
 
     #[test]
+    fn sidecar_exit_restart_policy_skips_intentional_shutdowns() {
+        assert!(!should_restart_sidecar_after_exit(Some("shutdown"), true));
+        assert!(!should_restart_sidecar_after_exit(Some("restart"), true));
+        assert!(!should_restart_sidecar_after_exit(Some("quit"), true));
+    }
+
+    #[test]
+    fn sidecar_exit_restart_policy_recovers_unexpected_exit() {
+        assert!(should_restart_sidecar_after_exit(None, true));
+        assert!(should_restart_sidecar_after_exit(Some(""), true));
+        assert!(!should_restart_sidecar_after_exit(None, false));
+    }
+
+    #[test]
     fn sidecar_request_restarts_then_retries_once() {
         let mut request_calls = 0;
         let mut restart_calls = 0;
@@ -2241,17 +2387,20 @@ mod tests {
 
     #[test]
     fn update_manager_progress_uses_expected_percentages() {
-        UPDATE_MANAGER.lock().expect("update manager").set_snapshot(UpdateStatePayload {
-            status: UpdateStatus::Downloading,
-            update: Some(UpdateInfoPayload {
-                body: None,
-                current_version: "1.1.7".to_string(),
-                date: None,
-                version: "1.1.9".to_string(),
-            }),
-            progress: Some(UpdateProgressPayload::default()),
-            error: None,
-        });
+        UPDATE_MANAGER
+            .lock()
+            .expect("update manager")
+            .set_snapshot(UpdateStatePayload {
+                status: UpdateStatus::Downloading,
+                update: Some(UpdateInfoPayload {
+                    body: None,
+                    current_version: "1.1.7".to_string(),
+                    date: None,
+                    version: "1.1.9".to_string(),
+                }),
+                progress: Some(UpdateProgressPayload::default()),
+                error: None,
+            });
 
         update_download_progress(25, 100, None).expect("progress update");
         let snapshot = UPDATE_MANAGER.lock().expect("update manager").snapshot();

--- a/docs/plans/2026-03-18-account-share-import-design.md
+++ b/docs/plans/2026-03-18-account-share-import-design.md
@@ -1,0 +1,203 @@
+# Account Share Import Design
+
+**Goal:** Add a safe account share and import flow that lets users export a full, re-importable account credential package only after explicit confirmation, and lets users paste that package back into the app with strict validation, without changing routing priority or exposing secrets in the UI.
+
+## Context
+
+The accounts dashboard already supports create, edit, duplicate, delete, official import, and local import. What it does not support is transferring an existing account between devices or teammates without manually re-entering every field.
+
+This feature must satisfy four constraints:
+
+- The copied payload must contain the full credential and enough metadata to recreate the account.
+- Sensitive content must never be rendered in plaintext in the UI.
+- User-controlled sort order must remain untouched. Import creates a new account record, but sharing must not mutate the source account.
+- Validation must be strict so malformed or partial payloads fail early before any account is created.
+
+## Approaches
+
+### Option A: Backend-issued JSON share package with frontend confirmation
+
+Add a backend endpoint that loads the account, normalizes its portable fields, and returns a JSON payload string. The frontend shows a minimal confirmation modal and only writes the payload to the clipboard after the user confirms. Import pastes the payload into a modal, sends it to a backend validator/import endpoint, and then refreshes the account list.
+
+**Pros**
+
+- Keeps the canonical export schema in one place.
+- Prevents the frontend from constructing or guessing sensitive payload structure.
+- Makes import validation identical for all clients.
+- Keeps future schema upgrades manageable with explicit `schema_version`.
+
+**Cons**
+
+- Requires two new backend endpoints.
+
+### Option B: Frontend builds and validates the share package from list data
+
+Use the existing account list payload to assemble the exported package in the browser and parse it locally on import.
+
+**Pros**
+
+- Smaller backend change set.
+
+**Cons**
+
+- The account list intentionally omits credential material, so this cannot produce a full importable package.
+- Frontend validation would drift from backend account rules.
+- Would encourage exposing more sensitive fields to normal list responses.
+
+## Decision
+
+Use **Option A**.
+
+The backend will own the share-package schema, the export serialization, and the import validation. The frontend will only orchestrate confirmation, clipboard copy, paste, and success/error feedback.
+
+## Share Package
+
+Export a JSON string in this shape:
+
+```json
+{
+  "kind": "aigate-account-share",
+  "schema_version": 1,
+  "exported_at": "2026-03-18T15:20:00Z",
+  "account": {
+    "provider_type": "openai-compatible",
+    "account_name": "mirror-east",
+    "source_icon": "ppchat",
+    "auth_mode": "api_key",
+    "base_url": "https://code.ppchat.vip/v1",
+    "credential_ref": "sk-...",
+    "account_driver": "builtin_openai_compatible",
+    "usage_driver": "lua",
+    "usage_config_json": "{\"script\":\"adapters/vendor.lua\"}",
+    "supports_responses": true
+  }
+}
+```
+
+The package intentionally excludes runtime and local-state fields:
+
+- `id`
+- `status`
+- `priority`
+- `is_active`
+- usage snapshots or health metrics
+
+That keeps export portable and prevents importing stale operational state.
+
+## Backend Design
+
+### Export endpoint
+
+Add `POST /accounts/{id}/share`.
+
+Behavior:
+
+- Load the account by id using the repository so `credential_ref` is already decrypted.
+- Apply built-in driver defaults before export so the payload stays self-contained.
+- Build the share package with current UTC `exported_at`.
+- Return JSON:
+
+```json
+{ "payload": "<json-string>" }
+```
+
+### Import endpoint
+
+Add `POST /accounts/import-shared`.
+
+Request:
+
+```json
+{ "payload": "<json-string>" }
+```
+
+Behavior:
+
+- Decode the outer request.
+- Parse the payload string as JSON.
+- Validate:
+  - `kind == "aigate-account-share"`
+  - `schema_version == 1`
+  - `account` object present
+  - required account fields present and non-empty where applicable
+  - `provider_type` is supported
+  - `auth_mode` is supported
+  - `base_url` is a valid absolute HTTP or HTTPS URL
+  - `usage_config_json` is either empty or valid JSON text
+- Normalize `source_icon` and apply built-in driver defaults.
+- Create a fresh account with:
+  - `status = active`
+  - `priority = 0`
+  - `is_active = false`
+- Return `201 Created`.
+
+Import will not mutate any existing account. If the imported name already exists, creation is still allowed because the current schema does not enforce unique `account_name`.
+
+## Frontend Design
+
+### Share flow
+
+In the account action area, add a share icon button.
+
+Flow:
+
+1. User clicks share.
+2. Show a minimal confirmation modal stating that importable account data is about to be copied and must not be leaked.
+3. On confirm, call the backend share endpoint.
+4. Copy the returned payload string to the clipboard.
+5. Show success or failure toast.
+
+The modal must not render the payload itself, any credential preview, or derived secret fragments.
+
+### Import flow
+
+In the add-account area, add an import entry alongside the existing add-account options.
+
+Flow:
+
+1. User opens the import modal.
+2. Paste the share payload into a multiline input.
+3. Submit to backend import endpoint.
+4. On success, close modal, refresh the account list, and refresh tray state.
+5. On failure, keep the modal open and show the validation error.
+
+The frontend may do lightweight empty-state validation, but the backend remains the source of truth.
+
+## Error Handling
+
+- Invalid payload format returns `400 Bad Request`.
+- Unknown schema version returns `400 Bad Request`.
+- Unsupported provider or auth mode returns `400 Bad Request`.
+- Invalid `base_url` or malformed `usage_config_json` returns `400 Bad Request`.
+- Clipboard failure returns a user-facing error and must not silently claim success.
+- Canceling the share modal performs no backend call and no clipboard write.
+
+## Testing
+
+### Backend
+
+Add handler tests for:
+
+- exporting a valid share payload with credential included
+- importing a valid payload creates a new account with reset runtime fields
+- invalid `kind` is rejected
+- invalid `schema_version` is rejected
+- invalid `base_url` is rejected
+- invalid `usage_config_json` is rejected
+
+### Frontend
+
+Add page tests for:
+
+- share cancel does not call clipboard or backend
+- share confirm calls backend and copies payload
+- import modal submits pasted payload
+- import failure keeps modal open and surfaces the backend error
+
+## Success Criteria
+
+- Users can share an account without seeing secret material in the UI.
+- The copied content is sufficient to import the same account elsewhere.
+- Import rejects malformed payloads before creating records.
+- Existing manual sort order is not rewritten by the share flow.
+- The interaction stays visually minimal and consistent with the current account page.

--- a/docs/plans/2026-03-18-account-share-import.md
+++ b/docs/plans/2026-03-18-account-share-import.md
@@ -1,0 +1,174 @@
+# Account Share Import Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a backend-owned account share/export endpoint and a strict import endpoint, then wire minimal frontend share and import flows that never expose credentials in the UI.
+
+**Architecture:** The backend defines a versioned portable share-package schema, exports it from an existing account record, and validates it on import before creating a fresh account. The frontend only confirms share intent, copies the backend-issued payload to the clipboard, and lets users paste that payload into an import modal.
+
+**Tech Stack:** Go, net/http, React, TypeScript, Ant Design, Vitest
+
+---
+
+### Task 1: Define and test the backend share package contract
+
+**Files:**
+- Modify: `backend/internal/api/accounts_handler_test.go`
+- Modify: `backend/internal/api/accounts_handler.go`
+
+**Step 1: Write the failing backend tests**
+
+Add tests that prove:
+
+- `POST /accounts/{id}/share` returns a JSON payload string
+- the payload has `kind = "aigate-account-share"` and `schema_version = 1`
+- the exported account contains the credential and portable fields, but not runtime-only fields
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/api -run TestAccountsHandlerShare -count=1`
+Expected: FAIL because the endpoint and share schema do not exist.
+
+**Step 3: Implement the minimal backend export logic**
+
+Add share-package structs and a `shareAccount` handler that:
+
+- parses the account id from the route
+- loads the account from the repository
+- applies built-in defaults
+- serializes the standardized payload string
+- returns `200 OK` with `{"payload":"..."}` 
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/api -run TestAccountsHandlerShare -count=1`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add backend/internal/api/accounts_handler.go backend/internal/api/accounts_handler_test.go
+git commit -m "feat(accounts): add share payload export"
+```
+
+### Task 2: Add strict shared-import validation and creation
+
+**Files:**
+- Modify: `backend/internal/api/accounts_handler_test.go`
+- Modify: `backend/internal/api/accounts_handler.go`
+
+**Step 1: Write the failing backend import tests**
+
+Add tests that prove:
+
+- `POST /accounts/import-shared` accepts a valid payload and creates a new account
+- imported accounts reset `status`, `priority`, and `is_active`
+- invalid `kind`, invalid `schema_version`, invalid `base_url`, and malformed `usage_config_json` return `400`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/api -run 'TestAccountsHandler(ImportShared|Share)' -count=1`
+Expected: FAIL because the import endpoint and validation do not exist.
+
+**Step 3: Implement the minimal backend import path**
+
+Add:
+
+- request structs for `payload`
+- validation helpers for provider, auth mode, base URL, and `usage_config_json`
+- import handler that creates a fresh active account without mutating existing records
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/api -run 'TestAccountsHandler(ImportShared|Share)' -count=1`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add backend/internal/api/accounts_handler.go backend/internal/api/accounts_handler_test.go
+git commit -m "feat(accounts): add shared account import"
+```
+
+### Task 3: Add frontend API client helpers and page tests for share/import
+
+**Files:**
+- Modify: `frontend/src/lib/api.ts`
+- Modify: `frontend/src/features/accounts/AccountsPage.test.tsx`
+- Modify: `frontend/src/features/accounts/AccountsPage.tsx`
+
+**Step 1: Write the failing frontend tests**
+
+Add tests that prove:
+
+- canceling the share modal does not call the backend or clipboard
+- confirming share calls the backend share endpoint and copies the returned payload
+- importing a pasted payload calls the import endpoint
+- failed import surfaces the backend error without closing the modal
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npm test -- --run src/features/accounts/AccountsPage.test.tsx`
+Expected: FAIL because the page does not yet expose share/import flows.
+
+**Step 3: Implement the minimal frontend flow**
+
+Add API helpers:
+
+- `shareAccount(id)`
+- `importSharedAccount(payload)`
+
+Update the accounts page to:
+
+- render a share action button
+- show a minimal confirmation modal
+- call `navigator.clipboard.writeText` only after confirm
+- add an import entry in the add-account menu
+- show a paste modal and submit its payload to the backend
+
+Keep the UI free of secret previews.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npm test -- --run src/features/accounts/AccountsPage.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add frontend/src/lib/api.ts frontend/src/features/accounts/AccountsPage.tsx frontend/src/features/accounts/AccountsPage.test.tsx
+git commit -m "feat(accounts): add share and import flow"
+```
+
+### Task 4: Verify the touched scope
+
+**Files:**
+- Modify: `backend/internal/api/accounts_handler.go`
+- Modify: `backend/internal/api/accounts_handler_test.go`
+- Modify: `frontend/src/lib/api.ts`
+- Modify: `frontend/src/features/accounts/AccountsPage.tsx`
+- Modify: `frontend/src/features/accounts/AccountsPage.test.tsx`
+- Create: `docs/plans/2026-03-18-account-share-import-design.md`
+- Create: `docs/plans/2026-03-18-account-share-import.md`
+
+**Step 1: Run backend verification**
+
+Run: `cd backend && go test ./internal/api -count=1`
+Expected: PASS.
+
+**Step 2: Run frontend verification**
+
+Run: `cd frontend && npm test -- --run src/features/accounts/AccountsPage.test.tsx`
+Expected: PASS.
+
+**Step 3: Run diff hygiene**
+
+Run: `git diff --check`
+Expected: no output.
+
+**Step 4: Commit docs if still unstaged**
+
+```bash
+git add docs/plans/2026-03-18-account-share-import-design.md docs/plans/2026-03-18-account-share-import.md
+git commit -m "docs: add account share and import plan"
+```

--- a/docs/plans/2026-03-18-update-download-backend-design.md
+++ b/docs/plans/2026-03-18-update-download-backend-design.md
@@ -1,0 +1,176 @@
+# Update Download Backend Design
+
+**Goal:** Move desktop update download task ownership out of the frontend component lifecycle and into the Tauri host so page refreshes do not lose the active download, progress stays queryable, duplicate downloads are prevented, and the user can cancel an in-flight download.
+
+## Context
+
+The current update flow is split across `frontend/src/features/updates/updateService.ts`, `UpdateCard.tsx`, and `HomeUpdatePanel.tsx`. The frontend calls `@tauri-apps/plugin-updater` directly, keeps the active `downloadAndInstall` closure in JS memory, and updates progress with local React state. That creates three problems:
+
+- Refreshing the page destroys the in-memory download task and its progress state.
+- Multiple views can attempt to start the same update independently.
+- There is no authoritative owner for cancellation or task deduplication.
+
+The actual download/install capability already lives in the desktop shell via Tauri. The correct place to centralize task ownership is therefore the Rust host layer, not the Go router backend.
+
+## Approaches
+
+### Option A: Tauri host manages download state and lifecycle
+
+Add a small update task manager in `desktop/src-tauri/src/main.rs` backed by global process memory. Expose Tauri commands for:
+
+- fetching the current update task snapshot
+- checking for the latest update
+- starting or resuming a download/install task
+- cancelling the active task
+- relaunching after install
+
+The frontend becomes a thin client that polls the authoritative task snapshot and renders it in both update surfaces.
+
+**Pros**
+
+- Matches where the updater capability already exists.
+- Survives frontend refresh without pretending to support cross-process recovery.
+- Prevents duplicate downloads with one in-memory task owner.
+- Keeps cancellation local to the component that actually owns the task.
+
+**Cons**
+
+- Requires a Rust-side state machine and background worker wiring.
+
+### Option B: Go backend stores update progress, frontend still triggers Tauri updater
+
+Persist progress into the Go backend and let the frontend restore UI state after refresh.
+
+**Pros**
+
+- Reuses existing HTTP API patterns.
+
+**Cons**
+
+- Does not solve the real problem because the actual updater task still dies with the frontend runtime.
+- Adds an unnecessary bridge between Go and Tauri.
+- Makes cancellation and deduplication harder.
+
+## Decision
+
+Use **Option A**.
+
+The Tauri host will be the single authority for update task state during the desktop process lifetime. The frontend will query and render that state. No cross-process persistence will be added in this task.
+
+## Architecture
+
+### Rust host state
+
+Add a global `UpdateManagerState` guarded by `Mutex`, containing:
+
+- `current_version`
+- `latest_update` metadata when known
+- `task_state`
+- `progress`
+- `error`
+- `cancel_requested`
+- `active_version`
+
+Represent state with a small enum:
+
+- `idle`
+- `checking`
+- `up_to_date`
+- `available`
+- `downloading`
+- `ready`
+- `unsupported`
+- `cancelled`
+- `error`
+
+The state must be serializable so the frontend can query it directly.
+
+### Tauri commands
+
+Add commands:
+
+- `get_update_state`
+- `check_for_app_update`
+- `start_update_download`
+- `cancel_update_download`
+- `relaunch_after_update`
+
+Rules:
+
+- `start_update_download` returns the current task snapshot.
+- If the same target version is already downloading, it must not start a second task.
+- If a different version is requested while another task is active, return a clear error.
+- `cancel_update_download` flips a cancellation flag; the background task stops at the next progress callback boundary and transitions to `cancelled`.
+
+### Background task model
+
+The host starts one background thread per accepted download request. The thread:
+
+1. Loads or revalidates the pending update.
+2. Calls `downloadAndInstall`.
+3. Updates shared state on `Started`, `Progress`, `Finished`.
+4. Checks the cancellation flag during progress callbacks and aborts cleanly.
+
+Only one active download/install task is allowed at a time.
+
+### Frontend model
+
+Replace direct updater calls in `frontend/src/features/updates/updateService.ts` with a Tauri-command-backed service:
+
+- `getState()`
+- `check()`
+- `downloadAndInstall()`
+- `cancelDownload()`
+- `relaunch()`
+
+`UpdateCard` and `HomeUpdatePanel` stop owning progress. They only:
+
+- hydrate from `getState()`
+- invoke `check()` or `downloadAndInstall()`
+- poll while state is `checking` or `downloading`
+- render `取消下载` during active download
+
+This keeps both views consistent after refresh and prevents separate local state machines from diverging.
+
+## Error Handling
+
+- Non-desktop environment: return `unsupported` without crashing.
+- Duplicate start: return current `downloading` snapshot.
+- Cancel after finish: no-op and return current state.
+- Cancel during install completion race: final terminal state wins.
+- Check failure or download failure: transition to `error` with a user-facing message.
+
+## Testing
+
+### Frontend
+
+Add service-level tests for:
+
+- hydrating an existing `downloading` state after refresh
+- deduplicated `start_update_download`
+- cancellation support
+
+Add component tests for:
+
+- rendering a backend-owned download already in progress on first paint
+- showing `取消下载`
+- preserving progress after remount
+
+### Rust
+
+Add focused unit tests around the update state reducer/helpers:
+
+- progress math
+- duplicate task rejection/reuse
+- cancellation transition
+- terminal state transition
+
+Full updater integration does not need to run in tests; state transitions can be verified with isolated helpers.
+
+## Success Criteria
+
+- Refreshing the frontend during an update still shows the active task and current progress.
+- Starting download from one surface is reflected in the other surface.
+- Re-clicking download does not create a second task.
+- User can cancel an active download from the UI.
+- No cross-process recovery is implied or implemented.

--- a/docs/plans/2026-03-18-update-download-backend.md
+++ b/docs/plans/2026-03-18-update-download-backend.md
@@ -1,0 +1,187 @@
+# Update Download Backend Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move desktop update download ownership into the Tauri host so frontend refreshes preserve the active update task view, duplicate downloads are prevented, and users can cancel a running download.
+
+**Architecture:** Add a Rust-side update manager that owns the active updater task and exposes a serialized state snapshot through Tauri commands. Refactor the frontend update service and both update views to read and control that shared host-managed state instead of holding download progress in local React memory.
+
+**Tech Stack:** Rust, Tauri 2 updater plugin, React, TypeScript, Vitest
+
+---
+
+### Task 1: Define the host-managed update contract
+
+**Files:**
+- Modify: `desktop/src-tauri/src/main.rs`
+- Modify: `frontend/src/features/updates/updateService.ts`
+- Test: `frontend/src/features/updates/updateService.test.ts`
+
+**Step 1: Write the failing frontend contract tests**
+
+Add tests that describe a host-managed service contract:
+
+- `getState()` returns an existing `downloading` snapshot on first load
+- `downloadAndInstall()` delegates to a host command instead of a frontend-held closure
+- `cancelDownload()` exists and delegates to the host
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npm test -- --run src/features/updates/updateService.test.ts`
+Expected: FAIL because the service does not yet expose host-managed state methods.
+
+**Step 3: Add the minimal TypeScript contract**
+
+Introduce:
+
+- a serializable `DesktopUpdateState`
+- command-backed adapter methods for `getState`, `check`, `downloadAndInstall`, `cancelDownload`, `relaunch`
+
+Keep the old direct-updater implementation only as an internal desktop host detail on the Rust side, not in the frontend.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npm test -- --run src/features/updates/updateService.test.ts`
+Expected: PASS.
+
+### Task 2: Add Rust-side update manager state helpers
+
+**Files:**
+- Modify: `desktop/src-tauri/src/main.rs`
+- Test: `desktop/src-tauri/src/main.rs`
+
+**Step 1: Write the failing Rust unit tests**
+
+Add focused tests for:
+
+- initial idle state
+- progress updates producing expected percent/transferred values
+- duplicate active version requests reusing current task state
+- cancellation moving the task to `cancelled`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd desktop/src-tauri && cargo test update_manager_ -q`
+Expected: FAIL because the manager helpers do not exist.
+
+**Step 3: Implement the state types and helpers**
+
+Add:
+
+- serializable update metadata payload
+- serializable progress payload
+- serializable task state enum/string form
+- `UpdateManagerState` with helper methods to mutate/check task state
+
+Keep the implementation pure where possible so tests stay fast.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd desktop/src-tauri && cargo test update_manager_ -q`
+Expected: PASS.
+
+### Task 3: Wire Tauri commands and background task execution
+
+**Files:**
+- Modify: `desktop/src-tauri/src/main.rs`
+- Test: `desktop/src-tauri/src/main.rs`
+
+**Step 1: Write the failing Rust command-level tests**
+
+Add tests or command-adjacent helper tests that prove:
+
+- checking for updates stores latest metadata into shared state
+- starting a second download for the same version does not create a new task
+- cancelling an active task flips shared state
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd desktop/src-tauri && cargo test update_command_ -q`
+Expected: FAIL because commands/background orchestration are missing.
+
+**Step 3: Implement the commands**
+
+Add Tauri commands:
+
+- `get_update_state`
+- `check_for_app_update`
+- `start_update_download`
+- `cancel_update_download`
+- `relaunch_after_update`
+
+Register them in `generate_handler!`. Spawn the background download task from the host and update the shared state during progress events.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd desktop/src-tauri && cargo test update_ -q`
+Expected: PASS.
+
+### Task 4: Refactor update views to hydrate from shared host state
+
+**Files:**
+- Modify: `frontend/src/features/updates/UpdateCard.tsx`
+- Modify: `frontend/src/features/updates/HomeUpdatePanel.tsx`
+- Modify: `frontend/src/features/updates/UpdateCard.test.tsx`
+- Modify: `frontend/src/App.test.tsx`
+
+**Step 1: Write the failing component tests**
+
+Add tests that prove:
+
+- a pre-existing `downloading` state renders on first paint
+- the UI shows `取消下载` while downloading
+- remounting the component preserves the rendered host-managed progress instead of resetting to zero
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npm test -- --run src/features/updates/UpdateCard.test.tsx src/App.test.tsx`
+Expected: FAIL because the components still own local download state.
+
+**Step 3: Implement the minimal component changes**
+
+Update both views to:
+
+- hydrate via `getState()`
+- poll while active
+- call `cancelDownload()`
+- stop holding a private frontend-only download closure
+
+Use one shared mapping from host state to UI text.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npm test -- --run src/features/updates/UpdateCard.test.tsx src/App.test.tsx`
+Expected: PASS.
+
+### Task 5: Verify end-to-end touched scope
+
+**Files:**
+- Modify: `desktop/src-tauri/src/main.rs`
+- Modify: `frontend/src/features/updates/updateService.ts`
+- Modify: `frontend/src/features/updates/UpdateCard.tsx`
+- Modify: `frontend/src/features/updates/HomeUpdatePanel.tsx`
+- Modify: tests touched above
+- Create: `docs/plans/2026-03-18-update-download-backend-design.md`
+- Create: `docs/plans/2026-03-18-update-download-backend.md`
+
+**Step 1: Run targeted frontend verification**
+
+Run: `cd frontend && npm test -- --run src/features/updates/updateService.test.ts src/features/updates/UpdateCard.test.tsx src/App.test.tsx`
+Expected: PASS.
+
+**Step 2: Run targeted desktop verification**
+
+Run: `cd desktop/src-tauri && cargo test update_ -q`
+Expected: PASS.
+
+**Step 3: Run repository diff hygiene**
+
+Run: `git diff --check`
+Expected: no output.
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-18-update-download-backend-design.md docs/plans/2026-03-18-update-download-backend.md desktop/src-tauri/src/main.rs frontend/src/features/updates/updateService.ts frontend/src/features/updates/UpdateCard.tsx frontend/src/features/updates/HomeUpdatePanel.tsx frontend/src/features/updates/updateService.test.ts frontend/src/features/updates/UpdateCard.test.tsx frontend/src/App.test.tsx
+git commit -m "feat(update): move download state into desktop host"
+```

--- a/docs/plans/2026-03-18-usage-refresh-hardening.md
+++ b/docs/plans/2026-03-18-usage-refresh-hardening.md
@@ -1,0 +1,133 @@
+# Usage Refresh Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make account usage refresh start automatically on backend startup and keep running even if the sidecar or a background job exits unexpectedly.
+
+**Architecture:** Run one refresh pass immediately when the backend boots, then continue on the existing interval inside a protected scheduler loop that cannot die silently on panic. In the desktop app, add a sidecar exit watcher that restarts `routerd` when it exits unexpectedly, while preserving the existing on-demand request recovery path.
+
+**Tech Stack:** Go backend, Rust/Tauri desktop runtime, existing HTTP/API integration tests.
+
+---
+
+### Task 1: Immediate Backend Refresh
+
+**Files:**
+- Modify: `backend/internal/bootstrap/bootstrap.go`
+- Test: `backend/internal/bootstrap/bootstrap_test.go`
+
+**Step 1: Write the failing test**
+
+Add a test that creates an account with a long scheduler interval, then verifies `/ai-router/api/accounts/usage` is populated without waiting for the first ticker cycle.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/bootstrap -run TestNewAppRefreshesUsageImmediatelyOnStartup -count=1`
+
+Expected: FAIL because refresh only runs after the first scheduler tick.
+
+**Step 3: Write minimal implementation**
+
+Refactor the background scheduler startup so it performs one immediate run of recovery/refresh/compaction/backup before entering the ticker loop.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/bootstrap -run TestNewAppRefreshesUsageImmediatelyOnStartup -count=1`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add backend/internal/bootstrap/bootstrap.go backend/internal/bootstrap/bootstrap_test.go
+git commit -m "fix: refresh usage on backend startup"
+```
+
+### Task 2: Protect Scheduler Loop
+
+**Files:**
+- Modify: `backend/internal/bootstrap/bootstrap.go`
+- Test: `backend/internal/bootstrap/bootstrap_test.go`
+
+**Step 1: Write the failing test**
+
+Add a focused unit test around the scheduler runner helper that simulates a panicking job and verifies subsequent iterations still execute.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/bootstrap -run TestBackgroundLoopRecoversFromPanics -count=1`
+
+Expected: FAIL because a panic currently kills the goroutine.
+
+**Step 3: Write minimal implementation**
+
+Wrap each background cycle with `defer recover()` and log the panic so the loop keeps running.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/bootstrap -run TestBackgroundLoopRecoversFromPanics -count=1`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add backend/internal/bootstrap/bootstrap.go backend/internal/bootstrap/bootstrap_test.go
+git commit -m "fix: keep background scheduler alive after panic"
+```
+
+### Task 3: Auto-Restart Desktop Sidecar
+
+**Files:**
+- Modify: `desktop/src-tauri/src/main.rs`
+- Test: `desktop/src-tauri/src/main.rs`
+
+**Step 1: Write the failing test**
+
+Add unit coverage for the restart policy helper so unexpected exits trigger recovery while intentional shutdown/restart paths do not.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd desktop/src-tauri && cargo test sidecar_exit -- --nocapture`
+
+Expected: FAIL because there is no exit watcher/restart policy yet.
+
+**Step 3: Write minimal implementation**
+
+Track intentional sidecar shutdown reasons, spawn a watcher thread after launching the child, and restart the sidecar when it exits unexpectedly.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd desktop/src-tauri && cargo test sidecar_exit -- --nocapture`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add desktop/src-tauri/src/main.rs
+git commit -m "fix: restart sidecar after unexpected exit"
+```
+
+### Task 4: Verify End-to-End Behavior
+
+**Files:**
+- Modify: none
+
+**Step 1: Run backend tests**
+
+Run: `cd backend && go test ./internal/bootstrap -count=1`
+
+Expected: PASS
+
+**Step 2: Run desktop tests**
+
+Run: `cd desktop/src-tauri && cargo test sidecar -- --nocapture`
+
+Expected: PASS
+
+**Step 3: Run diff hygiene**
+
+Run: `git diff --check`
+
+Expected: no output

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,8 +1,10 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 const mockedUpdateService = vi.hoisted(() => ({
+  getState: vi.fn(),
   check: vi.fn(),
   downloadAndInstall: vi.fn(),
+  cancelDownload: vi.fn(),
   relaunch: vi.fn(),
 }));
 
@@ -65,8 +67,10 @@ describe("App", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     MockEventSource.instances = [];
+    mockedUpdateService.getState.mockResolvedValue({ status: "idle", update: null, progress: null, error: null });
     mockedUpdateService.check.mockResolvedValue({ supported: true, update: null });
     mockedUpdateService.downloadAndInstall.mockResolvedValue(undefined);
+    mockedUpdateService.cancelDownload.mockResolvedValue(undefined);
     mockedUpdateService.relaunch.mockResolvedValue(undefined);
     vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
     vi.mocked(loadDesktopShellContext).mockResolvedValue({

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -212,6 +212,64 @@ describe("App", () => {
     expect(updateButton.querySelector(".top-home-update-dot")).not.toBeNull();
   });
 
+  it("offers shared account import from the global add menu", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/proxy/status") {
+          return Promise.resolve(new Response(JSON.stringify({ enabled: false }), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/app") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                launch_at_login: false,
+                silent_start: false,
+                close_to_tray: true,
+                show_proxy_switch_on_home: true,
+                show_home_update_indicator: false,
+                status_refresh_interval_seconds: 3600,
+                proxy_host: "127.0.0.1",
+                proxy_port: 6789,
+                auto_failover_enabled: true,
+                auto_backup_interval_hours: 24,
+                backup_retention_count: 10,
+                audit_limit_message: 200,
+                audit_limit_function_call: 100,
+                audit_limit_function_call_output: 100,
+                audit_limit_reasoning: 40,
+                audit_limit_custom_tool_call: 100,
+                audit_limit_custom_tool_call_output: 100,
+                language: "zh-CN",
+                theme_mode: "system",
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts/usage") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        return Promise.resolve(new Response(null, { status: 404 }));
+      }),
+    );
+    vi.mocked(subscribeDesktopBackendStateChanged).mockResolvedValue(() => {});
+
+    render(<App />);
+
+    expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("添加账户"));
+    fireEvent.click(await screen.findByText("导入账户"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/add-mode:shared_import/)).toBeInTheDocument();
+    });
+  });
+
   it("checks for home updates every hour when the indicator is enabled", async () => {
     vi.useFakeTimers();
     mockedUpdateService.check.mockResolvedValue({ supported: true, update: null });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -229,6 +229,7 @@ export function App() {
         content: `${details} ${translate("是否强制退出？")}`,
         okText: translate("强制退出"),
         cancelText: translate("取消"),
+        centered: true,
         onOk: async () => {
           try {
             await disableProxy({ force: true });
@@ -261,6 +262,7 @@ export function App() {
           content: t("当前 config.toml 已被外部修改。请选择关闭方式：覆盖恢复后关闭，或不覆盖直接关闭代理。"),
           okText: t("覆盖并关闭"),
           cancelText: t("不覆盖直接关闭"),
+          centered: true,
           onOk: async () => {
             setProxyLoading(true);
             try {
@@ -438,6 +440,7 @@ export function App() {
                 footer={null}
                 onCancel={() => setHomeUpdateModalOpen(false)}
                 destroyOnHidden
+                centered
                 width={720}
               >
                 <HomeUpdatePanel

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,7 +31,7 @@ export function App() {
   const [messageApi, contextHolder] = message.useMessage();
   const [view, setView] = useState<AppView>("accounts");
   const [settingsInitialTab, setSettingsInitialTab] = useState<"general" | "proxy" | "advanced" | "about">("general");
-  const [addModalMode, setAddModalMode] = useState<"official" | "third_party" | null>(null);
+  const [addModalMode, setAddModalMode] = useState<"official" | "third_party" | "shared_import" | null>(null);
   const [proxyEnabled, setProxyEnabled] = useState(false);
   const [proxyLoading, setProxyLoading] = useState(false);
   const [accountsSyncToken, setAccountsSyncToken] = useState(0);
@@ -398,8 +398,9 @@ export function App() {
                       items: [
                         { key: "official", label: t("官方账户") },
                         { key: "third_party", label: t("第三方账户") },
+                        { key: "shared_import", label: t("导入账户") },
                       ],
-                      onClick: ({ key }) => setAddModalMode(key as "official" | "third_party"),
+                      onClick: ({ key }) => setAddModalMode(key as "official" | "third_party" | "shared_import"),
                     }}
                   >
                     <Button type="primary" shape="circle" icon={<PlusOutlined />} aria-label={t("添加账户")} className="global-add-button" />

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -899,26 +899,28 @@ describe("AccountsPage", () => {
         return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
       }
       if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
-      }
-      if (url.startsWith("/ai-router/api/accounts/1/ppchat-token-logs") && (!init?.method || init.method === "GET")) {
         return Promise.resolve(
           new Response(
-            JSON.stringify({
-              success: true,
-              data: {
-                logs: [],
-                pagination: { page: 1, page_size: 10, total: 0, total_pages: 0 },
-                token_info: {
-                  name: "ppchat-main",
-                  today_usage_count: 172,
-                  today_used_quota: 1068,
-                  remain_quota_display: 13931,
-                  today_added_quota: 14999,
-                  expired_time_formatted: "2026-04-23 08:18:32",
-                },
+            JSON.stringify([
+              {
+                account_id: 1,
+                balance: 0,
+                quota_remaining: 0,
+                rpm_remaining: 0,
+                tpm_remaining: 0,
+                health_score: 1,
+                recent_error_rate: 0,
+                last_total_tokens: 0,
+                last_input_tokens: 0,
+                last_output_tokens: 0,
+                model_context_window: 0,
+                primary_used_percent: 0,
+                secondary_used_percent: 0,
+                ppchat_today_used_quota: 1068,
+                ppchat_today_remaining_quota: 13931,
+                ppchat_today_added_quota: 14999,
               },
-            }),
+            ]),
             { status: 200, headers: { "Content-Type": "application/json" } },
           ),
         );
@@ -934,6 +936,7 @@ describe("AccountsPage", () => {
     expect(await screen.findByText("1D")).toBeInTheDocument();
     expect(screen.getByText("93%")).toBeInTheDocument();
     expect(document.querySelector(".account-usage-mini")).toHaveClass("account-usage-mini-single");
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/ai-router/api/accounts/1/ppchat-token-logs"))).toBe(false);
   });
 
   it("reorders account cards during pointer drag before release", async () => {

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -130,6 +130,7 @@ describe("AccountsPage", () => {
     fireEvent.click(await screen.findByText("官方账户"));
 
     const officialModal = await screen.findByRole("dialog", { name: "添加官方账户" });
+    expect(officialModal.closest(".ant-modal-wrap")).toHaveClass("ant-modal-centered");
     fireEvent.change(within(officialModal).getByLabelText("账户名称"), {
       target: { value: "current-codex" },
     });
@@ -420,6 +421,58 @@ describe("AccountsPage", () => {
 
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: "导入账户" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("centers the delete confirmation modal vertically", async () => {
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-compatible",
+        account_name: "mirror-east",
+        source_icon: "openai",
+        auth_mode: "api_key",
+        base_url: "https://api.example/v1",
+        status: "active",
+        is_active: false,
+        priority: 2,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 100,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("mirror-east")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "删除-mirror-east" }));
+    await waitFor(() => {
+      const confirmWrap = document.querySelector(".ant-modal-confirm")?.closest(".ant-modal-wrap");
+      expect(confirmWrap).not.toBeNull();
+      expect(confirmWrap).toHaveClass("ant-modal-centered");
     });
   });
 

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -233,6 +233,187 @@ describe("AccountsPage", () => {
     expect(within(editTestModal).getByText("pong")).toBeInTheDocument();
   });
 
+  it("confirms before sharing and only copies after explicit approval", async () => {
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: { writeText: clipboardWriteText },
+      configurable: true,
+    });
+
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-compatible",
+        account_name: "mirror-east",
+        source_icon: "ppchat",
+        auth_mode: "api_key",
+        base_url: "https://code.ppchat.vip/v1",
+        account_driver: "builtin_api_key",
+        usage_driver: "lua",
+        usage_config_json: "{\"script\":\"adapters/vendor.lua\"}",
+        status: "active",
+        is_active: false,
+        priority: 2,
+        supports_responses: true,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 0,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "/ai-router/api/accounts/1/share" && init?.method === "POST") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ payload: "{\"kind\":\"aigate-account-share\"}" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("mirror-east")).toBeInTheDocument();
+    fetchMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "分享-mirror-east" }));
+    const confirmModal = await screen.findByRole("dialog", { name: "分享账户" });
+    fireEvent.click(within(confirmModal).getByRole("button", { name: /取\s*消/ }));
+
+    await waitFor(() => {
+      expect(clipboardWriteText).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "分享-mirror-east" }));
+    const approvedModal = await screen.findByRole("dialog", { name: "分享账户" });
+    fireEvent.click(within(approvedModal).getByRole("button", { name: "确认分享" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/1/share",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(clipboardWriteText).toHaveBeenCalledWith("{\"kind\":\"aigate-account-share\"}");
+    });
+  });
+
+  it("imports shared payload and keeps the modal open on validation failure", async () => {
+    const validPayload = "{\"kind\":\"aigate-account-share\",\"schema_version\":1}";
+
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-compatible",
+        account_name: "mirror-east",
+        source_icon: "ppchat",
+        auth_mode: "api_key",
+        base_url: "https://code.ppchat.vip/v1",
+        account_driver: "builtin_api_key",
+        usage_driver: "lua",
+        usage_config_json: "{\"script\":\"adapters/vendor.lua\"}",
+        status: "active",
+        is_active: false,
+        priority: 2,
+        supports_responses: true,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 0,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    let importAttempt = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "/ai-router/api/accounts/import-shared" && init?.method === "POST") {
+        importAttempt += 1;
+        if (importAttempt === 1) {
+          return Promise.resolve(new Response("分享内容无效", { status: 400 }));
+        }
+        return Promise.resolve(new Response(null, { status: 201 }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("mirror-east")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /添加账户/ }));
+    fireEvent.click(await screen.findByText("导入账户"));
+
+    const importModal = await screen.findByRole("dialog", { name: "导入账户" });
+    fireEvent.change(within(importModal).getByLabelText("粘贴分享内容"), {
+      target: { value: validPayload },
+    });
+    fireEvent.click(within(importModal).getByRole("button", { name: "校验并导入" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/import-shared",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ payload: validPayload }),
+        }),
+      );
+    });
+    expect(await within(importModal).findByText("分享内容无效")).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "导入账户" })).toBeInTheDocument();
+
+    fireEvent.click(within(importModal).getByRole("button", { name: "校验并导入" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/import-shared",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ payload: validPayload }),
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "导入账户" })).not.toBeInTheDocument();
+    });
+  });
+
   it("highlights active account and allows manual activation", async () => {
     const accountList = [
       {

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -67,6 +67,9 @@ describe("AccountsPage", () => {
       if (url === "/ai-router/api/accounts/import-current" && init?.method === "POST") {
         return Promise.resolve(new Response(null, { status: 201 }));
       }
+      if (url === "/ai-router/api/accounts/usage/refresh" && init?.method === "POST") {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
       if (url === "/ai-router/api/accounts" && init?.method === "POST") {
         return Promise.resolve(new Response(null, { status: 201 }));
       }
@@ -139,6 +142,12 @@ describe("AccountsPage", () => {
           method: "POST",
           body: JSON.stringify({ account_name: "current-codex" }),
         }),
+      );
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/usage/refresh",
+        expect.objectContaining({ method: "POST" }),
       );
     });
 
@@ -937,6 +946,72 @@ describe("AccountsPage", () => {
     expect(screen.getByText("93%")).toBeInTheDocument();
     expect(document.querySelector(".account-usage-mini")).toHaveClass("account-usage-mini-single");
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/ai-router/api/accounts/1/ppchat-token-logs"))).toBe(false);
+  });
+
+  it("refreshes usage after shared account import so imported accounts do not stay at default progress", async () => {
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-official",
+        account_name: "shared-codex",
+        source_icon: "openai",
+        auth_mode: "codex_local_import",
+        base_url: "https://chatgpt.com/backend-api/codex",
+        status: "active",
+        is_active: false,
+        priority: 1,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 0,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "/ai-router/api/accounts/import-shared" && init?.method === "POST") {
+        return Promise.resolve(new Response(null, { status: 201 }));
+      }
+      if (url === "/ai-router/api/accounts/usage/refresh" && init?.method === "POST") {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+    expect(await screen.findByText("shared-codex")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /添加账户/ }));
+    fireEvent.click(await screen.findByText("导入账户"));
+
+    const importModal = await screen.findByRole("dialog", { name: "导入账户" });
+    fireEvent.change(within(importModal).getByLabelText("粘贴分享内容"), {
+      target: { value: "{\"kind\":\"aigate-account-share\",\"schema_version\":1}" },
+    });
+    fireEvent.click(within(importModal).getByRole("button", { name: "校验并导入" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/usage/refresh",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
   });
 
   it("reorders account cards during pointer drag before release", async () => {

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -4,6 +4,7 @@ import {
   CopyOutlined,
   DeleteOutlined,
   EditOutlined,
+  ExportOutlined,
   HolderOutlined,
   InfoCircleOutlined,
   PlusOutlined,
@@ -60,9 +61,11 @@ import {
   deleteAccount,
   duplicateAccount,
   importCurrentCodexAuth,
+  importSharedAccount,
   fetchPPChatTokenLogs,
   listAccountUsage,
   listAccounts,
+  shareAccount,
   testAccount,
   updateAccount,
   type AccountRecord,
@@ -78,7 +81,7 @@ import sourcePPChatIcon from "../../assets/providers/ppchat.png";
 const { Title, Text } = Typography;
 
 const defaultBaseURL = "https://code.ppchat.vip/v1";
-type AddModalMode = "official" | "third_party" | null;
+type AddModalMode = "official" | "third_party" | "shared_import" | null;
 
 const statusColorMap: Record<string, string> = {
   active: "green",
@@ -300,6 +303,7 @@ export function AccountsPage({
   const [internalAddModalMode, setInternalAddModalMode] = useState<AddModalMode>(null);
   const [editingAccount, setEditingAccount] = useState<AccountRecord | null>(null);
   const [detailAccount, setDetailAccount] = useState<AccountRecord | null>(null);
+  const [sharedImportError, setSharedImportError] = useState<string>("");
   const [testResult, setTestResult] = useState<AccountTestResult | null>(null);
   const [detailLogsLoading, setDetailLogsLoading] = useState(false);
   const [detailLogs, setDetailLogs] = useState<PPChatTokenLogsPayload["data"] | null>(null);
@@ -307,6 +311,7 @@ export function AccountsPage({
 
   const [thirdPartyForm] = Form.useForm();
   const [officialForm] = Form.useForm();
+  const [sharedImportForm] = Form.useForm();
   const [editForm] = Form.useForm();
   const [testForm] = Form.useForm();
   const accountsRef = useRef<AccountRecord[]>([]);
@@ -453,6 +458,20 @@ export function AccountsPage({
     void messageApi.success(t("官方账户已导入"));
   }
 
+  async function handleImportShared(values: { payload: string }) {
+    setSharedImportError("");
+    try {
+      await importSharedAccount(values.payload);
+      sharedImportForm.resetFields();
+      setInternalAddModalMode(null);
+      await refreshAll();
+      void refreshDesktopTrayState();
+      void messageApi.success(t("导入成功"));
+    } catch (error) {
+      setSharedImportError(error instanceof Error ? t(error.message) : t("分享内容无效"));
+    }
+  }
+
   function openEditModal(account: AccountRecord) {
     setEditingAccount(account);
     setTestResult(null);
@@ -536,6 +555,24 @@ export function AccountsPage({
     } catch (error) {
       void messageApi.warning(error instanceof Error ? t(error.message) : t("复制失败，请稍后重试"));
     }
+  }
+
+  async function handleShareAccount(record: AccountRecord) {
+    await modal.confirm({
+      title: t("分享账户"),
+      content: t("即将复制可导入的账户信息，请注意保管，不要泄露。"),
+      okText: t("确认分享"),
+      cancelText: t("取消"),
+      centered: true,
+      onOk: async () => {
+        if (!navigator.clipboard?.writeText) {
+          throw new Error(t("当前环境不支持剪切板写入"));
+        }
+        const response = await shareAccount(record.id);
+        await navigator.clipboard.writeText(response.payload);
+        void messageApi.success(t("已复制账户分享信息"));
+      },
+    });
   }
 
   function handleDragStart(event: DragStartEvent) {
@@ -757,6 +794,14 @@ export function AccountsPage({
                 <Button
                   type="text"
                   className="account-action-button"
+                  aria-label={`${t("分享")}-${record.account_name}`}
+                  icon={<ExportOutlined />}
+                  disabled={options.actionsDisabled}
+                  onClick={() => void handleShareAccount(record)}
+                />
+                <Button
+                  type="text"
+                  className="account-action-button"
                   aria-label={`${t("详情")}-${record.account_name}`}
                   icon={<InfoCircleOutlined />}
                   disabled={options.actionsDisabled}
@@ -803,8 +848,12 @@ export function AccountsPage({
               items: [
                 { key: "official", label: t("官方账户") },
                 { key: "third_party", label: t("第三方账户") },
+                { key: "shared_import", label: t("导入账户") },
               ],
-              onClick: ({ key }) => setInternalAddModalMode(key as AddModalMode),
+              onClick: ({ key }) => {
+                setSharedImportError("");
+                setInternalAddModalMode(key as AddModalMode);
+              },
             }}
             trigger={["click"]}
           >
@@ -1016,6 +1065,37 @@ export function AccountsPage({
             <Button onClick={() => setInternalAddModalMode(null)}>{t("取消")}</Button>
             <Button type="primary" htmlType="submit">
               {t("导入")}
+            </Button>
+          </div>
+        </Form>
+      </Modal>
+
+      <Modal
+        open={internalAddModalMode === "shared_import"}
+        title={t("导入账户")}
+        onCancel={() => {
+          setSharedImportError("");
+          setInternalAddModalMode(null);
+        }}
+        footer={null}
+        destroyOnHidden
+      >
+        <Form form={sharedImportForm} layout="vertical" onFinish={(values) => void handleImportShared(values)}>
+          <Form.Item label={t("粘贴分享内容")} name="payload" rules={[{ required: true, message: t("请粘贴分享内容") }]}>
+            <Input.TextArea rows={8} spellCheck={false} />
+          </Form.Item>
+          {sharedImportError ? <Text type="danger">{sharedImportError}</Text> : null}
+          <div className="modal-footer">
+            <Button
+              onClick={() => {
+                setSharedImportError("");
+                setInternalAddModalMode(null);
+              }}
+            >
+              {t("取消")}
+            </Button>
+            <Button type="primary" htmlType="submit">
+              {t("校验并导入")}
             </Button>
           </div>
         </Form>

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -796,6 +796,7 @@ export function AccountsPage({
                       title: formatDeleteAccountTitle(language, record.account_name),
                       okText: t("删除"),
                       cancelText: t("取消"),
+                      centered: true,
                       okButtonProps: { danger: true },
                       onOk: () => handleDelete(record),
                     })
@@ -876,7 +877,7 @@ export function AccountsPage({
         </DndContext>
       )}
 
-      <Modal open={!!detailAccount} title={t("账户详情")} onCancel={() => setDetailAccount(null)} footer={null} destroyOnHidden width={880}>
+      <Modal open={!!detailAccount} title={t("账户详情")} onCancel={() => setDetailAccount(null)} footer={null} destroyOnHidden centered width={880}>
         {detailAccount ? (
           normalizeSourceIcon(detailAccount.source_icon) === "ppchat" ? (
             <div className="account-detail-layout">
@@ -997,6 +998,7 @@ export function AccountsPage({
         onCancel={() => setInternalAddModalMode(null)}
         footer={null}
         destroyOnHidden
+        centered
       >
         <Form
           form={thirdPartyForm}
@@ -1028,6 +1030,7 @@ export function AccountsPage({
         onCancel={() => setInternalAddModalMode(null)}
         footer={null}
         destroyOnHidden
+        centered
       >
         <Form form={officialForm} layout="vertical" onFinish={(values) => void handleCreateOfficial(values)}>
           <Form.Item label={t("账户名称")} name="account_name" initialValue="local-codex">
@@ -1056,6 +1059,7 @@ export function AccountsPage({
         }}
         footer={null}
         destroyOnHidden
+        centered
       >
         <Form form={sharedImportForm} layout="vertical" onFinish={(values) => void handleImportShared(values)}>
           <Form.Item label={t("粘贴分享内容")} name="payload" rules={[{ required: true, message: t("请粘贴分享内容") }]}>
@@ -1084,6 +1088,7 @@ export function AccountsPage({
         onCancel={() => setEditingAccount(null)}
         footer={null}
         destroyOnHidden
+        centered
       >
         <Form form={editForm} layout="vertical" onFinish={(values) => void handleEdit(values)}>
           <Form.Item label={t("账户名称")} name="account_name" rules={[{ required: true, message: t("请输入账户名称") }]}>

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -65,6 +65,7 @@ import {
   fetchPPChatTokenLogs,
   listAccountUsage,
   listAccounts,
+  refreshAccountUsage,
   shareAccount,
   testAccount,
   updateAccount,
@@ -403,6 +404,11 @@ export function AccountsPage({
       credential_ref: values.credential_ref,
       supports_responses: true,
     });
+    try {
+      await refreshAccountUsage();
+    } catch {
+      // Keep account creation successful even if immediate usage refresh fails.
+    }
     setInternalAddModalMode(null);
     thirdPartyForm.resetFields();
     await refreshAll();
@@ -412,6 +418,11 @@ export function AccountsPage({
 
   async function handleCreateOfficial(values: { account_name: string }) {
     await importCurrentCodexAuth(values.account_name || "local-codex");
+    try {
+      await refreshAccountUsage();
+    } catch {
+      // Keep import successful even if immediate usage refresh fails.
+    }
     officialForm.resetFields();
     setInternalAddModalMode(null);
     await refreshAll();
@@ -423,6 +434,11 @@ export function AccountsPage({
     setSharedImportError("");
     try {
       await importSharedAccount(values.payload);
+      try {
+        await refreshAccountUsage();
+      } catch {
+        // Keep import successful even if immediate usage refresh fails.
+      }
       sharedImportForm.resetFields();
       setInternalAddModalMode(null);
       await refreshAll();

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -223,28 +223,6 @@ function isPPChatAccount(record: AccountRecord): boolean {
   return normalizeSourceIcon(record.source_icon) === "ppchat" || /ppchat\.vip/i.test(record.base_url);
 }
 
-function buildPPChatUsageSummary(data: PPChatTokenLogsPayload["data"] | null | undefined): Pick<
-  AccountRecord,
-  "ppchat_today_added_quota" | "ppchat_today_used_quota" | "ppchat_today_remaining_quota"
-> | null {
-  const info = data?.token_info;
-  if (!info) {
-    return null;
-  }
-  const added = Math.max(info.today_added_quota ?? 0, 0);
-  const used = Math.max(info.today_used_quota ?? 0, 0);
-  const remaining = Math.max(info.remain_quota_display ?? 0, 0);
-  const total = Math.max(added, used+ remaining, 0);
-  if (total <= 0 && used <= 0 && remaining <= 0) {
-    return null;
-  }
-  return {
-    ppchat_today_added_quota: total,
-    ppchat_today_used_quota: used,
-    ppchat_today_remaining_quota: remaining,
-  };
-}
-
 type AccountsPageProps = {
   language?: AppLanguage;
   t?: Translator;
@@ -396,34 +374,17 @@ export function AccountsPage({
 
   async function refreshUsage() {
     try {
-      const currentAccounts = accountsRef.current;
-      const ppchatAccounts = currentAccounts.filter((item) => isPPChatAccount(item));
-      const [usageItems, ppchatSummaries] = await Promise.all([
-        listAccountUsage(),
-        Promise.all(
-          ppchatAccounts.map(async (item) => {
-            try {
-              const payload = await fetchPPChatTokenLogs(item.id);
-              return [item.id, buildPPChatUsageSummary(payload.data)] as const;
-            } catch {
-              return [item.id, null] as const;
-            }
-          }),
-        ),
-      ]);
+      const usageItems = await listAccountUsage();
       const usageByAccount = new Map(usageItems.map((item) => [item.account_id, item]));
-      const ppchatByAccount = new Map(ppchatSummaries.filter((entry): entry is readonly [number, NonNullable<typeof entry[1]>] => entry[1] !== null));
       setAccountsState((items) =>
         items.map((item) => {
           const usage = usageByAccount.get(item.id);
-          const ppchatUsage = ppchatByAccount.get(item.id);
           if (!usage) {
-            return ppchatUsage ? { ...item, ...ppchatUsage } : item;
+            return item;
           }
           return {
             ...item,
             ...usage,
-            ...(ppchatUsage ?? {}),
           };
         }),
       { preserveOrder: true });

--- a/frontend/src/features/settings/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/SettingsPage.test.tsx
@@ -251,6 +251,7 @@ describe("SettingsPage", () => {
     });
     await waitFor(() => {
       expect(confirmSpy).toHaveBeenCalled();
+      expect(confirmSpy).toHaveBeenCalledWith(expect.objectContaining({ centered: true }));
       expect(fetchMock).toHaveBeenCalledWith(
         "/ai-router/api/settings/database/backups/20260309-101500.000",
         expect.objectContaining({ method: "DELETE" }),

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -413,6 +413,7 @@ export function SettingsPage({
       content: `${t("确认删除此备份")} ${item.backup_id}？`,
       okText: t("确认删除"),
       cancelText: t("取消"),
+      centered: true,
       okButtonProps: { danger: true },
       onOk: async () => {
         setBackupBusy(`delete:${item.backup_id}`);
@@ -884,6 +885,7 @@ export function SettingsPage({
         open={importModalOpen}
         okText={t("验证并导入")}
         confirmLoading={importingSQL}
+        centered
         onOk={() => void handleImportSQL()}
         onCancel={() => {
           if (importingSQL) {

--- a/frontend/src/features/updates/HomeUpdatePanel.tsx
+++ b/frontend/src/features/updates/HomeUpdatePanel.tsx
@@ -1,11 +1,18 @@
-import { CloudDownloadOutlined, ReloadOutlined } from "@ant-design/icons";
+import { CloudDownloadOutlined, CloseOutlined, ReloadOutlined } from "@ant-design/icons";
 import { Button, Progress, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 
 import type { AppLanguage, Translator } from "../../lib/i18n";
-import { createDesktopUpdateService, type DesktopUpdateInfo, type DesktopUpdateService, type DownloadProgress } from "./updateService";
+import {
+  createDesktopUpdateService,
+  emptyUpdateState,
+  type DesktopUpdateInfo,
+  type DesktopUpdateService,
+  type DesktopUpdateState,
+} from "./updateService";
 
 const { Paragraph, Text } = Typography;
+const ACTIVE_POLL_MS = 1000;
 
 type HomeUpdatePanelProps = {
   currentVersion: string;
@@ -14,14 +21,6 @@ type HomeUpdatePanelProps = {
   t: Translator;
   service?: DesktopUpdateService;
 };
-
-type HomeUpdateViewState =
-  | { status: "up-to-date"; message: string }
-  | { status: "available"; message: string; update: DesktopUpdateInfo }
-  | { status: "downloading"; message: string; update: DesktopUpdateInfo; progress: DownloadProgress }
-  | { status: "ready"; message: string; update: DesktopUpdateInfo }
-  | { status: "unsupported"; message: string; update?: DesktopUpdateInfo }
-  | { status: "error"; message: string };
 
 function formatDate(value: string | null | undefined, language: AppLanguage) {
   if (!value) {
@@ -34,95 +33,130 @@ function formatDate(value: string | null | undefined, language: AppLanguage) {
   return date.toLocaleString(language, { hour12: false });
 }
 
-function buildInitialState(update: DesktopUpdateInfo | null, t: Translator): HomeUpdateViewState {
+function buildInitialState(update: DesktopUpdateInfo | null): DesktopUpdateState {
   if (!update) {
-    return { status: "up-to-date", message: t("已是最新版本") };
+    return { ...emptyUpdateState("up-to-date") };
   }
   return {
     status: "available",
-    message: `${t("发现新版本")} ${update.version}`,
     update,
+    progress: null,
+    error: null,
   };
+}
+
+function describeState(state: DesktopUpdateState, t: Translator) {
+  switch (state.status) {
+    case "up-to-date":
+      return t("已是最新版本");
+    case "available":
+      return state.update ? `${t("发现新版本")} ${state.update.version}` : t("发现新版本");
+    case "downloading":
+      return `${t("下载进度")} ${Math.round(state.progress?.percent ?? 0)}%`;
+    case "ready":
+      return t("更新已安装，重启后生效");
+    case "unsupported":
+      return state.update ? t("当前环境不支持自动安装，但已检查到最新版本。") : t("当前仅桌面版支持自动更新。");
+    case "cancelled":
+      return t("下载已取消");
+    case "error":
+      return state.error || t("安装更新失败");
+    case "checking":
+      return t("正在检查更新…");
+    case "idle":
+    default:
+      return t("检查 GitHub Release 中的最新版本。");
+  }
+}
+
+function shouldPoll(state: DesktopUpdateState) {
+  return state.status === "checking" || state.status === "downloading";
 }
 
 export function HomeUpdatePanel({ currentVersion, initialUpdate, language, t, service }: HomeUpdatePanelProps) {
   const updateService = useMemo(() => service ?? createDesktopUpdateService(), [service]);
-  const [state, setState] = useState<HomeUpdateViewState>(() => buildInitialState(initialUpdate, t));
+  const [state, setState] = useState<DesktopUpdateState>(() => buildInitialState(initialUpdate));
 
-  useEffect(() => {
-    setState((current) => {
-      if (current.status === "downloading" || current.status === "ready") {
-        return current;
-      }
-      return buildInitialState(initialUpdate, t);
-    });
-  }, [initialUpdate, t]);
+  async function hydrate() {
+    const snapshot = await updateService.getState();
+    setState(snapshot);
+    return snapshot;
+  }
+
+  async function handleDownloadAndInstall(update: DesktopUpdateInfo) {
+    try {
+      await updateService.downloadAndInstall(update);
+      await hydrate();
+    } catch (error) {
+      setState({
+        status: "error",
+        update,
+        progress: null,
+        error: error instanceof Error ? t(error.message) : t("安装更新失败"),
+      });
+    }
+  }
+
+  async function handleCancel() {
+    try {
+      await updateService.cancelDownload();
+      await hydrate();
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        status: "error",
+        error: error instanceof Error ? t(error.message) : t("安装更新失败"),
+      }));
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
 
-    async function hydrate() {
-      try {
-        const result = await updateService.check(currentVersion);
-        if (cancelled) {
-          return;
-        }
-        if (!result.supported) {
-          setState({
-            status: "unsupported",
-            message: result.update ? t("当前环境不支持自动安装，但已检查到最新版本。") : t("当前仅桌面版支持自动更新。"),
-            update: result.update ?? undefined,
-          });
-          return;
-        }
-        if (!result.update) {
-          setState({ status: "up-to-date", message: t("已是最新版本") });
-          return;
-        }
-        setState({
-          status: "available",
-          message: `${t("发现新版本")} ${result.update.version}`,
-          update: result.update,
-        });
-      } catch (error) {
-        if (cancelled) {
-          return;
-        }
-        setState({ status: "error", message: error instanceof Error ? t(error.message) : t("检查更新失败") });
+    async function bootstrap() {
+      const snapshot = await updateService.getState();
+      if (cancelled) {
+        return;
       }
+      if (snapshot.status !== "idle") {
+        setState(snapshot);
+        return;
+      }
+      const result = await updateService.check(currentVersion);
+      if (cancelled) {
+        return;
+      }
+      if (!result.supported) {
+        setState({
+          status: "unsupported",
+          update: result.update,
+          progress: null,
+          error: null,
+        });
+        return;
+      }
+      setState(buildInitialState(result.update ?? initialUpdate));
     }
 
-    void hydrate();
+    void bootstrap();
     return () => {
       cancelled = true;
     };
-  }, [currentVersion, t, updateService]);
+  }, [currentVersion, initialUpdate, updateService]);
 
-  async function handleDownloadAndInstall(update: DesktopUpdateInfo) {
-    setState({
-      status: "downloading",
-      message: `${t("下载进度")} 0%`,
-      update,
-      progress: { percent: 0, total: 0, transferred: 0 },
-    });
-    try {
-      await updateService.downloadAndInstall(update, (progress) => {
-        setState({
-          status: "downloading",
-          message: `${t("下载进度")} ${Math.round(progress.percent)}%`,
-          update,
-          progress,
-        });
-      });
-      setState({
-        status: "ready",
-        message: t("更新已安装，重启后生效"),
-        update,
-      });
-    } catch (error) {
-      setState({ status: "error", message: error instanceof Error ? t(error.message) : t("安装更新失败") });
+  useEffect(() => {
+    if (!shouldPoll(state)) {
+      return;
     }
-  }
+    const timer = window.setInterval(() => {
+      void hydrate();
+    }, ACTIVE_POLL_MS);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [state.status, state.progress?.percent]);
+
+  const message = describeState(state, t);
 
   return (
     <div className="home-update-panel">
@@ -134,10 +168,10 @@ export function HomeUpdatePanel({ currentVersion, initialUpdate, language, t, se
           </div>
           <div className="about-meta-row">
             <span>{t("状态")}</span>
-            <strong className={`update-status-value${state.status === "downloading" ? " is-checking" : ""}`}>{state.message}</strong>
+            <strong className={`update-status-value${state.status === "checking" || state.status === "downloading" ? " is-checking" : ""}`}>{message}</strong>
           </div>
 
-          {"update" in state && state.update ? (
+          {state.update ? (
             <>
               <div className="about-meta-row">
                 <span>{state.status === "unsupported" ? t("最新版本") : t("目标版本")}</span>
@@ -154,17 +188,22 @@ export function HomeUpdatePanel({ currentVersion, initialUpdate, language, t, se
           ) : null}
         </div>
 
-        {state.status === "downloading" ? <Progress percent={Math.round(state.progress.percent)} showInfo={false} /> : null}
+        {state.status === "downloading" && state.progress ? <Progress percent={Math.round(state.progress.percent)} showInfo={false} /> : null}
 
         <div className="update-card-actions">
-          {state.status === "available" ? (
+          {state.status === "available" && state.update ? (
             <Button
               aria-label={t("下载并安装")}
               type="primary"
               icon={<CloudDownloadOutlined />}
-              onClick={() => void handleDownloadAndInstall(state.update)}
+              onClick={() => void handleDownloadAndInstall(state.update!)}
             >
               {t("下载并安装")}
+            </Button>
+          ) : null}
+          {state.status === "downloading" ? (
+            <Button aria-label={t("终止下载")} icon={<CloseOutlined />} onClick={() => void handleCancel()}>
+              {t("终止下载")}
             </Button>
           ) : null}
           {state.status === "ready" ? (
@@ -172,7 +211,7 @@ export function HomeUpdatePanel({ currentVersion, initialUpdate, language, t, se
               {t("立即重启")}
             </Button>
           ) : null}
-          {state.status === "unsupported" && !state.update ? <Text type="secondary">{state.message}</Text> : null}
+          {state.status === "unsupported" && !state.update ? <Text type="secondary">{message}</Text> : null}
         </div>
       </div>
     </div>

--- a/frontend/src/features/updates/UpdateCard.test.tsx
+++ b/frontend/src/features/updates/UpdateCard.test.tsx
@@ -2,16 +2,32 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { UpdateCard } from "./UpdateCard";
-import type { DesktopUpdateInfo, DesktopUpdateService } from "./updateService";
+import type { DesktopUpdateInfo, DesktopUpdateService, DesktopUpdateState } from "./updateService";
 
-function createService(update: DesktopUpdateInfo | null): DesktopUpdateService {
+function createService(state: DesktopUpdateState): DesktopUpdateService {
+  const currentState = structuredClone(state) as DesktopUpdateState;
+  const snapshot = () => structuredClone(currentState) as DesktopUpdateState;
   return {
-    check: vi.fn().mockResolvedValue({ supported: true, update }),
-    downloadAndInstall: vi.fn().mockImplementation(async (_target, onProgress) => {
-      onProgress?.({ percent: 25, total: 100, transferred: 25 });
-      onProgress?.({ percent: 100, total: 100, transferred: 100 });
+    getState: vi.fn().mockImplementation(async () => snapshot()),
+    check: vi.fn().mockImplementation(async () => ({ supported: currentState.status !== "unsupported", update: currentState.update ? structuredClone(currentState.update) : null })),
+    downloadAndInstall: vi.fn().mockImplementation(async () => {
+      currentState.status = "downloading";
+      currentState.progress = { percent: 25, total: 100, transferred: 25 };
+    }),
+    cancelDownload: vi.fn().mockImplementation(async () => {
+      currentState.status = "cancelled";
+      currentState.progress = null;
     }),
     relaunch: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function availableUpdate(): DesktopUpdateInfo {
+  return {
+    body: "Important fixes",
+    currentVersion: "2.3.4",
+    date: "2026-03-11T12:00:00Z",
+    version: "2.3.5",
   };
 }
 
@@ -19,7 +35,12 @@ describe("UpdateCard", () => {
   const t = (value: string) => value;
 
   it("shows the latest status when no update is available", async () => {
-    const service = createService(null);
+    const service = createService({
+      status: "up-to-date",
+      update: null,
+      progress: null,
+      error: null,
+    });
 
     render(<UpdateCard autoCheckOnMount={false} currentVersion="2.3.4" language="zh-CN" t={t} service={service} />);
 
@@ -29,38 +50,64 @@ describe("UpdateCard", () => {
     expect(service.check).toHaveBeenCalledOnce();
   });
 
-  it("supports check, download, install and relaunch", async () => {
+  it("hydrates and renders a backend-owned download on first paint", async () => {
     const service = createService({
-      body: "Important fixes",
-      currentVersion: "2.3.4",
-      date: "2026-03-11T12:00:00Z",
-      version: "2.3.5",
+      status: "downloading",
+      update: availableUpdate(),
+      progress: { percent: 19, total: 100, transferred: 19 },
+      error: null,
     });
 
     render(<UpdateCard autoCheckOnMount={false} currentVersion="2.3.4" language="zh-CN" t={t} service={service} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "检查更新" }));
+    await screen.findByText("下载进度 19%");
+    expect(screen.getByRole("button", { name: "终止下载" })).toBeInTheDocument();
+  });
+
+  it("supports host-managed download, cancellation and relaunch", async () => {
+    const state: DesktopUpdateState = {
+      status: "available",
+      update: availableUpdate(),
+      progress: null,
+      error: null,
+    };
+    const service = createService(state);
+
+    render(<UpdateCard autoCheckOnMount={false} currentVersion="2.3.4" language="zh-CN" t={t} service={service} />);
 
     await screen.findByText("发现新版本 2.3.5");
-    expect(screen.getByText("Important fixes")).toBeInTheDocument();
-
     fireEvent.click(screen.getByRole("button", { name: "下载并安装" }));
 
-    await screen.findByText("下载进度 100%");
-    await screen.findByRole("button", { name: "立即重启" });
+    await screen.findByText("下载进度 25%");
     expect(service.downloadAndInstall).toHaveBeenCalledOnce();
 
+    fireEvent.click(screen.getByRole("button", { name: "终止下载" }));
+
+    await screen.findByText("下载已取消");
+    expect(service.cancelDownload).toHaveBeenCalledOnce();
+
+    const readyService = createService({
+      status: "ready",
+      update: availableUpdate(),
+      progress: { percent: 100, total: 100, transferred: 100 },
+      error: null,
+    });
+    render(<UpdateCard autoCheckOnMount={false} currentVersion="2.3.4" language="zh-CN" t={t} service={readyService} />);
+
+    await screen.findByRole("button", { name: "立即重启" });
     fireEvent.click(screen.getByRole("button", { name: "立即重启" }));
 
     await waitFor(() => {
-      expect(service.relaunch).toHaveBeenCalledOnce();
+      expect(readyService.relaunch).toHaveBeenCalledOnce();
     });
   });
 
   it("shows errors from failed checks", async () => {
     const service: DesktopUpdateService = {
+      getState: vi.fn().mockResolvedValue({ status: "idle", update: null, progress: null, error: null }),
       check: vi.fn().mockRejectedValue(new Error("boom")),
       downloadAndInstall: vi.fn(),
+      cancelDownload: vi.fn(),
       relaunch: vi.fn(),
     };
 
@@ -73,16 +120,13 @@ describe("UpdateCard", () => {
 
   it("shows latest version details even when automatic install is unsupported", async () => {
     const service: DesktopUpdateService = {
+      getState: vi.fn().mockResolvedValue({ status: "unsupported", update: availableUpdate(), progress: null, error: null }),
       check: vi.fn().mockResolvedValue({
         supported: false,
-        update: {
-          body: "Read-only fallback",
-          currentVersion: "2.3.4",
-          date: "2026-03-11T13:30:00Z",
-          version: "2.3.6",
-        },
+        update: availableUpdate(),
       }),
       downloadAndInstall: vi.fn(),
+      cancelDownload: vi.fn(),
       relaunch: vi.fn(),
     };
 
@@ -90,8 +134,8 @@ describe("UpdateCard", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "检查更新" }));
 
-    await screen.findByText("2.3.6");
-    expect(screen.getByText("Read-only fallback")).toBeInTheDocument();
+    await screen.findByText("2.3.5");
+    expect(screen.getByText("Important fixes")).toBeInTheDocument();
     expect(screen.getByText("当前环境不支持自动安装，但已检查到最新版本。")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "下载并安装" })).not.toBeInTheDocument();
   });
@@ -99,6 +143,7 @@ describe("UpdateCard", () => {
   it("adds a checking animation hook while the version lookup is in flight", async () => {
     let resolveCheck: ((value: { supported: boolean; update: DesktopUpdateInfo | null }) => void) | undefined;
     const service: DesktopUpdateService = {
+      getState: vi.fn().mockResolvedValue({ status: "idle", update: null, progress: null, error: null }),
       check: vi.fn().mockImplementation(
         () =>
           new Promise((resolve) => {
@@ -106,6 +151,7 @@ describe("UpdateCard", () => {
           }),
       ),
       downloadAndInstall: vi.fn(),
+      cancelDownload: vi.fn(),
       relaunch: vi.fn(),
     };
 
@@ -117,6 +163,8 @@ describe("UpdateCard", () => {
 
     resolveCheck?.({ supported: true, update: null });
 
-    await screen.findByText("已是最新版本");
+    await waitFor(() => {
+      expect(service.getState).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/features/updates/UpdateCard.tsx
+++ b/frontend/src/features/updates/UpdateCard.tsx
@@ -1,11 +1,18 @@
-import { CloudDownloadOutlined, ReloadOutlined, SyncOutlined } from "@ant-design/icons";
+import { CloudDownloadOutlined, CloseOutlined, ReloadOutlined, SyncOutlined } from "@ant-design/icons";
 import { Button, Card, Progress, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 
 import type { AppLanguage, Translator } from "../../lib/i18n";
-import { createDesktopUpdateService, type DesktopUpdateInfo, type DesktopUpdateService, type DownloadProgress } from "./updateService";
+import {
+  createDesktopUpdateService,
+  emptyUpdateState,
+  type DesktopUpdateInfo,
+  type DesktopUpdateService,
+  type DesktopUpdateState,
+} from "./updateService";
 
 const { Paragraph, Text } = Typography;
+const ACTIVE_POLL_MS = 1000;
 
 type UpdateCardProps = {
   autoCheckOnMount?: boolean;
@@ -14,16 +21,6 @@ type UpdateCardProps = {
   t: Translator;
   service?: DesktopUpdateService;
 };
-
-type UpdateViewState =
-  | { status: "idle"; message: string }
-  | { status: "checking"; message: string }
-  | { status: "up-to-date"; message: string }
-  | { status: "available"; message: string; update: DesktopUpdateInfo }
-  | { status: "downloading"; message: string; update: DesktopUpdateInfo; progress: DownloadProgress }
-  | { status: "ready"; message: string; update: DesktopUpdateInfo }
-  | { status: "unsupported"; message: string; update?: DesktopUpdateInfo }
-  | { status: "error"; message: string };
 
 function formatDate(value: string | null | undefined, language: AppLanguage) {
   if (!value) {
@@ -36,71 +33,116 @@ function formatDate(value: string | null | undefined, language: AppLanguage) {
   return date.toLocaleString(language, { hour12: false });
 }
 
+function describeState(state: DesktopUpdateState, t: Translator) {
+  switch (state.status) {
+    case "checking":
+      return t("正在检查更新…");
+    case "up-to-date":
+      return t("已是最新版本");
+    case "available":
+      return state.update ? `${t("发现新版本")} ${state.update.version}` : t("发现新版本");
+    case "downloading":
+      return `${t("下载进度")} ${Math.round(state.progress?.percent ?? 0)}%`;
+    case "ready":
+      return t("更新已安装，重启后生效");
+    case "unsupported":
+      return state.update ? t("当前环境不支持自动安装，但已检查到最新版本。") : t("当前仅桌面版支持自动更新。");
+    case "cancelled":
+      return t("下载已取消");
+    case "error":
+      return state.error || t("安装更新失败");
+    case "idle":
+    default:
+      return t("检查 GitHub Release 中的最新版本。");
+  }
+}
+
+function shouldPoll(state: DesktopUpdateState) {
+  return state.status === "checking" || state.status === "downloading";
+}
+
 export function UpdateCard({ autoCheckOnMount = true, currentVersion, language, t, service }: UpdateCardProps) {
   const updateService = useMemo(() => service ?? createDesktopUpdateService(), [service]);
-  const [state, setState] = useState<UpdateViewState>({ status: "idle", message: t("检查 GitHub Release 中的最新版本。") });
+  const [state, setState] = useState<DesktopUpdateState>(() => emptyUpdateState());
 
-  async function runCheck(silent = false) {
-    setState({ status: "checking", message: t("正在检查更新…") });
+  async function hydrate() {
+    const snapshot = await updateService.getState();
+    setState(snapshot);
+    return snapshot;
+  }
+
+  async function runCheck() {
+    setState((current) => ({ ...current, status: "checking", error: null }));
     try {
-      const result = await updateService.check(currentVersion);
-      if (!result.supported) {
-        setState({
-          status: "unsupported",
-          message: result.update ? t("当前环境不支持自动安装，但已检查到最新版本。") : t("当前仅桌面版支持自动更新。"),
-          update: result.update ?? undefined,
-        });
-        return;
-      }
-      if (!result.update) {
-        setState({ status: "up-to-date", message: t("已是最新版本") });
-        return;
-      }
-      setState({
-        status: "available",
-        message: `${t("发现新版本")} ${result.update.version}`,
-        update: result.update,
-      });
-      if (!silent) {
-        return;
-      }
+      await updateService.check(currentVersion);
+      await hydrate();
     } catch (error) {
-      setState({ status: "error", message: error instanceof Error ? t(error.message) : t("检查更新失败") });
+      setState({
+        ...emptyUpdateState("error"),
+        error: error instanceof Error ? t(error.message) : t("检查更新失败"),
+      });
     }
   }
 
   async function handleDownloadAndInstall(update: DesktopUpdateInfo) {
-    setState({
-      status: "downloading",
-      message: `${t("下载进度")} 0%`,
-      update,
-      progress: { percent: 0, total: 0, transferred: 0 },
-    });
     try {
-      await updateService.downloadAndInstall(update, (progress) => {
-        setState({
-          status: "downloading",
-          message: `${t("下载进度")} ${Math.round(progress.percent)}%`,
-          update,
-          progress,
-        });
-      });
-      setState({
-        status: "ready",
-        message: t("更新已安装，重启后生效"),
-        update,
-      });
+      await updateService.downloadAndInstall(update);
+      await hydrate();
     } catch (error) {
-      setState({ status: "error", message: error instanceof Error ? t(error.message) : t("安装更新失败") });
+      setState({
+        ...emptyUpdateState("error"),
+        update,
+        error: error instanceof Error ? t(error.message) : t("安装更新失败"),
+      });
+    }
+  }
+
+  async function handleCancel() {
+    try {
+      await updateService.cancelDownload();
+      await hydrate();
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        status: "error",
+        error: error instanceof Error ? t(error.message) : t("安装更新失败"),
+      }));
     }
   }
 
   useEffect(() => {
-    if (!autoCheckOnMount) {
+    let cancelled = false;
+
+    async function bootstrap() {
+      const snapshot = await updateService.getState();
+      if (cancelled) {
+        return;
+      }
+      setState(snapshot);
+      if (autoCheckOnMount && (snapshot.status === "idle" || snapshot.status === "up-to-date")) {
+        await runCheck();
+      }
+    }
+
+    void bootstrap();
+    return () => {
+      cancelled = true;
+    };
+  }, [autoCheckOnMount, currentVersion, updateService]);
+
+  useEffect(() => {
+    if (!shouldPoll(state)) {
       return;
     }
-    void runCheck(true);
-  }, [autoCheckOnMount]);
+    const timer = window.setInterval(() => {
+      void hydrate();
+    }, ACTIVE_POLL_MS);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [state.status, state.progress?.percent]);
+
+  const message = describeState(state, t);
 
   return (
     <Card className="settings-card update-card" variant="borderless">
@@ -113,7 +155,7 @@ export function UpdateCard({ autoCheckOnMount = true, currentVersion, language, 
           aria-label={t("检查更新")}
           icon={<SyncOutlined spin={state.status === "checking"} />}
           onClick={() => void runCheck()}
-          disabled={state.status === "checking"}
+          disabled={state.status === "checking" || state.status === "downloading"}
         >
           {t("检查更新")}
         </Button>
@@ -126,10 +168,10 @@ export function UpdateCard({ autoCheckOnMount = true, currentVersion, language, 
         </div>
         <div className="about-meta-row">
           <span>{t("状态")}</span>
-          <strong className={`update-status-value${state.status === "checking" ? " is-checking" : ""}`}>{state.message}</strong>
+          <strong className={`update-status-value${state.status === "checking" || state.status === "downloading" ? " is-checking" : ""}`}>{message}</strong>
         </div>
 
-        {"update" in state && state.update ? (
+        {state.update ? (
           <>
             <div className="about-meta-row">
               <span>{state.status === "unsupported" ? t("最新版本") : t("目标版本")}</span>
@@ -145,17 +187,22 @@ export function UpdateCard({ autoCheckOnMount = true, currentVersion, language, 
           </>
         ) : null}
 
-        {state.status === "downloading" ? <Progress percent={Math.round(state.progress.percent)} showInfo={false} /> : null}
+        {state.status === "downloading" && state.progress ? <Progress percent={Math.round(state.progress.percent)} showInfo={false} /> : null}
 
         <div className="update-card-actions">
-          {state.status === "available" ? (
+          {state.status === "available" && state.update ? (
             <Button
               aria-label={t("下载并安装")}
               type="primary"
               icon={<CloudDownloadOutlined />}
-              onClick={() => void handleDownloadAndInstall(state.update)}
+              onClick={() => void handleDownloadAndInstall(state.update!)}
             >
               {t("下载并安装")}
+            </Button>
+          ) : null}
+          {state.status === "downloading" ? (
+            <Button aria-label={t("终止下载")} icon={<CloseOutlined />} onClick={() => void handleCancel()}>
+              {t("终止下载")}
             </Button>
           ) : null}
           {state.status === "ready" ? (
@@ -163,7 +210,7 @@ export function UpdateCard({ autoCheckOnMount = true, currentVersion, language, 
               {t("立即重启")}
             </Button>
           ) : null}
-          {state.status === "unsupported" && !state.update ? <Text type="secondary">{state.message}</Text> : null}
+          {state.status === "unsupported" && !state.update ? <Text type="secondary">{message}</Text> : null}
         </div>
       </div>
     </Card>

--- a/frontend/src/features/updates/updateService.test.ts
+++ b/frontend/src/features/updates/updateService.test.ts
@@ -2,81 +2,117 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createDesktopUpdateService,
-  mapDownloadProgress,
+  emptyUpdateState,
   type DesktopUpdateAdapter,
-  type DesktopUpdateCheckResult,
+  type DesktopUpdateState,
 } from "./updateService";
 
-function buildAdapter(result: DesktopUpdateCheckResult | null): DesktopUpdateAdapter {
+function buildAdapter(state: DesktopUpdateState): DesktopUpdateAdapter {
   return {
     isSupported: () => true,
-    check: vi.fn().mockResolvedValue(result),
+    getState: vi.fn().mockResolvedValue(state),
+    check: vi.fn().mockResolvedValue(state),
+    startDownload: vi.fn().mockResolvedValue(state),
+    cancelDownload: vi.fn().mockResolvedValue({ ...state, status: "cancelled" }),
     relaunch: vi.fn().mockResolvedValue(undefined),
   };
 }
 
 describe("updateService", () => {
-  it("returns unsupported result without requesting remote metadata in web mode", async () => {
-    const fetchMock = vi.fn();
-    const service = createDesktopUpdateService({
-        isSupported: () => false,
-        check: vi.fn(),
-        relaunch: vi.fn(),
-      },
-      fetchMock as typeof fetch,
-    );
+  it("returns unsupported result without requesting desktop state in web mode", async () => {
+    const adapter: DesktopUpdateAdapter = {
+      isSupported: () => false,
+      getState: vi.fn(),
+      check: vi.fn(),
+      startDownload: vi.fn(),
+      cancelDownload: vi.fn(),
+      relaunch: vi.fn(),
+    };
+    const service = createDesktopUpdateService(adapter);
 
     await expect(service.check()).resolves.toEqual({ supported: false, update: null });
-    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(service.getState()).resolves.toEqual({ status: "unsupported", update: null, progress: null, error: null });
+    expect(adapter.check).not.toHaveBeenCalled();
+    expect(adapter.getState).not.toHaveBeenCalled();
+  });
+
+  it("hydrates an existing backend-owned downloading state", async () => {
+    const adapter = buildAdapter({
+      status: "downloading",
+      update: {
+        body: "Bug fixes",
+        currentVersion: "2.3.4",
+        date: "2026-03-11T12:00:00Z",
+        version: "2.3.5",
+      },
+      progress: { percent: 19, total: 100, transferred: 19 },
+      error: null,
+    });
+    const service = createDesktopUpdateService(adapter);
+
+    await expect(service.getState()).resolves.toEqual({
+      status: "downloading",
+      update: {
+        body: "Bug fixes",
+        currentVersion: "2.3.4",
+        date: "2026-03-11T12:00:00Z",
+        version: "2.3.5",
+      },
+      progress: { percent: 19, total: 100, transferred: 19 },
+      error: null,
+    });
   });
 
   it("returns update details when a newer release is available", async () => {
-    const downloadAndInstall = vi.fn().mockImplementation(async (handler?: (event: unknown) => void) => {
-      handler?.({ event: "Started", data: { contentLength: 100 } });
-      handler?.({ event: "Progress", data: { chunkLength: 40 } });
-      handler?.({ event: "Progress", data: { chunkLength: 60 } });
-      handler?.({ event: "Finished" });
-    });
     const adapter = buildAdapter({
-      body: "Bug fixes",
-      currentVersion: "2.3.4",
-      date: "2026-03-11T12:00:00Z",
-      downloadAndInstall,
-      version: "2.3.5",
+      status: "available",
+      update: {
+        body: "Bug fixes",
+        currentVersion: "2.3.4",
+        date: "2026-03-11T12:00:00Z",
+        version: "2.3.5",
+      },
+      progress: null,
+      error: null,
     });
     const service = createDesktopUpdateService(adapter);
-    const checkResult = await service.check();
 
-    expect(checkResult.supported).toBe(true);
-    expect(checkResult.update).toMatchObject({
-      body: "Bug fixes",
-      currentVersion: "2.3.4",
-      version: "2.3.5",
+    await expect(service.check()).resolves.toEqual({
+      supported: true,
+      update: {
+        body: "Bug fixes",
+        currentVersion: "2.3.4",
+        date: "2026-03-11T12:00:00Z",
+        version: "2.3.5",
+      },
     });
+  });
 
-    const progress = vi.fn();
-    await service.downloadAndInstall(checkResult.update!, progress);
+  it("starts a host-managed download by version and supports cancellation", async () => {
+    const adapter = buildAdapter({
+      status: "available",
+      update: {
+        currentVersion: "2.3.4",
+        version: "2.3.5",
+      },
+      progress: null,
+      error: null,
+    });
+    const service = createDesktopUpdateService(adapter);
 
-    expect(downloadAndInstall).toHaveBeenCalledOnce();
-    expect(progress.mock.calls).toEqual([[{ percent: 0, transferred: 0, total: 100 }], [{ percent: 40, transferred: 40, total: 100 }], [{ percent: 100, transferred: 100, total: 100 }], [{ percent: 100, transferred: 100, total: 100 }]]);
+    await service.downloadAndInstall({ currentVersion: "2.3.4", version: "2.3.5" });
+    await service.cancelDownload();
+
+    expect(adapter.startDownload).toHaveBeenCalledWith("2.3.5");
+    expect(adapter.cancelDownload).toHaveBeenCalledOnce();
   });
 
   it("propagates relaunch through the adapter", async () => {
-    const adapter = buildAdapter(null);
+    const adapter = buildAdapter(emptyUpdateState());
     const service = createDesktopUpdateService(adapter);
 
     await service.relaunch();
 
     expect(adapter.relaunch).toHaveBeenCalledOnce();
-  });
-
-  it("maps download progress events into deterministic UI state", () => {
-    expect(mapDownloadProgress(undefined)).toEqual({ percent: 0, total: 0, transferred: 0 });
-    expect(mapDownloadProgress({ contentLength: 200 })).toEqual({ percent: 0, total: 200, transferred: 0 });
-    expect(mapDownloadProgress({ chunkLength: 50 }, { total: 200, transferred: 25, percent: 12.5 })).toEqual({
-      percent: 37.5,
-      total: 200,
-      transferred: 75,
-    });
   });
 });

--- a/frontend/src/features/updates/updateService.ts
+++ b/frontend/src/features/updates/updateService.ts
@@ -1,5 +1,5 @@
+import { invoke } from "@tauri-apps/api/core";
 import { relaunch as tauriRelaunch } from "@tauri-apps/plugin-process";
-import { check as tauriCheck } from "@tauri-apps/plugin-updater";
 
 export type DesktopUpdateInfo = {
   body?: string | null;
@@ -14,28 +14,49 @@ export type DownloadProgress = {
   transferred: number;
 };
 
-type DownloadEvent =
-  | { event: "Started"; data: { contentLength?: number } }
-  | { event: "Progress"; data: { chunkLength?: number } }
-  | { event: "Finished" };
+export type DesktopUpdateStatus =
+  | "idle"
+  | "checking"
+  | "up-to-date"
+  | "available"
+  | "downloading"
+  | "ready"
+  | "unsupported"
+  | "cancelled"
+  | "error";
 
-type TauriUpdateResult = DesktopUpdateInfo & {
-  downloadAndInstall: (handler?: (event: DownloadEvent) => void) => Promise<void>;
+export type DesktopUpdateState = {
+  status: DesktopUpdateStatus;
+  update: DesktopUpdateInfo | null;
+  progress: DownloadProgress | null;
+  error: string | null;
 };
-
-export type DesktopUpdateCheckResult = TauriUpdateResult | null;
 
 export type DesktopUpdateAdapter = {
   isSupported: () => boolean;
-  check: () => Promise<DesktopUpdateCheckResult>;
+  getState: () => Promise<DesktopUpdateState>;
+  check: () => Promise<DesktopUpdateState>;
+  startDownload: (version: string) => Promise<DesktopUpdateState>;
+  cancelDownload: () => Promise<DesktopUpdateState>;
   relaunch: () => Promise<void>;
 };
 
 export type DesktopUpdateService = {
+  getState: () => Promise<DesktopUpdateState>;
   check: (currentVersion?: string) => Promise<{ supported: boolean; update: DesktopUpdateInfo | null }>;
-  downloadAndInstall: (update: DesktopUpdateInfo, onProgress?: (progress: DownloadProgress) => void) => Promise<void>;
+  downloadAndInstall: (update: DesktopUpdateInfo) => Promise<void>;
+  cancelDownload: () => Promise<void>;
   relaunch: () => Promise<void>;
 };
+
+export function emptyUpdateState(status: DesktopUpdateStatus = "idle"): DesktopUpdateState {
+  return {
+    status,
+    update: null,
+    progress: null,
+    error: null,
+  };
+}
 
 function isDesktopShell() {
   if (typeof window === "undefined") {
@@ -52,86 +73,50 @@ function isDesktopShell() {
   return protocol === "tauri:" || protocol === "file:";
 }
 
-export function mapDownloadProgress(
-  event?: { contentLength?: number; chunkLength?: number },
-  previous: DownloadProgress = { percent: 0, total: 0, transferred: 0 },
-): DownloadProgress {
-  if (!event) {
-    return previous;
-  }
-  if (typeof event.contentLength === "number") {
-    return {
-      percent: 0,
-      total: event.contentLength,
-      transferred: 0,
-    };
-  }
-  const transferred = previous.transferred + (event.chunkLength ?? 0);
-  const total = previous.total;
-  const percent = total > 0 ? Math.min(100, (transferred / total) * 100) : previous.percent;
-  return {
-    percent,
-    total,
-    transferred,
-  };
-}
-
 function createDefaultAdapter(): DesktopUpdateAdapter {
   return {
     isSupported: isDesktopShell,
-    check: () => tauriCheck() as Promise<DesktopUpdateCheckResult>,
+    getState: () => invoke<DesktopUpdateState>("get_update_state"),
+    check: () => invoke<DesktopUpdateState>("check_for_app_update"),
+    startDownload: (version) => invoke<DesktopUpdateState>("start_update_download", { version }),
+    cancelDownload: () => invoke<DesktopUpdateState>("cancel_update_download"),
     relaunch: () => tauriRelaunch(),
   };
 }
 
-export function createDesktopUpdateService(
-  adapter: DesktopUpdateAdapter = createDefaultAdapter(),
-  _fetchImpl: typeof fetch = ((...args) => {
-    if (typeof globalThis.fetch !== "function") {
-      throw new Error("Fetch API is unavailable");
-    }
-    return globalThis.fetch(...args);
-  }) as typeof fetch,
-): DesktopUpdateService {
-  let currentUpdate: TauriUpdateResult | null = null;
-
+export function createDesktopUpdateService(adapter: DesktopUpdateAdapter = createDefaultAdapter()): DesktopUpdateService {
   return {
+    async getState() {
+      if (!adapter.isSupported()) {
+        return {
+          ...emptyUpdateState("unsupported"),
+          error: null,
+        };
+      }
+      return adapter.getState();
+    },
     async check(currentVersion) {
       if (!adapter.isSupported()) {
-        currentUpdate = null;
         void currentVersion;
         return { supported: false, update: null };
       }
-      currentUpdate = await adapter.check();
-      if (!currentUpdate) {
-        return { supported: true, update: null };
-      }
-      const { body, currentVersion: latestCurrentVersion, date, version } = currentUpdate;
+      const state = await adapter.check();
       return {
-        supported: true,
-        update: {
-          body,
-          currentVersion: latestCurrentVersion,
-          date,
-          version,
-        },
+        supported: state.status !== "unsupported",
+        update: state.update,
       };
     },
-    async downloadAndInstall(update, onProgress) {
-      if (!currentUpdate || currentUpdate.version !== update.version) {
-        throw new Error("Update is no longer available. Check again and retry.");
+    async downloadAndInstall(update) {
+      if (!adapter.isSupported()) {
+        throw new Error("Automatic updates are only available in the desktop app.");
       }
-      let progress: DownloadProgress = { percent: 0, total: 0, transferred: 0 };
-      await currentUpdate.downloadAndInstall((event) => {
-        if (event.event === "Started") {
-          progress = mapDownloadProgress({ contentLength: event.data.contentLength }, progress);
-        } else if (event.event === "Progress") {
-          progress = mapDownloadProgress({ chunkLength: event.data.chunkLength }, progress);
-        } else {
-          progress = { ...progress, percent: 100 };
-        }
-        onProgress?.(progress);
-      });
+      await adapter.startDownload(update.version);
+    },
+    async cancelDownload() {
+      if (!adapter.isSupported()) {
+        return;
+      }
+      await adapter.cancelDownload();
     },
     relaunch: () => adapter.relaunch(),
   };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,6 +69,10 @@ export type CreateAccountPayload = {
   supports_responses?: boolean;
 };
 
+export type ShareAccountResponse = {
+  payload: string;
+};
+
 export type UsageDashboardSummary = {
   request_count: number;
   success_count: number;
@@ -287,6 +291,29 @@ export async function duplicateAccount(id: number): Promise<void> {
   if (!response.ok) {
     const details = await response.text();
     throw new Error(details || "failed to duplicate account");
+  }
+}
+
+export async function shareAccount(id: number): Promise<ShareAccountResponse> {
+  const response = await fetch(apiPath(`/accounts/${id}/share`), {
+    method: "POST",
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to share account");
+  }
+  return response.json();
+}
+
+export async function importSharedAccount(payload: string): Promise<void> {
+  const response = await fetch(apiPath("/accounts/import-shared"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ payload }),
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to import shared account");
   }
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -242,6 +242,16 @@ export async function listAccountUsage(): Promise<AccountUsageRecord[]> {
   return response.json();
 }
 
+export async function refreshAccountUsage(): Promise<void> {
+  const response = await fetch(apiPath("/accounts/usage/refresh"), {
+    method: "POST",
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to refresh account usage");
+  }
+}
+
 export function subscribeAccountRoutingStateChanged(handler: () => void): () => void {
   if (typeof window === "undefined" || typeof EventSource === "undefined") {
     return () => {};

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -133,6 +133,8 @@ const enUSMessages: Record<string, string> = {
   "检查更新失败": "Failed to check for updates",
   "下载进度": "Download progress",
   "下载并安装": "Download and install",
+  "终止下载": "Cancel download",
+  "下载已取消": "Download cancelled",
   "更新已安装，重启后生效": "The update is installed. Restart to finish applying it.",
   "安装更新失败": "Failed to install the update",
   "立即重启": "Restart now",


### PR DESCRIPTION
## Summary
- move desktop update download state and cancellation into the Tauri host so refreshes do not lose progress
- add account share/import flows, immediate usage refresh hardening, and official usage snapshot fixes
- center app modals vertically and polish related frontend flows

## Test Plan
- [x] npm --prefix frontend run test
- [x] cd backend && go test ./...
- [x] GitHub Dev CI
