### PR TITLE
feat: add managed lua usage editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ desktop/src-tauri/target/
 *.db
 *.sqlite
 *.sqlite3
+backend/data/
 
 # Local one-off/generated artifacts
 .tmp-app-server-hooks.prettier.js

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@ endif
 
 .PHONY: backend frontend test smoke-third-party package-desktop
 
+BACKEND_DATABASE_PATH ?= $(CURDIR)/backend/data/dev.sqlite
+
 backend:
-	cd backend && go run ./cmd/routerd
+	mkdir -p backend/data
+	cd backend && CODEX_ROUTER_DATABASE_PATH="$(BACKEND_DATABASE_PATH)" go run ./cmd/routerd
 
 frontend:
 	npm --prefix frontend run dev

--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -22,6 +22,8 @@ import (
 	providercodex "github.com/gcssloop/codex-router/backend/internal/providers/codex"
 	provideropenai "github.com/gcssloop/codex-router/backend/internal/providers/openai"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
+	luadrv "github.com/gcssloop/codex-router/backend/internal/usagedrv/lua"
+	driverregistry "github.com/gcssloop/codex-router/backend/internal/usagedrv/registry"
 )
 
 const officialOpenAIBaseURL = "https://api.openai.com/v1"
@@ -35,6 +37,9 @@ type AccountsHandler struct {
 	stateEvents *StateEventBus
 	refresher   AccountsUsageRefresher
 	refreshTTL  time.Duration
+	drivers     *driverregistry.Registry
+	luaScripts  *luadrv.ManagedScriptStore
+	luaRuntime  *luadrv.Runtime
 }
 
 type AccountsHandlerOption func(*AccountsHandler)
@@ -48,6 +53,28 @@ func WithAccountsStateEvents(bus *StateEventBus) AccountsHandlerOption {
 func WithAccountsUsageRefresher(refresher AccountsUsageRefresher) AccountsHandlerOption {
 	return func(handler *AccountsHandler) {
 		handler.refresher = refresher
+	}
+}
+
+func WithAccountsDriverRegistry(reg *driverregistry.Registry) AccountsHandlerOption {
+	return func(handler *AccountsHandler) {
+		handler.drivers = reg
+	}
+}
+
+func WithAccountsLuaScriptRoot(root string) AccountsHandlerOption {
+	return func(handler *AccountsHandler) {
+		if strings.TrimSpace(root) == "" {
+			return
+		}
+		store, err := luadrv.NewManagedScriptStore(root)
+		if err != nil {
+			return
+		}
+		handler.luaScripts = store
+		if handler.luaRuntime == nil {
+			handler.luaRuntime = luadrv.NewRuntime(handler.client, "")
+		}
 	}
 }
 
@@ -95,6 +122,12 @@ func (h *AccountsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.importCurrentAuth(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/accounts/import-shared":
 		h.importSharedAccount(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/accounts/usage-scripts":
+		h.listLuaUsageScripts(w)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/accounts/usage-scripts/"):
+		h.getLuaUsageScript(w, r)
+	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/accounts/usage-scripts/"):
+		h.putLuaUsageScript(w, r)
 	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/accounts/") && countPathSegments(r.URL.Path) == 2:
 		h.updateAccount(w, r)
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/accounts/") && countPathSegments(r.URL.Path) == 2:
@@ -105,6 +138,8 @@ func (h *AccountsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.shareAccount(w, r)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/accounts/") && strings.HasSuffix(r.URL.Path, "/test"):
 		h.testAccount(w, r)
+	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/accounts/") && strings.HasSuffix(r.URL.Path, "/usage-lua-test"):
+		h.testLuaUsage(w, r)
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/accounts/") && strings.HasSuffix(r.URL.Path, "/ppchat-token-logs"):
 		h.getPPChatTokenLogs(w, r)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/accounts/") && strings.HasSuffix(r.URL.Path, "/disable"):
@@ -185,6 +220,24 @@ type accountTestResponse struct {
 type accountChatTestRequest struct {
 	Model string `json:"model"`
 	Input string `json:"input"`
+}
+
+type luaUsageScriptRequest struct {
+	Content string `json:"content"`
+}
+
+type luaUsageScriptResponse struct {
+	Key     string `json:"key"`
+	Content string `json:"content,omitempty"`
+}
+
+type luaUsageScriptListResponse struct {
+	Items []string `json:"items"`
+}
+
+type luaUsageTestRequest struct {
+	UsageConfigJSON string `json:"usage_config_json"`
+	ScriptContent   string `json:"script_content"`
 }
 
 const accountShareKind = "aigate-account-share"
@@ -743,6 +796,153 @@ func (h *AccountsHandler) testAccount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, h.runAccountTest(r.Context(), account, credential, reqBody.Model, reqBody.Input))
+}
+
+func (h *AccountsHandler) getLuaUsageScript(w http.ResponseWriter, r *http.Request) {
+	key := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/accounts/usage-scripts/"))
+	if h.luaScripts == nil {
+		http.Error(w, "lua script storage is not configured", http.StatusNotFound)
+		return
+	}
+	content, err := h.luaScripts.Load(key)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, luaUsageScriptResponse{Key: key, Content: content})
+}
+
+func (h *AccountsHandler) listLuaUsageScripts(w http.ResponseWriter) {
+	if h.luaScripts == nil {
+		http.Error(w, "lua script storage is not configured", http.StatusNotFound)
+		return
+	}
+	items, err := h.luaScripts.List()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, luaUsageScriptListResponse{Items: items})
+}
+
+func (h *AccountsHandler) putLuaUsageScript(w http.ResponseWriter, r *http.Request) {
+	key := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/accounts/usage-scripts/"))
+	if h.luaScripts == nil {
+		http.Error(w, "lua script storage is not configured", http.StatusNotFound)
+		return
+	}
+	var req luaUsageScriptRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Content) == "" {
+		http.Error(w, "script content is required", http.StatusBadRequest)
+		return
+	}
+	if err := h.luaScripts.Save(key, req.Content); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, luaUsageScriptResponse{Key: key})
+}
+
+func (h *AccountsHandler) testLuaUsage(w http.ResponseWriter, r *http.Request) {
+	id, err := accountIDFromPath(strings.TrimSuffix(strings.TrimSuffix(r.URL.Path, "/usage-lua-test"), "/"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if h.drivers == nil {
+		http.Error(w, "driver registry is not configured", http.StatusInternalServerError)
+		return
+	}
+	account, err := h.repo.GetByID(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	var req luaUsageTestRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	configJSON := strings.TrimSpace(req.UsageConfigJSON)
+	if configJSON == "" {
+		configJSON = account.UsageConfigJSON
+	}
+	cfg, err := luadrv.ParseDriverConfig(configJSON)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	account.UsageDriver = "lua"
+	account.UsageConfigJSON = configJSON
+
+	accountDriver, err := h.drivers.AccountDriverFor(account)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	credential, err := accountDriver.Resolve(r.Context(), account)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	scriptContent := strings.TrimSpace(req.ScriptContent)
+	if scriptContent == "" {
+		if key, ok := luadrv.ParseManagedScriptKey(cfg.Script); ok && h.luaScripts != nil {
+			scriptContent, err = h.luaScripts.Load(key)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		} else {
+			http.Error(w, "script_content is required for non-managed lua test", http.StatusBadRequest)
+			return
+		}
+	}
+
+	if h.luaRuntime == nil {
+		h.luaRuntime = luadrv.NewRuntime(h.client, "")
+	}
+	result, err := h.luaRuntime.ExecuteSource(r.Context(), scriptContent, cfg.Script, account, credential, cfg.Raw)
+	if err != nil {
+		writeJSON(w, http.StatusOK, accountTestResponse{
+			OK:      false,
+			Message: "Lua usage 测试失败",
+			Details: err.Error(),
+		})
+		return
+	}
+	pretty, err := json.MarshalIndent(map[string]any{
+		"source":                 result.Source,
+		"confidence":             result.Confidence,
+		"balance":                result.Limits.Balance,
+		"quota_remaining":        result.Limits.QuotaRemaining,
+		"rpm_remaining":          result.Limits.RPMRemaining,
+		"tpm_remaining":          result.Limits.TPMRemaining,
+		"daily_remaining":        result.Limits.DailyRemaining,
+		"monthly_remaining":      result.Limits.MonthlyRemaining,
+		"primary_used_percent":   result.Limits.PrimaryUsedPercent,
+		"secondary_used_percent": result.Limits.SecondaryUsedPercent,
+		"primary_resets_at":      result.Limits.PrimaryResetsAt,
+		"secondary_resets_at":    result.Limits.SecondaryResetsAt,
+		"meta":                   result.Meta,
+		"payload":                result.Payload,
+	}, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, accountTestResponse{
+		OK:      true,
+		Message: "Lua usage 测试成功",
+		Details: "脚本已返回标准化 usage 结果",
+		Content: string(pretty),
+	})
 }
 
 func (h *AccountsHandler) getPPChatTokenLogs(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/accounts_handler_lua_test.go
+++ b/backend/internal/api/accounts_handler_lua_test.go
@@ -1,0 +1,226 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gcssloop/codex-router/backend/internal/accountdrv"
+	"github.com/gcssloop/codex-router/backend/internal/accounts"
+	"github.com/gcssloop/codex-router/backend/internal/api"
+	"github.com/gcssloop/codex-router/backend/internal/auth"
+	sqlitestore "github.com/gcssloop/codex-router/backend/internal/store/sqlite"
+	"github.com/gcssloop/codex-router/backend/internal/usagedrv"
+	luadrv "github.com/gcssloop/codex-router/backend/internal/usagedrv/lua"
+	"github.com/gcssloop/codex-router/backend/internal/usagedrv/registry"
+)
+
+func TestAccountsHandlerManagedLuaScriptCRUD(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	scriptRoot := filepath.Join(t.TempDir(), "usage-scripts")
+	handler := api.NewAccountsHandler(
+		repo,
+		nil,
+		auth.NewOAuthConnector(auth.Config{}),
+		auth.NewStateStore(5*time.Minute),
+		api.WithAccountsLuaScriptRoot(scriptRoot),
+	)
+
+	putReq := httptest.NewRequest(http.MethodPut, "/accounts/usage-scripts/vendor_shared", bytes.NewBufferString(`{
+		"content":"function fetch_usage(ctx)\n  return { ok = true, source = \"remote\", confidence = \"high\", limits = { quota_remaining = 123 } }\nend\n"
+	}`))
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	handler.ServeHTTP(putRec, putReq)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT /accounts/usage-scripts/vendor_shared status = %d, want %d body=%s", putRec.Code, http.StatusOK, putRec.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/accounts/usage-scripts/vendor_shared", nil)
+	getRec := httptest.NewRecorder()
+	handler.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET /accounts/usage-scripts/vendor_shared status = %d, want %d body=%s", getRec.Code, http.StatusOK, getRec.Body.String())
+	}
+
+	var payload struct {
+		Key     string `json:"key"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if payload.Key != "vendor_shared" {
+		t.Fatalf("key = %q, want vendor_shared", payload.Key)
+	}
+	if !strings.Contains(payload.Content, "fetch_usage") {
+		t.Fatalf("content = %q, want fetch_usage body", payload.Content)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/accounts/usage-scripts", nil)
+	listRec := httptest.NewRecorder()
+	handler.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("GET /accounts/usage-scripts status = %d, want %d body=%s", listRec.Code, http.StatusOK, listRec.Body.String())
+	}
+	var listed struct {
+		Items []string `json:"items"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("Unmarshal list returned error: %v", err)
+	}
+	if len(listed.Items) != 1 || listed.Items[0] != "vendor_shared" {
+		t.Fatalf("items = %#v, want [vendor_shared]", listed.Items)
+	}
+}
+
+func TestAccountsHandlerLuaUsageTestExecutesWithRealCredential(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-live" {
+			t.Fatalf("Authorization = %q, want Bearer sk-live", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"quota_remaining":4321,"rpm_remaining":21}`))
+	}))
+	defer upstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	if err := repo.Create(accounts.Account{
+		ProviderType:    accounts.ProviderOpenAICompatible,
+		AccountName:     "vendor-lua",
+		AuthMode:        accounts.AuthModeAPIKey,
+		BaseURL:         "https://mirror.example.test/v1",
+		CredentialRef:   "sk-live",
+		AccountDriver:   "builtin_api_key",
+		UsageDriver:     "lua",
+		UsageConfigJSON: `{"script":"managed:vendor_shared","endpoint":"` + upstream.URL + `/usage"}`,
+		Status:          accounts.StatusActive,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	scriptRoot := filepath.Join(t.TempDir(), "usage-scripts")
+	luaDriver := luadrv.NewDriver(http.DefaultClient, "", luadrv.WithManagedScriptRoot(scriptRoot))
+	driverRegistry, err := registry.New(
+		[]accountdrv.AccountDriver{
+			accountdrv.NewOfficialDriver(http.DefaultClient, repo),
+			accountdrv.NewAPIKeyDriver(),
+		},
+		[]usagedrv.UsageDriver{luaDriver},
+	)
+	if err != nil {
+		t.Fatalf("registry.New returned error: %v", err)
+	}
+
+	handler := api.NewAccountsHandler(
+		repo,
+		nil,
+		auth.NewOAuthConnector(auth.Config{}),
+		auth.NewStateStore(5*time.Minute),
+		api.WithAccountsLuaScriptRoot(scriptRoot),
+		api.WithAccountsDriverRegistry(driverRegistry),
+	)
+
+	seedReq := httptest.NewRequest(http.MethodPut, "/accounts/usage-scripts/vendor_shared", bytes.NewBufferString(`{
+		"content":"function fetch_usage(ctx)\n  local response = ctx.host.http_get({ url = ctx.config.endpoint, headers = { Authorization = 'Bearer ' .. ctx.credential.access_token } })\n  local payload = ctx.host.json_decode(response.body)\n  return { ok = true, source = 'remote', confidence = 'high', limits = { quota_remaining = payload.quota_remaining, rpm_remaining = payload.rpm_remaining }, meta = { account_name = ctx.account.account_name } }\nend\n"
+	}`))
+	seedReq.Header.Set("Content-Type", "application/json")
+	seedRec := httptest.NewRecorder()
+	handler.ServeHTTP(seedRec, seedReq)
+	if seedRec.Code != http.StatusOK {
+		t.Fatalf("seed PUT status = %d, want %d body=%s", seedRec.Code, http.StatusOK, seedRec.Body.String())
+	}
+
+	testReq := httptest.NewRequest(http.MethodPost, "/accounts/1/usage-lua-test", bytes.NewBufferString(`{
+		"usage_config_json":"{\"script\":\"managed:vendor_shared\",\"endpoint\":\"`+upstream.URL+`/usage\"}",
+		"script_content":"function fetch_usage(ctx)\n  local response = ctx.host.http_get({ url = ctx.config.endpoint, headers = { Authorization = 'Bearer ' .. ctx.credential.access_token } })\n  local payload = ctx.host.json_decode(response.body)\n  return { ok = true, source = 'remote', confidence = 'high', limits = { quota_remaining = payload.quota_remaining, rpm_remaining = payload.rpm_remaining }, meta = { account_name = ctx.account.account_name } }\nend\n"
+	}`))
+	testReq.Header.Set("Content-Type", "application/json")
+	testRec := httptest.NewRecorder()
+	handler.ServeHTTP(testRec, testReq)
+	if testRec.Code != http.StatusOK {
+		t.Fatalf("POST /accounts/1/usage-lua-test status = %d, want %d body=%s", testRec.Code, http.StatusOK, testRec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(testRec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if payload["ok"] != true {
+		t.Fatalf("ok = %v, want true", payload["ok"])
+	}
+	content, _ := payload["content"].(string)
+	if !strings.Contains(content, `"quota_remaining": 4321`) {
+		t.Fatalf("content = %q, want quota_remaining output", content)
+	}
+	if !strings.Contains(content, `"account_name": "vendor-lua"`) {
+		t.Fatalf("content = %q, want account_name in meta", content)
+	}
+}
+
+func TestAccountsHandlerLuaUsageTestRejectsMalformedConfig(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	if err := repo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "vendor-lua",
+		AuthMode:      accounts.AuthModeAPIKey,
+		CredentialRef: "sk-live",
+		UsageDriver:   "lua",
+		Status:        accounts.StatusActive,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	driverRegistry, err := registry.New(
+		[]accountdrv.AccountDriver{accountdrv.NewAPIKeyDriver()},
+		[]usagedrv.UsageDriver{luadrv.NewDriver(http.DefaultClient, "")},
+	)
+	if err != nil {
+		t.Fatalf("registry.New returned error: %v", err)
+	}
+
+	handler := api.NewAccountsHandler(
+		repo,
+		nil,
+		auth.NewOAuthConnector(auth.Config{}),
+		auth.NewStateStore(5*time.Minute),
+		api.WithAccountsDriverRegistry(driverRegistry),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/accounts/1/usage-lua-test", bytes.NewBufferString(`{"usage_config_json":"{"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST /accounts/1/usage-lua-test status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"path/filepath"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -53,6 +54,7 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 	if cfg.DatabasePath == "" {
 		return nil, errors.New("database path is required")
 	}
+	luaScriptRoot := filepath.Join(filepath.Dir(cfg.DatabasePath), "usage-scripts")
 
 	store, err := sqlite.Open(cfg.DatabasePath)
 	if err != nil {
@@ -88,7 +90,7 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 		[]usagedrv.UsageDriver{
 			builtin.NewOpenAIOfficialDriver(http.DefaultClient),
 			builtin.NewPPChatDriver(http.DefaultClient),
-			luadrv.NewDriver(http.DefaultClient, ""),
+			luadrv.NewDriver(http.DefaultClient, "", luadrv.WithManagedScriptRoot(luaScriptRoot)),
 		},
 	)
 	if err != nil {
@@ -103,6 +105,8 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 		stateStore,
 		api.WithAccountsStateEvents(stateEvents),
 		api.WithAccountsUsageRefresher(refreshOrchestrator),
+		api.WithAccountsDriverRegistry(driverRegistry),
+		api.WithAccountsLuaScriptRoot(luaScriptRoot),
 	)
 	conversationsHandler := api.NewConversationsHandler(conversationRepo)
 

--- a/backend/internal/store/sqlite/store.go
+++ b/backend/internal/store/sqlite/store.go
@@ -3,8 +3,10 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
@@ -18,14 +20,19 @@ func Open(path string) (*Store, error) {
 		return nil, fmt.Errorf("create sqlite directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", path)
+	db, err := sql.Open("sqlite", sqliteDSN(path))
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite database: %w", err)
 	}
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(4)
 
 	store := &Store{db: db}
 	if err := store.migrate(); err != nil {
 		_ = db.Close()
+		if isSQLiteBusy(err) {
+			return nil, fmt.Errorf("run migration: %w; database path %s is busy, another AI Gate instance may be using the same database", err, path)
+		}
 		return nil, err
 	}
 
@@ -51,6 +58,23 @@ func (s *Store) HasTable(name string) (bool, error) {
 	}
 
 	return exists, nil
+}
+
+func sqliteDSN(path string) string {
+	values := url.Values{}
+	values.Add("_pragma", "journal_mode(WAL)")
+	values.Add("_pragma", "busy_timeout(5000)")
+	values.Add("_pragma", "synchronous(NORMAL)")
+	values.Add("_pragma", "foreign_keys(ON)")
+	return fmt.Sprintf("file:%s?%s", path, values.Encode())
+}
+
+func isSQLiteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "database is locked") || strings.Contains(text, "sqlite_busy")
 }
 
 func (s *Store) migrate() error {

--- a/backend/internal/store/sqlite/store_test.go
+++ b/backend/internal/store/sqlite/store_test.go
@@ -1,8 +1,13 @@
 package sqlite_test
 
 import (
+	"database/sql"
+	"errors"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gcssloop/codex-router/backend/internal/store/sqlite"
 )
@@ -87,4 +92,103 @@ func TestOpenAddsSnapshotMetadataColumns(t *testing.T) {
 			t.Fatalf("column %q count = %d, want 1", column, count)
 		}
 	}
+}
+
+func TestOpenConfiguresSQLiteForBusyDesktopWorkload(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "codex-router.sqlite")
+
+	store, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	var journalMode string
+	if err := store.DB().QueryRow(`PRAGMA journal_mode;`).Scan(&journalMode); err != nil {
+		t.Fatalf("QueryRow(journal_mode) returned error: %v", err)
+	}
+	if strings.ToLower(journalMode) != "wal" {
+		t.Fatalf("journal_mode = %q, want wal", journalMode)
+	}
+
+	var busyTimeout int
+	if err := store.DB().QueryRow(`PRAGMA busy_timeout;`).Scan(&busyTimeout); err != nil {
+		t.Fatalf("QueryRow(busy_timeout) returned error: %v", err)
+	}
+	if busyTimeout < 5000 {
+		t.Fatalf("busy_timeout = %d, want >= 5000", busyTimeout)
+	}
+
+}
+
+func TestOpenAvoidsSQLITEBUSYDuringConcurrentReadWrite(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "codex-router.sqlite")
+
+	store, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	if _, err := store.DB().Exec(`INSERT INTO accounts (provider_type, account_name, source_icon, auth_mode, credential_ref, base_url, status, priority, is_active, supports_responses)
+		VALUES ('openai-compatible', 'busy-check', 'openai', 'api_key', 'secret', 'https://example.test/v1', 'active', 1, 1, 1)`); err != nil {
+		t.Fatalf("seed account returned error: %v", err)
+	}
+
+	tx, err := store.DB().Begin()
+	if err != nil {
+		t.Fatalf("Begin returned error: %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	if _, err := tx.Exec(`UPDATE accounts SET status = 'cooldown' WHERE id = 1`); err != nil {
+		t.Fatalf("UPDATE inside transaction returned error: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	started := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(started)
+		var count int
+		err := store.DB().QueryRow(`SELECT COUNT(*) FROM accounts`).Scan(&count)
+		errCh <- err
+	}()
+
+	<-started
+	time.Sleep(150 * time.Millisecond)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit returned error: %v", err)
+	}
+	wg.Wait()
+
+	if err := <-errCh; err != nil {
+		if sqliteBusy(err) {
+			t.Fatalf("concurrent read returned SQLITE_BUSY: %v", err)
+		}
+		t.Fatalf("concurrent read returned error: %v", err)
+	}
+}
+
+func sqliteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, sql.ErrConnDone) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "database is locked") ||
+		strings.Contains(strings.ToLower(err.Error()), "sqlite_busy")
 }

--- a/backend/internal/usagedrv/lua/driver.go
+++ b/backend/internal/usagedrv/lua/driver.go
@@ -17,7 +17,8 @@ import (
 )
 
 type Driver struct {
-	runtime *Runtime
+	runtime      *Runtime
+	managedStore *ManagedScriptStore
 }
 
 type DriverConfig struct {
@@ -26,10 +27,38 @@ type DriverConfig struct {
 	Raw       map[string]any `json:"-"`
 }
 
-func NewDriver(client *http.Client, baseDir string) *Driver {
-	return &Driver{
+type DriverOption func(*Driver)
+
+func WithManagedScriptRoot(root string) DriverOption {
+	return func(driver *Driver) {
+		if driver == nil || strings.TrimSpace(root) == "" {
+			return
+		}
+		store, err := NewManagedScriptStore(root)
+		if err == nil {
+			driver.managedStore = store
+		}
+	}
+}
+
+func WithManagedScriptStore(store *ManagedScriptStore) DriverOption {
+	return func(driver *Driver) {
+		if driver != nil {
+			driver.managedStore = store
+		}
+	}
+}
+
+func NewDriver(client *http.Client, baseDir string, opts ...DriverOption) *Driver {
+	driver := &Driver{
 		runtime: NewRuntime(client, baseDir),
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(driver)
+		}
+	}
+	return driver
 }
 
 func NewDriverWithRuntime(runtime *Runtime) *Driver {
@@ -45,7 +74,7 @@ func (d *Driver) Supports(account accounts.Account) bool {
 }
 
 func (d *Driver) Fetch(ctx context.Context, account accounts.Account, credential accountdrv.ResolvedCredential) (usagedrv.RawUsageResult, error) {
-	config, err := parseDriverConfig(account.UsageConfigJSON)
+	config, err := ParseDriverConfig(account.UsageConfigJSON)
 	if err != nil {
 		return usagedrv.RawUsageResult{}, err
 	}
@@ -61,10 +90,21 @@ func (d *Driver) Fetch(ctx context.Context, account accounts.Account, credential
 		d.runtime = NewRuntime(nil, "")
 	}
 
+	if key, ok := ParseManagedScriptKey(config.Script); ok {
+		if d.managedStore == nil {
+			return usagedrv.RawUsageResult{}, fmt.Errorf("managed script store is not configured")
+		}
+		source, err := d.managedStore.Load(key)
+		if err != nil {
+			return usagedrv.RawUsageResult{}, err
+		}
+		return d.runtime.ExecuteSource(callCtx, source, "managed:"+key, account, credential, config.Raw)
+	}
+
 	return d.runtime.Execute(callCtx, config.Script, account, credential, config.Raw)
 }
 
-func parseDriverConfig(raw string) (DriverConfig, error) {
+func ParseDriverConfig(raw string) (DriverConfig, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return DriverConfig{}, fmt.Errorf("lua usage config is empty")

--- a/backend/internal/usagedrv/lua/managed_scripts_test.go
+++ b/backend/internal/usagedrv/lua/managed_scripts_test.go
@@ -1,0 +1,71 @@
+package lua_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/gcssloop/codex-router/backend/internal/accountdrv"
+	"github.com/gcssloop/codex-router/backend/internal/accounts"
+	luadrv "github.com/gcssloop/codex-router/backend/internal/usagedrv/lua"
+)
+
+func TestLuaDriverFetchesManagedScript(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-managed" {
+			t.Fatalf("Authorization = %q, want Bearer sk-managed", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"quota_remaining":2468}`))
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	manager, err := luadrv.NewManagedScriptStore(root)
+	if err != nil {
+		t.Fatalf("NewManagedScriptStore returned error: %v", err)
+	}
+	if err := manager.Save("vendor_shared", `function fetch_usage(ctx)
+  local response = ctx.host.http_get({ url = ctx.config.endpoint, headers = { Authorization = "Bearer " .. ctx.credential.access_token } })
+  local payload = ctx.host.json_decode(response.body)
+  return {
+    ok = true,
+    source = "remote",
+    confidence = "high",
+    limits = {
+      quota_remaining = payload.quota_remaining
+    }
+  }
+end
+`); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	driver := luadrv.NewDriver(nil, moduleRoot(t), luadrv.WithManagedScriptRoot(root))
+	result, err := driver.Fetch(context.Background(), accounts.Account{
+		UsageDriver:     "lua",
+		UsageConfigJSON: `{"script":"managed:vendor_shared","endpoint":"` + server.URL + `/usage"}`,
+	}, accountdrv.ResolvedCredential{AccessToken: "sk-managed"})
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if result.Limits.QuotaRemaining == nil || *result.Limits.QuotaRemaining != 2468 {
+		t.Fatalf("QuotaRemaining = %#v, want 2468", result.Limits.QuotaRemaining)
+	}
+}
+
+func TestManagedScriptStoreRejectsInvalidKey(t *testing.T) {
+	t.Parallel()
+
+	manager, err := luadrv.NewManagedScriptStore(filepath.Join(t.TempDir(), "usage-scripts"))
+	if err != nil {
+		t.Fatalf("NewManagedScriptStore returned error: %v", err)
+	}
+	if err := manager.Save("../escape", "function fetch_usage(ctx) return { ok = true, limits = {} } end"); err == nil {
+		t.Fatal("Save returned nil error, want invalid key error")
+	}
+}

--- a/backend/internal/usagedrv/lua/runtime.go
+++ b/backend/internal/usagedrv/lua/runtime.go
@@ -35,7 +35,14 @@ func (r *Runtime) Execute(ctx context.Context, script string, account accounts.A
 	if err != nil {
 		return usagedrv.RawUsageResult{}, err
 	}
+	rawScript, err := os.ReadFile(resolvedScript)
+	if err != nil {
+		return usagedrv.RawUsageResult{}, fmt.Errorf("lua read script: %w", err)
+	}
+	return r.ExecuteSource(ctx, string(rawScript), resolvedScript, account, credential, config)
+}
 
+func (r *Runtime) ExecuteSource(ctx context.Context, source string, sourceName string, account accounts.Account, credential accountdrv.ResolvedCredential, config map[string]any) (usagedrv.RawUsageResult, error) {
 	L := golua.NewState(golua.Options{
 		SkipOpenLibs: true,
 	})
@@ -46,11 +53,14 @@ func (r *Runtime) Execute(ctx context.Context, script string, account accounts.A
 		return usagedrv.RawUsageResult{}, err
 	}
 
-	if err := L.DoFile(resolvedScript); err != nil {
+	if strings.TrimSpace(sourceName) == "" {
+		sourceName = "inline.lua"
+	}
+	if err := L.DoString(source); err != nil {
 		if ctx.Err() != nil {
 			return usagedrv.RawUsageResult{}, fmt.Errorf("lua runtime timeout: %w", ctx.Err())
 		}
-		return usagedrv.RawUsageResult{}, fmt.Errorf("lua load script: %w", err)
+		return usagedrv.RawUsageResult{}, fmt.Errorf("lua load script %s: %w", sourceName, err)
 	}
 
 	fn := L.GetGlobal("fetch_usage")

--- a/backend/internal/usagedrv/lua/scripts.go
+++ b/backend/internal/usagedrv/lua/scripts.go
@@ -1,0 +1,120 @@
+package lua
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var managedScriptKeyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`)
+
+type ManagedScriptStore struct {
+	root string
+}
+
+func NewManagedScriptStore(root string) (*ManagedScriptStore, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, fmt.Errorf("managed script root is required")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve managed script root: %w", err)
+	}
+	if err := os.MkdirAll(absRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir managed script root: %w", err)
+	}
+	return &ManagedScriptStore{root: absRoot}, nil
+}
+
+func (s *ManagedScriptStore) Root() string {
+	if s == nil {
+		return ""
+	}
+	return s.root
+}
+
+func (s *ManagedScriptStore) Save(key string, content string) error {
+	if s == nil {
+		return fmt.Errorf("managed script store is not configured")
+	}
+	path, err := s.resolvePath(key)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o600); err != nil {
+		return fmt.Errorf("save managed script %q: %w", key, err)
+	}
+	return nil
+}
+
+func (s *ManagedScriptStore) Load(key string) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("managed script store is not configured")
+	}
+	path, err := s.resolvePath(key)
+	if err != nil {
+		return "", err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("load managed script %q: %w", key, err)
+	}
+	return string(raw), nil
+}
+
+func (s *ManagedScriptStore) PathForKey(key string) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("managed script store is not configured")
+	}
+	return s.resolvePath(key)
+}
+
+func (s *ManagedScriptStore) List() ([]string, error) {
+	if s == nil {
+		return nil, fmt.Errorf("managed script store is not configured")
+	}
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return nil, fmt.Errorf("list managed scripts: %w", err)
+	}
+	items := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".lua") {
+			continue
+		}
+		key := strings.TrimSuffix(name, ".lua")
+		if managedScriptKeyPattern.MatchString(key) {
+			items = append(items, key)
+		}
+	}
+	sort.Strings(items)
+	return items, nil
+}
+
+func ParseManagedScriptKey(script string) (string, bool) {
+	value := strings.TrimSpace(script)
+	if !strings.HasPrefix(value, "managed:") {
+		return "", false
+	}
+	key := strings.TrimSpace(strings.TrimPrefix(value, "managed:"))
+	if !managedScriptKeyPattern.MatchString(key) {
+		return "", false
+	}
+	return key, true
+}
+
+func (s *ManagedScriptStore) resolvePath(key string) (string, error) {
+	key = strings.TrimSpace(key)
+	if !managedScriptKeyPattern.MatchString(key) {
+		return "", fmt.Errorf("invalid managed script key %q", key)
+	}
+	return filepath.Join(s.root, key+".lua"), nil
+}

--- a/docs/plans/2026-03-18-lua-usage-editor-plan.md
+++ b/docs/plans/2026-03-18-lua-usage-editor-plan.md
@@ -1,0 +1,112 @@
+# Lua Usage Editor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add per-account Lua usage configuration to the account editor, including reusable script storage, AI skill copy with account context, and a real Lua test workflow.
+
+**Architecture:** Keep account records storing `usage_driver` plus JSON config, but move managed Lua source into dedicated backend-managed script storage. Add backend APIs for script CRUD and test execution, then wire the account editor to edit script references, copy a generated AI skill prompt with current account context, and run real test requests through the existing Lua runtime.
+
+**Tech Stack:** Go, SQLite, React, Ant Design, Vitest, Go `net/http/httptest`.
+
+---
+
+### Task 1: Define managed script storage contract
+
+**Files:**
+- Create: `backend/internal/usagedrv/lua/scripts.go`
+- Modify: `backend/internal/usagedrv/lua/driver.go`
+- Test: `backend/internal/usagedrv/lua/driver_test.go`
+
+**Step 1: Write failing tests**
+- Add tests that expect `usage_config_json` to support a managed script key and resolve it to stored source.
+- Add tests for invalid script key handling.
+
+**Step 2: Run targeted Go tests and confirm failure**
+Run: `go test ./backend/internal/usagedrv/lua ./backend/internal/api -run 'Lua|UsageScript'`
+Expected: failure because managed script storage is not implemented.
+
+**Step 3: Implement script storage and resolution**
+- Add a small script manager abstraction.
+- Resolve `script` config entries like `managed:<key>` into stored source before Lua execution.
+
+**Step 4: Re-run Go tests**
+Run: `go test ./backend/internal/usagedrv/lua ./backend/internal/api -run 'Lua|UsageScript'`
+Expected: tests pass.
+
+**Step 5: Commit**
+`git add backend/internal/usagedrv/lua docs/plans/2026-03-18-lua-usage-editor-plan.md && git commit -m "feat: add managed lua usage scripts"`
+
+### Task 2: Add backend APIs for script CRUD and Lua testing
+
+**Files:**
+- Modify: `backend/internal/api/accounts_handler.go`
+- Modify: `backend/internal/api/accounts_handler_test.go`
+- Modify: `backend/internal/bootstrap/bootstrap.go`
+- Modify: `backend/internal/bootstrap/bootstrap_test.go`
+
+**Step 1: Write failing tests**
+- Add API tests for loading/saving a managed script.
+- Add API tests for Lua test execution using account credentials and returning output.
+
+**Step 2: Run targeted Go tests and confirm failure**
+Run: `go test ./backend/internal/api ./backend/internal/bootstrap -run 'Lua|UsageScript'`
+Expected: route not found / handler missing failures.
+
+**Step 3: Implement APIs**
+- Add endpoints for managed usage script read/write.
+- Add an account-scoped Lua test endpoint that executes real runtime logic and returns structured output.
+- Register dependencies from bootstrap.
+
+**Step 4: Re-run Go tests**
+Run: `go test ./backend/internal/api ./backend/internal/bootstrap -run 'Lua|UsageScript'`
+Expected: pass.
+
+**Step 5: Commit**
+`git add backend/internal/api backend/internal/bootstrap && git commit -m "feat: add lua usage config APIs"`
+
+### Task 3: Add frontend account editor UI and skill copy flow
+
+**Files:**
+- Modify: `frontend/src/features/accounts/AccountsPage.tsx`
+- Modify: `frontend/src/features/accounts/AccountsPage.test.tsx`
+- Modify: `frontend/src/lib/api.ts`
+
+**Step 1: Write failing frontend tests**
+- Add tests for showing Lua config fields in edit modal.
+- Add tests for copying the generated skill prompt with account context.
+- Add tests for test execution output rendering.
+
+**Step 2: Run targeted frontend tests and confirm failure**
+Run: `npm test -- --run frontend/src/features/accounts/AccountsPage.test.tsx`
+Expected: failures because the UI and APIs do not exist yet.
+
+**Step 3: Implement UI**
+- Add a Lua usage section in the edit modal.
+- Include managed script key, Lua textarea, config JSON, copy-skill action, test action, and output panel.
+- Load and save managed scripts via the new backend APIs.
+
+**Step 4: Re-run frontend tests**
+Run: `npm test -- --run frontend/src/features/accounts/AccountsPage.test.tsx`
+Expected: pass.
+
+**Step 5: Commit**
+`git add frontend/src/features/accounts/AccountsPage.tsx frontend/src/features/accounts/AccountsPage.test.tsx frontend/src/lib/api.ts && git commit -m "feat: add lua usage editor UI"`
+
+### Task 4: Verify end-to-end behavior
+
+**Files:**
+- Modify as needed from previous tasks.
+
+**Step 1: Run focused verification**
+Run: `go test ./backend/internal/usagedrv/lua ./backend/internal/api ./backend/internal/bootstrap`
+Run: `npm test -- --run frontend/src/features/accounts/AccountsPage.test.tsx`
+
+**Step 2: Run broader regression checks if focused tests pass**
+Run: `go test ./...`
+Run: `npm test -- --run`
+
+**Step 3: Fix any regressions**
+- Keep changes minimal and scoped.
+
+**Step 4: Final review and summary**
+- Confirm API shapes, managed script persistence, and UI copy/test workflow.

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { App as AntApp, ConfigProvider } from "antd";
 
 import { refreshDesktopTrayState } from "../../lib/desktop-shell";
@@ -58,16 +64,33 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
         return Promise.resolve(listResponse());
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/import-current" && init?.method === "POST") {
+      if (
+        url === "/ai-router/api/accounts/import-current" &&
+        init?.method === "POST"
+      ) {
         return Promise.resolve(new Response(null, { status: 201 }));
       }
-      if (url === "/ai-router/api/accounts/usage/refresh" && init?.method === "POST") {
+      if (
+        url === "/ai-router/api/accounts/usage/refresh" &&
+        init?.method === "POST"
+      ) {
         return Promise.resolve(new Response(null, { status: 204 }));
       }
       if (url === "/ai-router/api/accounts" && init?.method === "POST") {
@@ -92,14 +115,22 @@ describe("AccountsPage", () => {
           ),
         );
       }
-      if (url.startsWith("/ai-router/api/accounts/1/ppchat-token-logs") && (!init?.method || init.method === "GET")) {
+      if (
+        url.startsWith("/ai-router/api/accounts/1/ppchat-token-logs") &&
+        (!init?.method || init.method === "GET")
+      ) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
               success: true,
               data: {
                 logs: [],
-                pagination: { page: 1, page_size: 10, total: 0, total_pages: 0 },
+                pagination: {
+                  page: 1,
+                  page_size: 10,
+                  total: 0,
+                  total_pages: 0,
+                },
                 token_info: {
                   name: "edwardtoday-xmax",
                   today_usage_count: 172,
@@ -124,17 +155,25 @@ describe("AccountsPage", () => {
     renderAccountsPage();
 
     expect(await screen.findByText("mirror-east")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "账户列表" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "账户列表" }),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /添加账户/ }));
     fireEvent.click(await screen.findByText("官方账户"));
 
-    const officialModal = await screen.findByRole("dialog", { name: "添加官方账户" });
-    expect(officialModal.closest(".ant-modal-wrap")).toHaveClass("ant-modal-centered");
+    const officialModal = await screen.findByRole("dialog", {
+      name: "添加官方账户",
+    });
+    expect(officialModal.closest(".ant-modal-wrap")).toHaveClass(
+      "ant-modal-centered",
+    );
     fireEvent.change(within(officialModal).getByLabelText("账户名称"), {
       target: { value: "current-codex" },
     });
-    fireEvent.click(within(officialModal).getByRole("button", { name: /导\s*入/ }));
+    fireEvent.click(
+      within(officialModal).getByRole("button", { name: /导\s*入/ }),
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -155,8 +194,12 @@ describe("AccountsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /添加账户/ }));
     fireEvent.click(await screen.findByText("第三方账户"));
 
-    const thirdPartyModal = await screen.findByRole("dialog", { name: "添加第三方账户" });
-    expect(within(thirdPartyModal).queryByLabelText("原生 /responses")).not.toBeInTheDocument();
+    const thirdPartyModal = await screen.findByRole("dialog", {
+      name: "添加第三方账户",
+    });
+    expect(
+      within(thirdPartyModal).queryByLabelText("原生 /responses"),
+    ).not.toBeInTheDocument();
     fireEvent.change(within(thirdPartyModal).getByLabelText("账户名称"), {
       target: { value: "ppchat-main" },
     });
@@ -166,7 +209,9 @@ describe("AccountsPage", () => {
     fireEvent.change(within(thirdPartyModal).getByLabelText("API Key"), {
       target: { value: "sk-test" },
     });
-    fireEvent.click(within(thirdPartyModal).getByRole("button", { name: /保\s*存/ }));
+    fireEvent.click(
+      within(thirdPartyModal).getByRole("button", { name: /保\s*存/ }),
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -188,7 +233,9 @@ describe("AccountsPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "编辑-mirror-east" }));
     const editModal = await screen.findByRole("dialog", { name: "编辑账户" });
-    expect(within(editModal).queryByLabelText("原生 /responses")).not.toBeInTheDocument();
+    expect(
+      within(editModal).queryByLabelText("原生 /responses"),
+    ).not.toBeInTheDocument();
     expect(within(editModal).queryByText("回退配置")).not.toBeInTheDocument();
     fireEvent.click(within(editModal).getByRole("button", { name: /保\s*存/ }));
 
@@ -201,6 +248,8 @@ describe("AccountsPage", () => {
             account_name: "mirror-east",
             source_icon: "ppchat",
             base_url: "https://code.ppchat.vip/v1",
+            usage_driver: "",
+            usage_config_json: "",
             supports_responses: true,
           }),
         }),
@@ -209,25 +258,41 @@ describe("AccountsPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "详情-mirror-east" }));
     const detailModal = await screen.findByRole("dialog", { name: "账户详情" });
-    expect(await within(detailModal).findByText("今日配额进度")).toBeInTheDocument();
+    expect(
+      await within(detailModal).findByText("今日配额进度"),
+    ).toBeInTheDocument();
     expect(within(detailModal).getByText("当天增加配额")).toBeInTheDocument();
     expect(within(detailModal).getByText("今日已用次数")).toBeInTheDocument();
     expect(within(detailModal).getByText("剩余 13,931")).toBeInTheDocument();
-    expect(within(detailModal).getByText("已用 1,068 / 新增 14,999")).toBeInTheDocument();
-    expect(within(detailModal).queryByText("TOKEN 名称")).not.toBeInTheDocument();
+    expect(
+      within(detailModal).getByText("已用 1,068 / 新增 14,999"),
+    ).toBeInTheDocument();
+    expect(
+      within(detailModal).queryByText("TOKEN 名称"),
+    ).not.toBeInTheDocument();
     expect(within(detailModal).queryByText("套餐类型")).not.toBeInTheDocument();
     expect(within(detailModal).queryByText("到期时间")).not.toBeInTheDocument();
-    expect(within(detailModal).queryByText("今日 OPUS 使用次数")).not.toBeInTheDocument();
-    expect(within(detailModal).queryByText("今日大TOKEN请求数")).not.toBeInTheDocument();
-    expect(await within(detailModal).findByText("PPChat Token 日志")).toBeInTheDocument();
+    expect(
+      within(detailModal).queryByText("今日 OPUS 使用次数"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(detailModal).queryByText("今日大TOKEN请求数"),
+    ).not.toBeInTheDocument();
+    expect(
+      await within(detailModal).findByText("PPChat Token 日志"),
+    ).toBeInTheDocument();
     fireEvent.click(within(detailModal).getByRole("button", { name: "Close" }));
 
     fireEvent.click(screen.getByRole("button", { name: "编辑-mirror-east" }));
-    const editTestModal = await screen.findByRole("dialog", { name: "编辑账户" });
+    const editTestModal = await screen.findByRole("dialog", {
+      name: "编辑账户",
+    });
     fireEvent.change(within(editTestModal).getByLabelText("输入内容"), {
       target: { value: "ping" },
     });
-    fireEvent.click(within(editTestModal).getByRole("button", { name: /测\s*试/ }));
+    fireEvent.click(
+      within(editTestModal).getByRole("button", { name: /测\s*试/ }),
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -239,7 +304,9 @@ describe("AccountsPage", () => {
       );
     });
 
-    expect(await within(editTestModal).findByText("远端连通性测试成功")).toBeInTheDocument();
+    expect(
+      await within(editTestModal).findByText("远端连通性测试成功"),
+    ).toBeInTheDocument();
     expect(within(editTestModal).getByText("pong")).toBeInTheDocument();
   });
 
@@ -260,7 +327,7 @@ describe("AccountsPage", () => {
         base_url: "https://code.ppchat.vip/v1",
         account_driver: "builtin_api_key",
         usage_driver: "lua",
-        usage_config_json: "{\"script\":\"adapters/vendor.lua\"}",
+        usage_config_json: '{"script":"adapters/vendor.lua"}',
         status: "active",
         is_active: false,
         priority: 2,
@@ -282,18 +349,40 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
-      }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
-      }
-      if (url === "/ai-router/api/accounts/1/share" && init?.method === "POST") {
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
         return Promise.resolve(
-          new Response(JSON.stringify({ payload: "{\"kind\":\"aigate-account-share\"}" }), {
+          new Response(JSON.stringify(accountList), {
             status: 200,
             headers: { "Content-Type": "application/json" },
           }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/1/share" &&
+        init?.method === "POST"
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ payload: '{"kind":"aigate-account-share"}' }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
         );
       }
       return Promise.resolve(new Response(null, { status: 404 }));
@@ -307,8 +396,12 @@ describe("AccountsPage", () => {
     fetchMock.mockClear();
 
     fireEvent.click(screen.getByRole("button", { name: "分享-mirror-east" }));
-    const confirmModal = await screen.findByRole("dialog", { name: "分享账户" });
-    fireEvent.click(within(confirmModal).getByRole("button", { name: /取\s*消/ }));
+    const confirmModal = await screen.findByRole("dialog", {
+      name: "分享账户",
+    });
+    fireEvent.click(
+      within(confirmModal).getByRole("button", { name: /取\s*消/ }),
+    );
 
     await waitFor(() => {
       expect(clipboardWriteText).not.toHaveBeenCalled();
@@ -316,20 +409,245 @@ describe("AccountsPage", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "分享-mirror-east" }));
-    const approvedModal = await screen.findByRole("dialog", { name: "分享账户" });
-    fireEvent.click(within(approvedModal).getByRole("button", { name: "确认分享" }));
+    const approvedModal = await screen.findByRole("dialog", {
+      name: "分享账户",
+    });
+    fireEvent.click(
+      within(approvedModal).getByRole("button", { name: "确认分享" }),
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
         "/ai-router/api/accounts/1/share",
         expect.objectContaining({ method: "POST" }),
       );
-      expect(clipboardWriteText).toHaveBeenCalledWith("{\"kind\":\"aigate-account-share\"}");
+      expect(clipboardWriteText).toHaveBeenCalledWith(
+        '{"kind":"aigate-account-share"}',
+      );
+    });
+  });
+
+  it("supports editing lua usage config, copying AI skill context, and testing lua output", async () => {
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: { writeText: clipboardWriteText },
+      configurable: true,
+    });
+
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-compatible",
+        account_name: "vendor-lua",
+        source_icon: "openai",
+        auth_mode: "api_key",
+        base_url: "https://mirror.example.test/v1",
+        account_driver: "builtin_api_key",
+        usage_driver: "lua",
+        usage_config_json:
+          '{"script":"managed:vendor_shared","endpoint":"https://usage.example.test/v1/usage"}',
+        status: "active",
+        is_active: false,
+        priority: 1,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 0,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage-scripts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ items: ["vendor_shared"] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage-scripts/vendor_shared" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              key: "vendor_shared",
+              content:
+                "function fetch_usage(ctx)\n  return { ok = true, source = 'remote', confidence = 'high', limits = { quota_remaining = 123 } }\nend\n",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage-scripts/vendor_shared" &&
+        init?.method === "PUT"
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ key: "vendor_shared" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/1/usage-lua-test" &&
+        init?.method === "POST"
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ok: true,
+              message: "Lua usage 测试成功",
+              details: "脚本已返回标准化 usage 结果",
+              content:
+                '{\n  "quota_remaining": 4321,\n  "meta": {\n    "account_name": "vendor-lua"\n  }\n}',
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      if (url === "/ai-router/api/accounts/1" && init?.method === "PUT") {
+        return Promise.resolve(new Response(null, { status: 200 }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("vendor-lua")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "编辑-vendor-lua" }));
+
+    const editModal = await screen.findByRole("dialog", { name: "编辑账户" });
+    expect(
+      await within(editModal).findByText("Lua Usage 配置"),
+    ).toBeInTheDocument();
+    expect(
+      within(editModal).queryByLabelText("Usage 配置 JSON"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(editModal).getByText("当前脚本标识: vendor_shared"),
+    ).toBeInTheDocument();
+    expect(
+      (within(editModal).getByLabelText("Lua 脚本") as HTMLTextAreaElement)
+        .value,
+    ).toContain("fetch_usage");
+
+    fireEvent.click(
+      within(editModal).getByRole("button", { name: "复制 AI Skill" }),
+    );
+    await waitFor(() => {
+      expect(clipboardWriteText).toHaveBeenCalledTimes(1);
+    });
+    expect(clipboardWriteText.mock.calls[0][0]).toContain("账户上下文");
+    expect(clipboardWriteText.mock.calls[0][0]).toContain(
+      '"account_name": "vendor-lua"',
+    );
+    expect(clipboardWriteText.mock.calls[0][0]).toContain(
+      '"script_key": "vendor_shared"',
+    );
+    expect(clipboardWriteText.mock.calls[0][0]).toContain(
+      "http://127.0.0.1:6789",
+    );
+
+    fireEvent.click(
+      within(editModal).getByRole("button", { name: "高级配置" }),
+    );
+    expect(
+      await within(editModal).findByLabelText("Usage 配置 JSON"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(editModal).getByRole("button", { name: "测试 Lua 脚本" }),
+    );
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/1/usage-lua-test",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    expect(
+      await within(editModal).findByText("Lua usage 测试成功"),
+    ).toBeInTheDocument();
+    expect(
+      within(editModal)
+        .getAllByText(/quota_remaining/)
+        .some((node) => node.classList.contains("test-output")),
+    ).toBe(true);
+
+    fireEvent.click(within(editModal).getByRole("button", { name: /保\s*存/ }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/usage-scripts/vendor_shared",
+        expect.objectContaining({
+          method: "PUT",
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            account_name: "vendor-lua",
+            source_icon: "openai",
+            base_url: "https://mirror.example.test/v1",
+            usage_driver: "lua",
+            usage_config_json:
+              '{"script":"managed:vendor_shared","endpoint":"https://usage.example.test/v1/usage"}',
+            supports_responses: true,
+          }),
+        }),
+      );
     });
   });
 
   it("imports shared payload and keeps the modal open on validation failure", async () => {
-    const validPayload = "{\"kind\":\"aigate-account-share\",\"schema_version\":1}";
+    const validPayload = '{"kind":"aigate-account-share","schema_version":1}';
 
     const accountList = [
       {
@@ -341,7 +659,7 @@ describe("AccountsPage", () => {
         base_url: "https://code.ppchat.vip/v1",
         account_driver: "builtin_api_key",
         usage_driver: "lua",
-        usage_config_json: "{\"script\":\"adapters/vendor.lua\"}",
+        usage_config_json: '{"script":"adapters/vendor.lua"}',
         status: "active",
         is_active: false,
         priority: 2,
@@ -364,13 +682,32 @@ describe("AccountsPage", () => {
     let importAttempt = 0;
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/import-shared" && init?.method === "POST") {
+      if (
+        url === "/ai-router/api/accounts/import-shared" &&
+        init?.method === "POST"
+      ) {
         importAttempt += 1;
         if (importAttempt === 1) {
           return Promise.resolve(new Response("分享内容无效", { status: 400 }));
@@ -393,7 +730,9 @@ describe("AccountsPage", () => {
     fireEvent.change(within(importModal).getByLabelText("粘贴分享内容"), {
       target: { value: validPayload },
     });
-    fireEvent.click(within(importModal).getByRole("button", { name: "校验并导入" }));
+    fireEvent.click(
+      within(importModal).getByRole("button", { name: "校验并导入" }),
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -404,10 +743,16 @@ describe("AccountsPage", () => {
         }),
       );
     });
-    expect(await within(importModal).findByText("分享内容无效")).toBeInTheDocument();
-    expect(screen.getByRole("dialog", { name: "导入账户" })).toBeInTheDocument();
+    expect(
+      await within(importModal).findByText("分享内容无效"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "导入账户" }),
+    ).toBeInTheDocument();
 
-    fireEvent.click(within(importModal).getByRole("button", { name: "校验并导入" }));
+    fireEvent.click(
+      within(importModal).getByRole("button", { name: "校验并导入" }),
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -420,7 +765,9 @@ describe("AccountsPage", () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "导入账户" })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", { name: "导入账户" }),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -453,11 +800,27 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
       return Promise.resolve(new Response(null, { status: 404 }));
     });
@@ -470,7 +833,9 @@ describe("AccountsPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "删除-mirror-east" }));
     await waitFor(() => {
-      const confirmWrap = document.querySelector(".ant-modal-confirm")?.closest(".ant-modal-wrap");
+      const confirmWrap = document
+        .querySelector(".ant-modal-confirm")
+        ?.closest(".ant-modal-wrap");
       expect(confirmWrap).not.toBeNull();
       expect(confirmWrap).toHaveClass("ant-modal-centered");
     });
@@ -528,11 +893,27 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
       if (url === "/ai-router/api/accounts/1" && init?.method === "PUT") {
         return Promise.resolve(new Response(null, { status: 200 }));
@@ -545,7 +926,9 @@ describe("AccountsPage", () => {
     renderAccountsPage();
 
     expect(await screen.findByText("account-a")).toBeInTheDocument();
-    const activeRow = screen.getByText("account-b").closest(".account-card-item");
+    const activeRow = screen
+      .getByText("account-b")
+      .closest(".account-card-item");
     expect(activeRow).toHaveClass("active-account-card");
 
     fireEvent.click(screen.getByRole("button", { name: "设为激活-account-a" }));
@@ -638,11 +1021,27 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
       return Promise.resolve(new Response(null, { status: 404 }));
     });
@@ -653,7 +1052,9 @@ describe("AccountsPage", () => {
 
     expect(await screen.findByText("high-priority")).toBeInTheDocument();
 
-    const order = Array.from(container.querySelectorAll(".account-cards .account-card-item strong")).map((node) => node.textContent);
+    const order = Array.from(
+      container.querySelectorAll(".account-cards .account-card-item strong"),
+    ).map((node) => node.textContent);
     expect(order).toEqual(["high-priority", "mid-priority", "low-priority"]);
   });
 
@@ -696,15 +1097,34 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
         const payload = listCallCount === 0 ? initialList : duplicatedList;
         listCallCount += 1;
-        return Promise.resolve(new Response(JSON.stringify(payload), { status: 200, headers: { "Content-Type": "application/json" } }));
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/1/duplicate" && init?.method === "POST") {
+      if (
+        url === "/ai-router/api/accounts/1/duplicate" &&
+        init?.method === "POST"
+      ) {
         return Promise.resolve(new Response(null, { status: 201 }));
       }
       return Promise.resolve(new Response(null, { status: 404 }));
@@ -760,10 +1180,21 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
         return Promise.resolve(
           new Response(
             JSON.stringify([
@@ -799,8 +1230,16 @@ describe("AccountsPage", () => {
     expect(screen.getByText("7D")).toBeInTheDocument();
     expect(screen.getByText("25%")).toBeInTheDocument();
     expect(screen.getByText("5%")).toBeInTheDocument();
-    expect(document.querySelector('[aria-label="official-main-5H"] .account-usage-mini-fill')).toHaveClass("is-warning");
-    expect(document.querySelector('[aria-label="official-main-7D"] .account-usage-mini-fill')).toHaveClass("is-danger");
+    expect(
+      document.querySelector(
+        '[aria-label="official-main-5H"] .account-usage-mini-fill',
+      ),
+    ).toHaveClass("is-warning");
+    expect(
+      document.querySelector(
+        '[aria-label="official-main-7D"] .account-usage-mini-fill',
+      ),
+    ).toHaveClass("is-danger");
   });
 
   it("keeps previous usage visible while a refresh is pending", async () => {
@@ -835,10 +1274,21 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
         usageCallCount += 1;
         if (usageCallCount === 1) {
           return Promise.resolve(
@@ -957,10 +1407,21 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
         return Promise.resolve(
           new Response(
             JSON.stringify([
@@ -997,8 +1458,14 @@ describe("AccountsPage", () => {
     expect(await screen.findByText("ppchat-main")).toBeInTheDocument();
     expect(await screen.findByText("1D")).toBeInTheDocument();
     expect(screen.getByText("93%")).toBeInTheDocument();
-    expect(document.querySelector(".account-usage-mini")).toHaveClass("account-usage-mini-single");
-    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/ai-router/api/accounts/1/ppchat-token-logs"))).toBe(false);
+    expect(document.querySelector(".account-usage-mini")).toHaveClass(
+      "account-usage-mini-single",
+    );
+    expect(
+      fetchMock.mock.calls.some(([url]) =>
+        String(url).includes("/ai-router/api/accounts/1/ppchat-token-logs"),
+      ),
+    ).toBe(false);
   });
 
   it("refreshes usage after shared account import so imported accounts do not stay at default progress", async () => {
@@ -1030,16 +1497,38 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/import-shared" && init?.method === "POST") {
+      if (
+        url === "/ai-router/api/accounts/import-shared" &&
+        init?.method === "POST"
+      ) {
         return Promise.resolve(new Response(null, { status: 201 }));
       }
-      if (url === "/ai-router/api/accounts/usage/refresh" && init?.method === "POST") {
+      if (
+        url === "/ai-router/api/accounts/usage/refresh" &&
+        init?.method === "POST"
+      ) {
         return Promise.resolve(new Response(null, { status: 204 }));
       }
       return Promise.resolve(new Response(null, { status: 404 }));
@@ -1055,9 +1544,11 @@ describe("AccountsPage", () => {
 
     const importModal = await screen.findByRole("dialog", { name: "导入账户" });
     fireEvent.change(within(importModal).getByLabelText("粘贴分享内容"), {
-      target: { value: "{\"kind\":\"aigate-account-share\",\"schema_version\":1}" },
+      target: { value: '{"kind":"aigate-account-share","schema_version":1}' },
     });
-    fireEvent.click(within(importModal).getByRole("button", { name: "校验并导入" }));
+    fireEvent.click(
+      within(importModal).getByRole("button", { name: "校验并导入" }),
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -1142,13 +1633,32 @@ describe("AccountsPage", () => {
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/ai-router/api/accounts" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify(accountList), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (url === "/ai-router/api/accounts/usage" && (!init?.method || init.method === "GET")) {
-        return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      if (/^\/ai-router\/api\/accounts\/\d+$/.test(url) && init?.method === "PUT") {
+      if (
+        /^\/ai-router\/api\/accounts\/\d+$/.test(url) &&
+        init?.method === "PUT"
+      ) {
         return Promise.resolve(new Response(null, { status: 200 }));
       }
       return Promise.resolve(new Response(null, { status: 404 }));
@@ -1160,7 +1670,9 @@ describe("AccountsPage", () => {
 
     expect(await screen.findByText("account-a")).toBeInTheDocument();
 
-    const cards = Array.from(container.querySelectorAll(".account-card-item")) as HTMLElement[];
+    const cards = Array.from(
+      container.querySelectorAll(".account-card-item"),
+    ) as HTMLElement[];
     cards.forEach((card, index) => {
       Object.defineProperty(card, "getBoundingClientRect", {
         configurable: true,
@@ -1180,16 +1692,28 @@ describe("AccountsPage", () => {
 
     const handles = screen.getAllByLabelText(/拖拽排序-/);
     fireEvent.mouseDown(handles[0], { button: 0, clientX: 24, clientY: 40 });
-    fireEvent.mouseMove(document.body, { buttons: 1, clientX: 24, clientY: 56 });
-    fireEvent.mouseMove(document.body, { buttons: 1, clientX: 24, clientY: 175 });
+    fireEvent.mouseMove(document.body, {
+      buttons: 1,
+      clientX: 24,
+      clientY: 56,
+    });
+    fireEvent.mouseMove(document.body, {
+      buttons: 1,
+      clientX: 24,
+      clientY: 175,
+    });
 
     await waitFor(() => {
-      expect(container.querySelector(".account-card-item-placeholder")).toBeTruthy();
+      expect(
+        container.querySelector(".account-card-item-placeholder"),
+      ).toBeTruthy();
       expect(document.body.querySelector(".account-drag-overlay")).toBeTruthy();
     });
 
     await waitFor(() => {
-      const liveOrder = Array.from(container.querySelectorAll(".account-cards .account-card-item strong")).map((node) => node.textContent);
+      const liveOrder = Array.from(
+        container.querySelectorAll(".account-cards .account-card-item strong"),
+      ).map((node) => node.textContent);
       expect(liveOrder).toEqual(["account-b", "account-a", "account-c"]);
     });
     expect(fetchMock).not.toHaveBeenCalledWith(

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -60,14 +60,18 @@ import {
   createAccount,
   deleteAccount,
   duplicateAccount,
+  fetchPPChatTokenLogs,
+  getLuaUsageScript,
   importCurrentCodexAuth,
   importSharedAccount,
-  fetchPPChatTokenLogs,
+  listLuaUsageScripts,
   listAccountUsage,
   listAccounts,
   refreshAccountUsage,
+  saveLuaUsageScript,
   shareAccount,
   testAccount,
+  testLuaUsage,
   updateAccount,
   type AccountRecord,
   type PPChatTokenLogsPayload,
@@ -128,8 +132,194 @@ function inferSourceIconByBaseURL(baseURL: string): SourceIcon {
   return "openai";
 }
 
-function sameAccountOrder(left: AccountRecord[], right: AccountRecord[]): boolean {
-  return left.length === right.length && left.every((item, index) => item.id === right[index]?.id);
+function parseUsageConfig(raw?: string): Record<string, unknown> {
+  if (!raw || raw.trim() === "") {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+function stringifyUsageConfig(value: Record<string, unknown>): string {
+  return JSON.stringify(value);
+}
+
+function getManagedLuaScriptKey(raw?: string): string {
+  const parsed = parseUsageConfig(raw);
+  const script = typeof parsed.script === "string" ? String(parsed.script) : "";
+  return script.startsWith("managed:") ? script.slice("managed:".length) : "";
+}
+
+function inferLuaScriptKeyFromBaseURL(baseURL: string): string {
+  try {
+    const parsed = new URL(baseURL);
+    return parsed.hostname
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9.-]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  } catch {
+    return "";
+  }
+}
+
+function stringifyLuaConfigDraft(raw: string, scriptKey: string): string {
+  const parsed = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : {};
+  if (scriptKey.trim() !== "") {
+    parsed.script = `managed:${scriptKey.trim()}`;
+  }
+  return stringifyUsageConfig(parsed);
+}
+
+function buildLuaSkillPrompt(
+  account: AccountRecord,
+  scriptKey: string,
+  usageConfigJSON: string,
+): string {
+  const accountContext = {
+    account_id: account.id,
+    account_name: account.account_name,
+    provider_type: account.provider_type,
+    auth_mode: account.auth_mode,
+    base_url: account.base_url,
+    source_icon: normalizeSourceIcon(account.source_icon),
+    usage_driver: "lua",
+    script_key: scriptKey,
+    usage_config_json: usageConfigJSON,
+  };
+
+  return `# AI Gate Lua Usage Adapter Skill
+
+你正在为 AI Gate 调试第三方 API 的 usage 采集脚本。目标是直接配置并验证账户 ${account.account_name}（ID ${account.id}） 的 Lua usage 驱动，不要改成内置 driver，也不要降级成手工统计。
+
+## 账户上下文
+${JSON.stringify(accountContext, null, 2)}
+
+## 你的任务
+1. 基于当前账户上下文，为该账户生成或修正 Lua usage 脚本。
+2. 只处理 usage 采集，不要改请求代理逻辑。
+3. 优先复用共享脚本键 \`${scriptKey || "请先填写共享脚本标识"}\`。
+4. 若第三方 usage 接口需要额外字段，请直接写入 \`usage_config_json\`。
+
+## Lua 入口规范
+- 必须实现：\`function fetch_usage(ctx)\`
+- 成功返回：
+\`\`\`lua
+return {
+  ok = true,
+  source = "remote",
+  confidence = "high",
+  limits = {
+    balance = nil,
+    quota_remaining = nil,
+    rpm_remaining = nil,
+    tpm_remaining = nil,
+    daily_remaining = nil,
+    monthly_remaining = nil,
+    primary_used_percent = nil,
+    secondary_used_percent = nil,
+    primary_resets_at = nil,
+    secondary_resets_at = nil
+  },
+  meta = {},
+  payload = {}
+}
+\`\`\`
+- 失败返回：
+\`\`\`lua
+return {
+  ok = false,
+  error = {
+    kind = "auth",
+    message = "session expired"
+  }
+}
+\`\`\`
+
+## ctx 可用字段
+- \`ctx.account.id\`
+- \`ctx.account.account_name\`
+- \`ctx.account.provider_type\`
+- \`ctx.account.auth_mode\`
+- \`ctx.account.base_url\`
+- \`ctx.credential.access_token\`
+- \`ctx.credential.api_key\`
+- \`ctx.credential.refresh_token\`
+- \`ctx.credential.session\`
+- \`ctx.credential.headers\`
+- \`ctx.credential.metadata\`
+- \`ctx.config\`：来自 \`usage_config_json\`
+
+## host API
+- \`ctx.host.http_get({ url = "...", headers = { Authorization = "Bearer xxx" } })\`
+- \`ctx.host.json_decode(raw)\`
+- \`ctx.host.json_encode(value)\`
+- \`ctx.host.sleep_ms(ms)\`
+
+## 配置方式
+- 所有配置和验证都走 HTTP API，服务基地址固定为：\`http://127.0.0.1:6789\`
+- 共享脚本列表：
+  - \`GET http://127.0.0.1:6789/ai-router/api/accounts/usage-scripts\`
+- 读取共享脚本：
+  - \`GET http://127.0.0.1:6789/ai-router/api/accounts/usage-scripts/${scriptKey || "<script_key>"}\`
+- 保存共享脚本：
+  - \`PUT http://127.0.0.1:6789/ai-router/api/accounts/usage-scripts/${scriptKey || "<script_key>"}\`
+  - body: \`{ "content": "<lua source>" }\`
+- 账户引用方式：
+  - \`usage_driver = "lua"\`
+  - \`usage_config_json\` 中写 \`"script":"managed:${scriptKey || "<script_key>"}"\`
+- 更新账户接口：
+  - \`PUT http://127.0.0.1:6789/ai-router/api/accounts/${account.id}\`
+
+## 调试步骤
+1. 先读取当前共享脚本：
+   - \`GET http://127.0.0.1:6789/ai-router/api/accounts/usage-scripts/${scriptKey || "<script_key>"}\`
+2. 修改脚本后，不要先假设成功，必须调用 Lua 测试接口：
+   - \`POST http://127.0.0.1:6789/ai-router/api/accounts/${account.id}/usage-lua-test\`
+   - body:
+\`\`\`json
+{
+  "usage_config_json": ${JSON.stringify(usageConfigJSON)},
+  "script_content": "<当前 Lua 源码>"
+}
+\`\`\`
+3. 只有当返回 \`ok=true\`，并且 \`content\` 中出现标准化字段（如 \`quota_remaining\` / \`balance\` / \`primary_used_percent\`），才算成功。
+4. 如果失败，优先检查：
+   - 鉴权头是否正确
+   - 上游 usage 接口 URL 是否正确
+   - JSON 解析是否匹配真实响应
+   - 返回结构是否符合 AI Gate Lua schema
+5. 测试通过后，再保存共享脚本并更新账户配置。
+
+## 成功判定
+- Lua 测试接口返回 \`ok=true\`
+- \`content\` 为格式化后的标准化 usage JSON
+- 更新账户接口返回成功
+- 后续再调用 \`GET http://127.0.0.1:6789/ai-router/api/accounts/usage\` 时可以看到该账户 usage 已可正常刷新
+
+## 执行要求
+- 直接在当前仓库中完成修改
+- 优先做最小改动
+- 不要输出伪代码
+- 配置、保存、验证都优先使用 HTTP API，不要依赖数据库直改或手工文件操作
+`;
+}
+
+function sameAccountOrder(
+  left: AccountRecord[],
+  right: AccountRecord[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => item.id === right[index]?.id)
+  );
 }
 
 function sortAccountsByPriority(items: AccountRecord[]): AccountRecord[] {
@@ -141,7 +331,10 @@ function sortAccountsByPriority(items: AccountRecord[]): AccountRecord[] {
   });
 }
 
-function mergeDisplayUsage(previous: AccountRecord, next: AccountRecord): AccountRecord {
+function mergeDisplayUsage(
+  previous: AccountRecord,
+  next: AccountRecord,
+): AccountRecord {
   return {
     ...next,
     balance: previous.balance,
@@ -178,25 +371,49 @@ function formatResetAt(value: string | undefined, language: AppLanguage) {
     date.getMonth() === now.getMonth() &&
     date.getDate() === now.getDate();
   if (sameDay) {
-    return date.toLocaleTimeString(language, { hour: "2-digit", minute: "2-digit", hour12: false });
+    return date.toLocaleTimeString(language, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
   }
-  return date.toLocaleDateString(language, { month: "numeric", day: "numeric" });
+  return date.toLocaleDateString(language, {
+    month: "numeric",
+    day: "numeric",
+  });
 }
 
 function formatInteger(language: AppLanguage, value: number): string {
-  return new Intl.NumberFormat(language, { maximumFractionDigits: 0 }).format(value);
+  return new Intl.NumberFormat(language, { maximumFractionDigits: 0 }).format(
+    value,
+  );
 }
 
-function formatDeletedAccountMessage(language: AppLanguage, accountName: string): string {
-  return language === "en-US" ? `Deleted account ${accountName}` : `已删除账户 ${accountName}`;
+function formatDeletedAccountMessage(
+  language: AppLanguage,
+  accountName: string,
+): string {
+  return language === "en-US"
+    ? `Deleted account ${accountName}`
+    : `已删除账户 ${accountName}`;
 }
 
-function formatActiveAccountMessage(language: AppLanguage, accountName: string): string {
-  return language === "en-US" ? `Current account switched to ${accountName}` : `已切换当前使用中账户为 ${accountName}`;
+function formatActiveAccountMessage(
+  language: AppLanguage,
+  accountName: string,
+): string {
+  return language === "en-US"
+    ? `Current account switched to ${accountName}`
+    : `已切换当前使用中账户为 ${accountName}`;
 }
 
-function formatDeleteAccountTitle(language: AppLanguage, accountName: string): string {
-  return language === "en-US" ? `Delete account "${accountName}"?` : `确认删除账户「${accountName}」吗？`;
+function formatDeleteAccountTitle(
+  language: AppLanguage,
+  accountName: string,
+): string {
+  return language === "en-US"
+    ? `Delete account "${accountName}"?`
+    : `确认删除账户「${accountName}」吗？`;
 }
 
 function clampPercent(value: number): number {
@@ -217,11 +434,16 @@ function getRemainingTone(value: number): "ok" | "warning" | "danger" {
 }
 
 function isOfficialAccount(record: AccountRecord): boolean {
-  return record.auth_mode === "oauth" || record.auth_mode === "codex_local_import";
+  return (
+    record.auth_mode === "oauth" || record.auth_mode === "codex_local_import"
+  );
 }
 
 function isPPChatAccount(record: AccountRecord): boolean {
-  return normalizeSourceIcon(record.source_icon) === "ppchat" || /ppchat\.vip/i.test(record.base_url);
+  return (
+    normalizeSourceIcon(record.source_icon) === "ppchat" ||
+    /ppchat\.vip/i.test(record.base_url)
+  );
 }
 
 type AccountsPageProps = {
@@ -246,12 +468,26 @@ type AccountCardRenderOptions = {
 type SortableAccountCardProps = {
   id: number;
   record: AccountRecord;
-  renderCard: (record: AccountRecord, options?: AccountCardRenderOptions) => ReactNode;
+  renderCard: (
+    record: AccountRecord,
+    options?: AccountCardRenderOptions,
+  ) => ReactNode;
 };
 
-function SortableAccountCard({ id, record, renderCard }: SortableAccountCardProps) {
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } =
-    useSortable({ id });
+function SortableAccountCard({
+  id,
+  record,
+  renderCard,
+}: SortableAccountCardProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
 
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
@@ -279,20 +515,41 @@ export function AccountsPage({
   const [messageApi, contextHolder] = message.useMessage();
   const { modal } = AntApp.useApp();
   const [accounts, setAccounts] = useState<AccountRecord[]>([]);
-  const [internalAddModalMode, setInternalAddModalMode] = useState<AddModalMode>(null);
-  const [editingAccount, setEditingAccount] = useState<AccountRecord | null>(null);
-  const [detailAccount, setDetailAccount] = useState<AccountRecord | null>(null);
+  const [internalAddModalMode, setInternalAddModalMode] =
+    useState<AddModalMode>(null);
+  const [editingAccount, setEditingAccount] = useState<AccountRecord | null>(
+    null,
+  );
+  const [detailAccount, setDetailAccount] = useState<AccountRecord | null>(
+    null,
+  );
   const [sharedImportError, setSharedImportError] = useState<string>("");
   const [testResult, setTestResult] = useState<AccountTestResult | null>(null);
+  const [luaTestResult, setLuaTestResult] = useState<AccountTestResult | null>(
+    null,
+  );
+  const [luaScriptKey, setLuaScriptKey] = useState("");
+  const [luaScriptContent, setLuaScriptContent] = useState("");
+  const [luaConfigDraft, setLuaConfigDraft] = useState("");
+  const [availableLuaScripts, setAvailableLuaScripts] = useState<string[]>([]);
+  const [showAdvancedLuaConfig, setShowAdvancedLuaConfig] = useState(false);
+  const [luaScriptLoading, setLuaScriptLoading] = useState(false);
+  const [luaTesting, setLuaTesting] = useState(false);
   const [detailLogsLoading, setDetailLogsLoading] = useState(false);
-  const [detailLogs, setDetailLogs] = useState<PPChatTokenLogsPayload["data"] | null>(null);
-  const [draggingAccountID, setDraggingAccountID] = useState<number | null>(null);
+  const [detailLogs, setDetailLogs] = useState<
+    PPChatTokenLogsPayload["data"] | null
+  >(null);
+  const [draggingAccountID, setDraggingAccountID] = useState<number | null>(
+    null,
+  );
 
   const [thirdPartyForm] = Form.useForm();
   const [officialForm] = Form.useForm();
   const [sharedImportForm] = Form.useForm();
   const [editForm] = Form.useForm();
   const [testForm] = Form.useForm();
+  const editUsageDriver = Form.useWatch("usage_driver", editForm);
+  const editBaseURL = Form.useWatch("base_url", editForm);
   const accountsRef = useRef<AccountRecord[]>([]);
   const dragSnapshotRef = useRef<AccountRecord[] | null>(null);
   const sensors = useSensors(
@@ -304,10 +561,15 @@ export function AccountsPage({
     }),
   );
 
-  function setAccountsState(next: AccountRecord[] | ((items: AccountRecord[]) => AccountRecord[]), options?: { preserveOrder?: boolean }) {
+  function setAccountsState(
+    next: AccountRecord[] | ((items: AccountRecord[]) => AccountRecord[]),
+    options?: { preserveOrder?: boolean },
+  ) {
     setAccounts((items) => {
       const resolved = typeof next === "function" ? next(items) : next;
-      const ordered = options?.preserveOrder ? resolved : sortAccountsByPriority(resolved);
+      const ordered = options?.preserveOrder
+        ? resolved
+        : sortAccountsByPriority(resolved);
       accountsRef.current = ordered;
       return ordered;
     });
@@ -360,8 +622,94 @@ export function AccountsPage({
     };
   }, [detailAccount]);
 
+  useEffect(() => {
+    if (!editingAccount) {
+      setLuaScriptKey("");
+      setLuaScriptContent("");
+      setLuaConfigDraft("");
+      setAvailableLuaScripts([]);
+      setShowAdvancedLuaConfig(false);
+      setLuaScriptLoading(false);
+      setLuaTestResult(null);
+      return;
+    }
+
+    const config = parseUsageConfig(editingAccount.usage_config_json);
+    const explicitScriptKey = getManagedLuaScriptKey(
+      editingAccount.usage_config_json,
+    );
+    const inferredScriptKey = inferLuaScriptKeyFromBaseURL(
+      editingAccount.base_url,
+    );
+    const nextScriptKey = explicitScriptKey || inferredScriptKey;
+    setLuaScriptKey(nextScriptKey);
+    setLuaConfigDraft(JSON.stringify(config, null, 2));
+    setLuaScriptContent("");
+    setLuaTestResult(null);
+    setShowAdvancedLuaConfig(false);
+
+    let cancelled = false;
+    void listLuaUsageScripts()
+      .then((response) => {
+        if (!cancelled) {
+          setAvailableLuaScripts(response.items);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAvailableLuaScripts([]);
+        }
+      });
+
+    if (!nextScriptKey) {
+      setLuaScriptLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setLuaScriptLoading(true);
+    void getLuaUsageScript(nextScriptKey)
+      .then((record) => {
+        if (!cancelled) {
+          setLuaScriptContent(record.content);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLuaScriptContent("");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLuaScriptLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [editingAccount]);
+
+  useEffect(() => {
+    if (!editingAccount || editUsageDriver !== "lua") {
+      return;
+    }
+    if (luaScriptKey.trim() !== "") {
+      return;
+    }
+    const inferred = inferLuaScriptKeyFromBaseURL(
+      editBaseURL || editingAccount.base_url,
+    );
+    if (inferred) {
+      setLuaScriptKey(inferred);
+    }
+  }, [editBaseURL, editUsageDriver, editingAccount, luaScriptKey]);
+
   async function refreshAll() {
-    const previousByID = new Map(accountsRef.current.map((item) => [item.id, item]));
+    const previousByID = new Map(
+      accountsRef.current.map((item) => [item.id, item]),
+    );
     const accountItems = sortAccountsByPriority(
       (await listAccounts()).map((item) => {
         const previous = previousByID.get(item.id);
@@ -376,25 +724,33 @@ export function AccountsPage({
   async function refreshUsage() {
     try {
       const usageItems = await listAccountUsage();
-      const usageByAccount = new Map(usageItems.map((item) => [item.account_id, item]));
-      setAccountsState((items) =>
-        items.map((item) => {
-          const usage = usageByAccount.get(item.id);
-          if (!usage) {
-            return item;
-          }
-          return {
-            ...item,
-            ...usage,
-          };
-        }),
-      { preserveOrder: true });
+      const usageByAccount = new Map(
+        usageItems.map((item) => [item.account_id, item]),
+      );
+      setAccountsState(
+        (items) =>
+          items.map((item) => {
+            const usage = usageByAccount.get(item.id);
+            if (!usage) {
+              return item;
+            }
+            return {
+              ...item,
+              ...usage,
+            };
+          }),
+        { preserveOrder: true },
+      );
     } catch {
       // Keep base account list responsive even when usage endpoint is unavailable.
     }
   }
 
-  async function handleCreateThirdParty(values: { account_name: string; base_url: string; credential_ref: string }) {
+  async function handleCreateThirdParty(values: {
+    account_name: string;
+    base_url: string;
+    credential_ref: string;
+  }) {
     await createAccount({
       provider_type: "openai-compatible",
       account_name: values.account_name,
@@ -445,18 +801,22 @@ export function AccountsPage({
       void refreshDesktopTrayState();
       void messageApi.success(t("导入成功"));
     } catch (error) {
-      setSharedImportError(error instanceof Error ? t(error.message) : t("分享内容无效"));
+      setSharedImportError(
+        error instanceof Error ? t(error.message) : t("分享内容无效"),
+      );
     }
   }
 
   function openEditModal(account: AccountRecord) {
     setEditingAccount(account);
     setTestResult(null);
+    setLuaTestResult(null);
     editForm.setFieldsValue({
       account_name: account.account_name,
       source_icon: normalizeSourceIcon(account.source_icon),
       base_url: account.base_url,
       credential_ref: "",
+      usage_driver: account.usage_driver === "lua" ? "lua" : "",
     });
     testForm.setFieldsValue({
       model: getDefaultTestModel(account),
@@ -469,15 +829,37 @@ export function AccountsPage({
     source_icon: SourceIcon;
     base_url: string;
     credential_ref?: string;
+    usage_driver?: string;
   }) {
     if (!editingAccount) {
       return;
+    }
+    let usageDriver: string | undefined;
+    let usageConfigJSON: string | undefined;
+    if (values.usage_driver === "lua") {
+      if (luaScriptKey.trim() === "") {
+        throw new Error(t("请填写共享脚本标识"));
+      }
+      if (luaScriptContent.trim() === "") {
+        throw new Error(t("请填写 Lua 脚本"));
+      }
+      usageConfigJSON = stringifyLuaConfigDraft(
+        luaConfigDraft || "{}",
+        luaScriptKey,
+      );
+      await saveLuaUsageScript(luaScriptKey, luaScriptContent);
+      usageDriver = "lua";
+    } else {
+      usageDriver = "";
+      usageConfigJSON = "";
     }
     await updateAccount(editingAccount.id, {
       account_name: values.account_name,
       source_icon: normalizeSourceIcon(values.source_icon),
       base_url: values.base_url,
       credential_ref: values.credential_ref || undefined,
+      usage_driver: usageDriver,
+      usage_config_json: usageConfigJSON,
       supports_responses: true,
     });
     setEditingAccount(null);
@@ -491,7 +873,9 @@ export function AccountsPage({
     await deleteAccount(account.id);
     await refreshAll();
     void refreshDesktopTrayState();
-    void messageApi.success(formatDeletedAccountMessage(language, account.account_name));
+    void messageApi.success(
+      formatDeletedAccountMessage(language, account.account_name),
+    );
   }
 
   async function handleTest(values: { model: string; input: string }) {
@@ -500,6 +884,102 @@ export function AccountsPage({
     }
     const result = await testAccount(editingAccount.id, values);
     setTestResult(result);
+  }
+
+  async function handleCopyLuaSkill() {
+    if (!editingAccount) {
+      return;
+    }
+    if (!navigator.clipboard?.writeText) {
+      throw new Error(t("当前环境不支持剪切板写入"));
+    }
+    const usageConfigJSON = (() => {
+      try {
+        return stringifyLuaConfigDraft(luaConfigDraft || "{}", luaScriptKey);
+      } catch {
+        return editingAccount.usage_config_json || "{}";
+      }
+    })();
+    await navigator.clipboard.writeText(
+      buildLuaSkillPrompt(editingAccount, luaScriptKey.trim(), usageConfigJSON),
+    );
+    void messageApi.success(t("已复制 AI Skill"));
+  }
+
+  async function handleLuaTest() {
+    if (!editingAccount) {
+      return;
+    }
+    if ((editUsageDriver || "") !== "lua") {
+      setLuaTestResult({
+        ok: false,
+        message: t("请先将用量驱动切换为 Lua"),
+      });
+      return;
+    }
+    let usageConfigJSON = "";
+    try {
+      usageConfigJSON = stringifyLuaConfigDraft(
+        luaConfigDraft || "{}",
+        luaScriptKey,
+      );
+    } catch (error) {
+      setLuaTestResult({
+        ok: false,
+        message: t("Lua 配置无效"),
+        details:
+          error instanceof Error
+            ? error.message
+            : t("usage_config_json 不是合法 JSON"),
+      });
+      return;
+    }
+    setLuaTesting(true);
+    try {
+      const result = await testLuaUsage(editingAccount.id, {
+        usage_config_json: usageConfigJSON,
+        script_content: luaScriptContent,
+      });
+      setLuaTestResult(result);
+    } finally {
+      setLuaTesting(false);
+    }
+  }
+
+  async function loadLuaScriptByKey(key: string) {
+    const trimmed = key.trim();
+    setLuaScriptKey(trimmed);
+    if (trimmed === "") {
+      setLuaScriptContent("");
+      return;
+    }
+    setLuaScriptLoading(true);
+    try {
+      const record = await getLuaUsageScript(trimmed);
+      setLuaScriptContent(record.content);
+    } catch {
+      setLuaScriptContent("");
+    } finally {
+      setLuaScriptLoading(false);
+    }
+  }
+
+  async function handleSelectLuaScript(nextKey: string) {
+    await loadLuaScriptByKey(nextKey);
+  }
+
+  async function handleCreateLuaScript() {
+    const fallbackBaseURL =
+      String(editForm.getFieldValue("base_url") || "") ||
+      editingAccount?.base_url ||
+      "";
+    const nextKey = inferLuaScriptKeyFromBaseURL(fallbackBaseURL);
+    if (!nextKey) {
+      void messageApi.warning(t("当前接口地址无法自动生成脚本标识"));
+      return;
+    }
+    await loadLuaScriptByKey(nextKey);
+    void messageApi.success(t("已切换到当前供应商脚本"));
   }
 
   async function handleSetActive(account: AccountRecord) {
@@ -516,10 +996,14 @@ export function AccountsPage({
     try {
       await updateAccount(account.id, { is_active: true });
       void refreshDesktopTrayState();
-      void messageApi.success(formatActiveAccountMessage(language, account.account_name));
+      void messageApi.success(
+        formatActiveAccountMessage(language, account.account_name),
+      );
     } catch (error) {
       setAccountsState(previous);
-      void messageApi.error(error instanceof Error ? t(error.message) : t("切换激活账户失败"));
+      void messageApi.error(
+        error instanceof Error ? t(error.message) : t("切换激活账户失败"),
+      );
     }
   }
 
@@ -530,7 +1014,9 @@ export function AccountsPage({
       void refreshDesktopTrayState();
       void messageApi.success(t("已复制账户"));
     } catch (error) {
-      void messageApi.warning(error instanceof Error ? t(error.message) : t("复制失败，请稍后重试"));
+      void messageApi.warning(
+        error instanceof Error ? t(error.message) : t("复制失败，请稍后重试"),
+      );
     }
   }
 
@@ -564,14 +1050,19 @@ export function AccountsPage({
       return;
     }
 
-    setAccountsState((items) => {
-      const activeIndex = items.findIndex((item) => item.id === Number(event.active.id));
-      const overIndex = items.findIndex((item) => item.id === overID);
-      if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) {
-        return items;
-      }
-      return arrayMove(items, activeIndex, overIndex);
-    }, { preserveOrder: true });
+    setAccountsState(
+      (items) => {
+        const activeIndex = items.findIndex(
+          (item) => item.id === Number(event.active.id),
+        );
+        const overIndex = items.findIndex((item) => item.id === overID);
+        if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) {
+          return items;
+        }
+        return arrayMove(items, activeIndex, overIndex);
+      },
+      { preserveOrder: true },
+    );
   }
 
   async function finishDragSort() {
@@ -588,7 +1079,9 @@ export function AccountsPage({
       await persistAccountPriority(current);
     } catch {
       setAccountsState(snapshot);
-      void messageApi.warning(t("排序已更新到界面，但保存顺序失败，请稍后重试"));
+      void messageApi.warning(
+        t("排序已更新到界面，但保存顺序失败，请稍后重试"),
+      );
     }
   }
 
@@ -637,7 +1130,12 @@ export function AccountsPage({
     if (!detailLogs?.logs?.length) {
       return 0;
     }
-    return Math.max(...detailLogs.logs.map((log) => log.prompt_tokens + log.completion_tokens), 1);
+    return Math.max(
+      ...detailLogs.logs.map(
+        (log) => log.prompt_tokens + log.completion_tokens,
+      ),
+      1,
+    );
   }, [detailLogs]);
 
   const ppchatQuotaSummary = useMemo(() => {
@@ -649,7 +1147,7 @@ export function AccountsPage({
     const used = Math.max(info.today_used_quota ?? 0, 0);
     const remain = info.remain_quota_display ?? 0;
     const remainingVisible = Math.max(remain, 0);
-    const total = Math.max(added, used+ remainingVisible, 1);
+    const total = Math.max(added, used + remainingVisible, 1);
     const overflow = remain < 0 ? Math.abs(remain) : Math.max(used - total, 0);
 
     return {
@@ -666,28 +1164,40 @@ export function AccountsPage({
   const draggingAccount =
     draggingAccountID === null
       ? null
-      : accounts.find((item) => item.id === draggingAccountID) ??
-        dragSnapshotRef.current?.find((item) => item.id === draggingAccountID) ??
-        null;
+      : (accounts.find((item) => item.id === draggingAccountID) ??
+        dragSnapshotRef.current?.find(
+          (item) => item.id === draggingAccountID,
+        ) ??
+        null);
 
-  function renderAccountCard(record: AccountRecord, options: AccountCardRenderOptions = {}) {
+  function renderAccountCard(
+    record: AccountRecord,
+    options: AccountCardRenderOptions = {},
+  ) {
     const sourceIcon = sourceIconMap[normalizeSourceIcon(record.source_icon)];
     const usageWindows = isOfficialAccount(record)
       ? [
-          { label: "5H", remainingPercent: clampPercent(100 - record.primary_used_percent) },
-          { label: "7D", remainingPercent: clampPercent(100 - record.secondary_used_percent) },
+          {
+            label: "5H",
+            remainingPercent: clampPercent(100 - record.primary_used_percent),
+          },
+          {
+            label: "7D",
+            remainingPercent: clampPercent(100 - record.secondary_used_percent),
+          },
         ]
-      : isPPChatAccount(record) &&
-          (record.ppchat_today_added_quota ?? 0) > 0
+      : isPPChatAccount(record) && (record.ppchat_today_added_quota ?? 0) > 0
         ? [
             {
               label: "1D",
               remainingPercent: clampPercent(
-                ((record.ppchat_today_remaining_quota ?? 0) / Math.max(record.ppchat_today_added_quota ?? 0, 1)) * 100,
+                ((record.ppchat_today_remaining_quota ?? 0) /
+                  Math.max(record.ppchat_today_added_quota ?? 0, 1)) *
+                  100,
               ),
             },
           ]
-      : [];
+        : [];
 
     return (
       <div
@@ -702,20 +1212,31 @@ export function AccountsPage({
               ref={options.setHandleRef}
               className="account-drag-handle"
               aria-label={`${t("拖拽排序")}-${record.account_name}`}
-              {...(options.handleAttributes as ButtonHTMLAttributes<HTMLButtonElement> | undefined)}
-              {...(options.handleListeners as ButtonHTMLAttributes<HTMLButtonElement> | undefined)}
+              {...(options.handleAttributes as
+                | ButtonHTMLAttributes<HTMLButtonElement>
+                | undefined)}
+              {...(options.handleListeners as
+                | ButtonHTMLAttributes<HTMLButtonElement>
+                | undefined)}
             >
               <HolderOutlined />
             </button>
             <div className="account-main">
-              <Avatar src={sourceIcon.icon} size={36} shape="square" className="account-source-icon" />
+              <Avatar
+                src={sourceIcon.icon}
+                size={36}
+                shape="square"
+                className="account-source-icon"
+              />
               <div className="account-main-text">
                 <div className="account-title-row">
                   <Text strong>{record.account_name}</Text>
                   <Tag color={statusColorMap[record.status] ?? "default"}>
                     {t(statusTextMap[record.status] ?? record.status)}
                   </Tag>
-                  {record.is_active ? <Tag color="green">{t("当前使用中")}</Tag> : null}
+                  {record.is_active ? (
+                    <Tag color="green">{t("当前使用中")}</Tag>
+                  ) : null}
                 </div>
                 <Text type="secondary" className="account-base-url">
                   {record.base_url || t("OpenAI 官方")}
@@ -729,10 +1250,17 @@ export function AccountsPage({
                 {usageWindows.map((item) => (
                   <div className="account-usage-mini-row" key={item.label}>
                     <div className="account-usage-mini-head">
-                      <span className="account-usage-mini-label">{item.label}</span>
-                      <span className={`account-usage-mini-value is-${getRemainingTone(item.remainingPercent)}`}>{`${Math.round(item.remainingPercent)}%`}</span>
+                      <span className="account-usage-mini-label">
+                        {item.label}
+                      </span>
+                      <span
+                        className={`account-usage-mini-value is-${getRemainingTone(item.remainingPercent)}`}
+                      >{`${Math.round(item.remainingPercent)}%`}</span>
                     </div>
-                    <div className="account-usage-mini-track" aria-label={`${record.account_name}-${item.label}`}>
+                    <div
+                      className="account-usage-mini-track"
+                      aria-label={`${record.account_name}-${item.label}`}
+                    >
                       <div
                         className={`account-usage-mini-fill is-${getRemainingTone(item.remainingPercent)}`}
                         style={{ width: `${item.remainingPercent}%` }}
@@ -793,7 +1321,10 @@ export function AccountsPage({
                   disabled={options.actionsDisabled}
                   onClick={() =>
                     void modal.confirm({
-                      title: formatDeleteAccountTitle(language, record.account_name),
+                      title: formatDeleteAccountTitle(
+                        language,
+                        record.account_name,
+                      ),
                       okText: t("删除"),
                       cancelText: t("取消"),
                       centered: true,
@@ -819,7 +1350,9 @@ export function AccountsPage({
             <Title level={2} style={{ marginBottom: 8 }}>
               {t("账户列表")}
             </Title>
-            <Text type="secondary">{t("主表仅展示核心状态，详细信息请通过详情查看。")}</Text>
+            <Text type="secondary">
+              {t("主表仅展示核心状态，详细信息请通过详情查看。")}
+            </Text>
           </div>
           <Dropdown
             menu={{
@@ -857,7 +1390,10 @@ export function AccountsPage({
           onDragEnd={(event) => void handleDragEnd(event)}
           onDragCancel={handleDragCancel}
         >
-          <SortableContext items={accounts.map((record) => record.id)} strategy={verticalListSortingStrategy}>
+          <SortableContext
+            items={accounts.map((record) => record.id)}
+            strategy={verticalListSortingStrategy}
+          >
             <div className="account-cards">
               {accounts.map((record) => (
                 <SortableAccountCard
@@ -871,18 +1407,31 @@ export function AccountsPage({
           </SortableContext>
           <DragOverlay>
             {draggingAccount ? (
-              <div className="account-drag-overlay">{renderAccountCard(draggingAccount, { actionsDisabled: true })}</div>
+              <div className="account-drag-overlay">
+                {renderAccountCard(draggingAccount, { actionsDisabled: true })}
+              </div>
             ) : null}
           </DragOverlay>
         </DndContext>
       )}
 
-      <Modal open={!!detailAccount} title={t("账户详情")} onCancel={() => setDetailAccount(null)} footer={null} destroyOnHidden centered width={880}>
+      <Modal
+        open={!!detailAccount}
+        title={t("账户详情")}
+        onCancel={() => setDetailAccount(null)}
+        footer={null}
+        destroyOnHidden
+        centered
+        width={880}
+      >
         {detailAccount ? (
           normalizeSourceIcon(detailAccount.source_icon) === "ppchat" ? (
             <div className="account-detail-layout">
               {detailLogsLoading ? (
-                <Card variant="borderless" className="account-detail-chart-card">
+                <Card
+                  variant="borderless"
+                  className="account-detail-chart-card"
+                >
                   <Skeleton active paragraph={{ rows: 8 }} />
                 </Card>
               ) : (
@@ -890,56 +1439,108 @@ export function AccountsPage({
                   <Card variant="borderless" className="ppchat-progress-card">
                     <div className="ppchat-stat-title">{t("今日配额进度")}</div>
                     <div className="ppchat-progress-head">
-                      <span className={`ppchat-progress-primary ${ppchatQuotaSummary?.overflow ? "is-danger" : ""}`}>
+                      <span
+                        className={`ppchat-progress-primary ${ppchatQuotaSummary?.overflow ? "is-danger" : ""}`}
+                      >
                         {ppchatQuotaSummary
                           ? `${ppchatQuotaSummary.overflow ? t("超出") : t("剩余")} ${formatInteger(language, ppchatQuotaSummary.overflow || ppchatQuotaSummary.remain)}`
                           : "--"}
                       </span>
-                      <span className={`ppchat-progress-secondary ${ppchatQuotaSummary?.overflow ? "is-danger" : ""}`}>
+                      <span
+                        className={`ppchat-progress-secondary ${ppchatQuotaSummary?.overflow ? "is-danger" : ""}`}
+                      >
                         {ppchatQuotaSummary
                           ? `${t("已用")} ${formatInteger(language, ppchatQuotaSummary.used)} / ${t("新增")} ${formatInteger(language, ppchatQuotaSummary.added)}`
                           : "--"}
                       </span>
                     </div>
-                    <div className="ppchat-progress-bar-shell" aria-label={t("今日配额进度")}>
+                    <div
+                      className="ppchat-progress-bar-shell"
+                      aria-label={t("今日配额进度")}
+                    >
                       <div
                         className={`ppchat-progress-bar ${ppchatQuotaSummary?.overflow ? "is-danger" : ""}`}
-                        style={{ width: `${ppchatQuotaSummary?.progressPercent ?? 0}%` }}
+                        style={{
+                          width: `${ppchatQuotaSummary?.progressPercent ?? 0}%`,
+                        }}
                       />
                     </div>
                   </Card>
-                  <Card variant="borderless" className="ppchat-metric-card ppchat-metric-card-compact">
+                  <Card
+                    variant="borderless"
+                    className="ppchat-metric-card ppchat-metric-card-compact"
+                  >
                     <Statistic
-                      title={<span className="ppchat-stat-title">{t("当天增加配额")}</span>}
-                      value={ppchatQuotaSummary ? formatInteger(language, ppchatQuotaSummary.added) : "--"}
-                      valueRender={(node) => <span className="ppchat-stat-value">{node}</span>}
+                      title={
+                        <span className="ppchat-stat-title">
+                          {t("当天增加配额")}
+                        </span>
+                      }
+                      value={
+                        ppchatQuotaSummary
+                          ? formatInteger(language, ppchatQuotaSummary.added)
+                          : "--"
+                      }
+                      valueRender={(node) => (
+                        <span className="ppchat-stat-value">{node}</span>
+                      )}
                     />
                   </Card>
-                  <Card variant="borderless" className="ppchat-metric-card ppchat-metric-card-compact">
+                  <Card
+                    variant="borderless"
+                    className="ppchat-metric-card ppchat-metric-card-compact"
+                  >
                     <Statistic
-                      title={<span className="ppchat-stat-title">{t("今日已用次数")}</span>}
-                      value={ppchatQuotaSummary ? formatInteger(language, ppchatQuotaSummary.usageCount) : "--"}
-                      valueRender={(node) => <span className="ppchat-stat-value">{node}</span>}
+                      title={
+                        <span className="ppchat-stat-title">
+                          {t("今日已用次数")}
+                        </span>
+                      }
+                      value={
+                        ppchatQuotaSummary
+                          ? formatInteger(
+                              language,
+                              ppchatQuotaSummary.usageCount,
+                            )
+                          : "--"
+                      }
+                      valueRender={(node) => (
+                        <span className="ppchat-stat-value">{node}</span>
+                      )}
                     />
                   </Card>
                 </div>
               )}
-              <Card variant="borderless" className="account-detail-chart-card" title={t("PPChat Token 日志")} extra={<BarChartOutlined />}>
+              <Card
+                variant="borderless"
+                className="account-detail-chart-card"
+                title={t("PPChat Token 日志")}
+                extra={<BarChartOutlined />}
+              >
                 {detailLogsLoading ? (
                   <Skeleton active paragraph={{ rows: 5 }} />
                 ) : detailLogs?.logs?.length ? (
                   <div className="token-log-list">
                     {detailLogs.logs.slice(0, 8).map((log, index) => {
                       const total = log.prompt_tokens + log.completion_tokens;
-                      const width = detailLogMaxTokens > 0 ? Math.max((total / detailLogMaxTokens) * 100, 6) : 0;
+                      const width =
+                        detailLogMaxTokens > 0
+                          ? Math.max((total / detailLogMaxTokens) * 100, 6)
+                          : 0;
                       return (
-                        <div className="token-log-row" key={`${log.created_at}-${index}`}>
+                        <div
+                          className="token-log-row"
+                          key={`${log.created_at}-${index}`}
+                        >
                           <div className="token-log-meta">
                             <span>{log.model_name}</span>
                             <span>{log.created_time}</span>
                           </div>
                           <div className="token-log-bar-bg">
-                            <div className="token-log-bar" style={{ width: `${width}%` }} />
+                            <div
+                              className="token-log-bar"
+                              style={{ width: `${width}%` }}
+                            />
                           </div>
                           <div className="token-log-values">
                             <span>Prompt {log.prompt_tokens}</span>
@@ -950,7 +1551,10 @@ export function AccountsPage({
                     })}
                   </div>
                 ) : (
-                  <Empty description={t("暂无 PPChat 日志数据")} image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                  <Empty
+                    description={t("暂无 PPChat 日志数据")}
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  />
                 )}
               </Card>
             </div>
@@ -958,32 +1562,65 @@ export function AccountsPage({
             <div className="account-detail-layout">
               <div className="account-detail-stats">
                 <Card variant="borderless">
-                  <Statistic title={t("额度余额")} value={Math.round(detailAccount.quota_remaining)} />
+                  <Statistic
+                    title={t("额度余额")}
+                    value={Math.round(detailAccount.quota_remaining)}
+                  />
                 </Card>
                 <Card variant="borderless">
-                  <Statistic title={t("健康分")} value={detailAccount.health_score.toFixed(2)} />
+                  <Statistic
+                    title={t("健康分")}
+                    value={detailAccount.health_score.toFixed(2)}
+                  />
                 </Card>
                 <Card variant="borderless">
-                  <Statistic title={t("最近 Token")} value={Math.round(detailAccount.last_total_tokens)} />
+                  <Statistic
+                    title={t("最近 Token")}
+                    value={Math.round(detailAccount.last_total_tokens)}
+                  />
                 </Card>
                 <Card variant="borderless">
-                  <Statistic title={t("错误率")} value={(detailAccount.recent_error_rate * 100).toFixed(1)} suffix="%" />
+                  <Statistic
+                    title={t("错误率")}
+                    value={(detailAccount.recent_error_rate * 100).toFixed(1)}
+                    suffix="%"
+                  />
                 </Card>
               </div>
               <Card variant="borderless" className="account-detail-meta">
                 <Descriptions column={2} size="small">
-                  <Descriptions.Item label={t("账户")}>{detailAccount.account_name}</Descriptions.Item>
-                  <Descriptions.Item label={t("来源")}>{sourceIconMap[normalizeSourceIcon(detailAccount.source_icon)].label}</Descriptions.Item>
-                  <Descriptions.Item label={t("状态")}>{t(statusTextMap[detailAccount.status] ?? detailAccount.status)}</Descriptions.Item>
-                  <Descriptions.Item label={t("认证方式")}>{t(authModeTextMap[detailAccount.auth_mode] ?? detailAccount.auth_mode)}</Descriptions.Item>
+                  <Descriptions.Item label={t("账户")}>
+                    {detailAccount.account_name}
+                  </Descriptions.Item>
+                  <Descriptions.Item label={t("来源")}>
+                    {
+                      sourceIconMap[
+                        normalizeSourceIcon(detailAccount.source_icon)
+                      ].label
+                    }
+                  </Descriptions.Item>
+                  <Descriptions.Item label={t("状态")}>
+                    {t(
+                      statusTextMap[detailAccount.status] ??
+                        detailAccount.status,
+                    )}
+                  </Descriptions.Item>
+                  <Descriptions.Item label={t("认证方式")}>
+                    {t(
+                      authModeTextMap[detailAccount.auth_mode] ??
+                        detailAccount.auth_mode,
+                    )}
+                  </Descriptions.Item>
                   <Descriptions.Item label={t("接口地址")} span={2}>
                     {detailAccount.base_url || t("OpenAI 官方")}
                   </Descriptions.Item>
                   <Descriptions.Item label={t("5 小时剩余")}>
-                    {(100 - detailAccount.primary_used_percent).toFixed(0)}% · {formatResetAt(detailAccount.primary_resets_at, language)}
+                    {(100 - detailAccount.primary_used_percent).toFixed(0)}% ·{" "}
+                    {formatResetAt(detailAccount.primary_resets_at, language)}
                   </Descriptions.Item>
                   <Descriptions.Item label={t("1 周剩余")}>
-                    {(100 - detailAccount.secondary_used_percent).toFixed(0)}% · {formatResetAt(detailAccount.secondary_resets_at, language)}
+                    {(100 - detailAccount.secondary_used_percent).toFixed(0)}% ·{" "}
+                    {formatResetAt(detailAccount.secondary_resets_at, language)}
                   </Descriptions.Item>
                 </Descriptions>
               </Card>
@@ -1006,17 +1643,31 @@ export function AccountsPage({
           initialValues={{ base_url: defaultBaseURL }}
           onFinish={(values) => void handleCreateThirdParty(values)}
         >
-          <Form.Item label={t("账户名称")} name="account_name" rules={[{ required: true, message: t("请输入账户名称") }]}>
+          <Form.Item
+            label={t("账户名称")}
+            name="account_name"
+            rules={[{ required: true, message: t("请输入账户名称") }]}
+          >
             <Input />
           </Form.Item>
-          <Form.Item label={t("接口地址")} name="base_url" rules={[{ required: true, message: t("请输入接口地址") }]}>
+          <Form.Item
+            label={t("接口地址")}
+            name="base_url"
+            rules={[{ required: true, message: t("请输入接口地址") }]}
+          >
             <Input />
           </Form.Item>
-          <Form.Item label="API Key" name="credential_ref" rules={[{ required: true, message: t("请输入 API Key") }]}>
+          <Form.Item
+            label="API Key"
+            name="credential_ref"
+            rules={[{ required: true, message: t("请输入 API Key") }]}
+          >
             <Input.Password />
           </Form.Item>
           <div className="modal-footer">
-            <Button onClick={() => setInternalAddModalMode(null)}>{t("取消")}</Button>
+            <Button onClick={() => setInternalAddModalMode(null)}>
+              {t("取消")}
+            </Button>
             <Button type="primary" htmlType="submit">
               {t("保存")}
             </Button>
@@ -1032,17 +1683,34 @@ export function AccountsPage({
         destroyOnHidden
         centered
       >
-        <Form form={officialForm} layout="vertical" onFinish={(values) => void handleCreateOfficial(values)}>
-          <Form.Item label={t("账户名称")} name="account_name" initialValue="local-codex">
+        <Form
+          form={officialForm}
+          layout="vertical"
+          onFinish={(values) => void handleCreateOfficial(values)}
+        >
+          <Form.Item
+            label={t("账户名称")}
+            name="account_name"
+            initialValue="local-codex"
+          >
             <Input />
           </Form.Item>
           <Text type="secondary">
-            {language === "en-US"
-              ? <>The app reads <code>~/.codex/auth.json</code> directly from the current user directory.</>
-              : <>将直接读取当前用户目录下的 <code>~/.codex/auth.json</code>。</>}
+            {language === "en-US" ? (
+              <>
+                The app reads <code>~/.codex/auth.json</code> directly from the
+                current user directory.
+              </>
+            ) : (
+              <>
+                将直接读取当前用户目录下的 <code>~/.codex/auth.json</code>。
+              </>
+            )}
           </Text>
           <div className="modal-footer">
-            <Button onClick={() => setInternalAddModalMode(null)}>{t("取消")}</Button>
+            <Button onClick={() => setInternalAddModalMode(null)}>
+              {t("取消")}
+            </Button>
             <Button type="primary" htmlType="submit">
               {t("导入")}
             </Button>
@@ -1061,11 +1729,21 @@ export function AccountsPage({
         destroyOnHidden
         centered
       >
-        <Form form={sharedImportForm} layout="vertical" onFinish={(values) => void handleImportShared(values)}>
-          <Form.Item label={t("粘贴分享内容")} name="payload" rules={[{ required: true, message: t("请粘贴分享内容") }]}>
+        <Form
+          form={sharedImportForm}
+          layout="vertical"
+          onFinish={(values) => void handleImportShared(values)}
+        >
+          <Form.Item
+            label={t("粘贴分享内容")}
+            name="payload"
+            rules={[{ required: true, message: t("请粘贴分享内容") }]}
+          >
             <Input.TextArea rows={8} spellCheck={false} />
           </Form.Item>
-          {sharedImportError ? <Text type="danger">{sharedImportError}</Text> : null}
+          {sharedImportError ? (
+            <Text type="danger">{sharedImportError}</Text>
+          ) : null}
           <div className="modal-footer">
             <Button
               onClick={() => {
@@ -1090,29 +1768,161 @@ export function AccountsPage({
         destroyOnHidden
         centered
       >
-        <Form form={editForm} layout="vertical" onFinish={(values) => void handleEdit(values)}>
-          <Form.Item label={t("账户名称")} name="account_name" rules={[{ required: true, message: t("请输入账户名称") }]}>
+        <Form
+          form={editForm}
+          layout="vertical"
+          onFinish={(values) =>
+            void handleEdit(values).catch((error) => {
+              void messageApi.error(
+                error instanceof Error ? error.message : t("账户更新失败"),
+              );
+            })
+          }
+        >
+          <Form.Item
+            label={t("账户名称")}
+            name="account_name"
+            rules={[{ required: true, message: t("请输入账户名称") }]}
+          >
             <Input />
           </Form.Item>
-          <Form.Item label={t("来源图标")} name="source_icon" rules={[{ required: true, message: t("请选择来源图标") }]}>
+          <Form.Item
+            label={t("来源图标")}
+            name="source_icon"
+            rules={[{ required: true, message: t("请选择来源图标") }]}
+          >
             <Select
-              options={(Object.keys(sourceIconMap) as SourceIcon[]).map((key) => ({
-                value: key,
-                label: (
-                  <span className="source-option">
-                    <Avatar src={sourceIconMap[key].icon} size={16} shape="square" />
-                    <span>{sourceIconMap[key].label}</span>
-                  </span>
-                ),
-              }))}
+              options={(Object.keys(sourceIconMap) as SourceIcon[]).map(
+                (key) => ({
+                  value: key,
+                  label: (
+                    <span className="source-option">
+                      <Avatar
+                        src={sourceIconMap[key].icon}
+                        size={16}
+                        shape="square"
+                      />
+                      <span>{sourceIconMap[key].label}</span>
+                    </span>
+                  ),
+                }),
+              )}
             />
           </Form.Item>
-          <Form.Item label={t("接口地址")} name="base_url" rules={[{ required: true, message: t("请输入接口地址") }]}>
+          <Form.Item
+            label={t("接口地址")}
+            name="base_url"
+            rules={[{ required: true, message: t("请输入接口地址") }]}
+          >
             <Input />
           </Form.Item>
           <Form.Item label={t("API Key / Token")} name="credential_ref">
             <Input.Password placeholder={t("留空表示不修改")} />
           </Form.Item>
+          <Form.Item label={t("用量驱动")} name="usage_driver">
+            <Select
+              options={[
+                { value: "", label: t("自动 / 内置") },
+                { value: "lua", label: "Lua" },
+              ]}
+            />
+          </Form.Item>
+          {editUsageDriver === "lua" ? (
+            <div className="lua-usage-panel">
+              <div className="lua-usage-panel-header">
+                <Text strong>{t("Lua Usage 配置")}</Text>
+                <div className="lua-usage-panel-actions">
+                  <Button
+                    type="text"
+                    onClick={() => setShowAdvancedLuaConfig((value) => !value)}
+                  >
+                    {showAdvancedLuaConfig ? t("隐藏高级配置") : t("高级配置")}
+                  </Button>
+                  <Button
+                    type="text"
+                    onClick={() =>
+                      void handleCopyLuaSkill().catch((error) => {
+                        void messageApi.error(
+                          error instanceof Error
+                            ? error.message
+                            : t("复制 AI Skill 失败"),
+                        );
+                      })
+                    }
+                  >
+                    {t("复制 AI Skill")}
+                  </Button>
+                </div>
+              </div>
+              <Form.Item label={t("共享脚本")} htmlFor="lua-script-key">
+                <div className="lua-script-select-row">
+                  <Select
+                    id="lua-script-key"
+                    value={luaScriptKey || undefined}
+                    placeholder={t("按当前供应商自动匹配脚本")}
+                    options={availableLuaScripts.map((item) => ({
+                      value: item,
+                      label: item,
+                    }))}
+                    onChange={(value) =>
+                      void handleSelectLuaScript(String(value || ""))
+                    }
+                    showSearch
+                    optionFilterProp="label"
+                    allowClear
+                    className="lua-script-select"
+                  />
+                  <Button onClick={() => void handleCreateLuaScript()}>
+                    {t("新增脚本")}
+                  </Button>
+                </div>
+                {luaScriptKey ? (
+                  <Text type="secondary">
+                    {t("当前脚本标识")}: {luaScriptKey}
+                  </Text>
+                ) : (
+                  <Text type="secondary">
+                    {t("将按接口地址主机名自动匹配共享脚本")}
+                  </Text>
+                )}
+              </Form.Item>
+              <Form.Item label={t("Lua 脚本")} htmlFor="lua-script-content">
+                <Input.TextArea
+                  id="lua-script-content"
+                  rows={10}
+                  value={luaScriptContent}
+                  onChange={(event) => setLuaScriptContent(event.target.value)}
+                  spellCheck={false}
+                  placeholder="function fetch_usage(ctx) ... end"
+                />
+              </Form.Item>
+              {showAdvancedLuaConfig ? (
+                <Form.Item
+                  label={t("Usage 配置 JSON")}
+                  htmlFor="lua-config-draft"
+                >
+                  <Input.TextArea
+                    id="lua-config-draft"
+                    rows={5}
+                    value={luaConfigDraft}
+                    onChange={(event) => setLuaConfigDraft(event.target.value)}
+                    spellCheck={false}
+                  />
+                </Form.Item>
+              ) : null}
+              {luaScriptLoading ? (
+                <Text type="secondary">{t("正在加载共享脚本...")}</Text>
+              ) : null}
+              <div className="modal-footer">
+                <Button
+                  onClick={() => void handleLuaTest()}
+                  loading={luaTesting}
+                >
+                  {t("测试 Lua 脚本")}
+                </Button>
+              </div>
+            </div>
+          ) : null}
           <div className="modal-footer">
             <Button onClick={() => setEditingAccount(null)}>{t("取消")}</Button>
             <Button type="primary" htmlType="submit">
@@ -1122,8 +1932,17 @@ export function AccountsPage({
         </Form>
         <div className="edit-test-panel">
           <Text strong>{t("连接测试")}</Text>
-          <Form form={testForm} layout="vertical" initialValues={{ model: "gpt-5.4", input: "ping" }} onFinish={(values) => void handleTest(values)}>
-            <Form.Item label={t("模型")} name="model" rules={[{ required: true, message: t("请选择模型") }]}>
+          <Form
+            form={testForm}
+            layout="vertical"
+            initialValues={{ model: "gpt-5.4", input: "ping" }}
+            onFinish={(values) => void handleTest(values)}
+          >
+            <Form.Item
+              label={t("模型")}
+              name="model"
+              rules={[{ required: true, message: t("请选择模型") }]}
+            >
               <Select
                 options={[
                   { value: "gpt-5.4", label: "gpt-5.4" },
@@ -1134,7 +1953,11 @@ export function AccountsPage({
                 ]}
               />
             </Form.Item>
-            <Form.Item label={t("输入内容")} name="input" rules={[{ required: true, message: t("请输入测试内容") }]}>
+            <Form.Item
+              label={t("输入内容")}
+              name="input"
+              rules={[{ required: true, message: t("请输入测试内容") }]}
+            >
               <Input.TextArea rows={3} />
             </Form.Item>
             <div className="modal-footer">
@@ -1144,9 +1967,28 @@ export function AccountsPage({
         </div>
         {testResult ? (
           <div className="test-result-panel">
-            <Tag color={testResult.ok ? "green" : "red"}>{testResult.message}</Tag>
-            {testResult.details ? <Text type="secondary">{testResult.details}</Text> : null}
-            {testResult.content ? <pre className="test-output">{testResult.content}</pre> : null}
+            <Tag color={testResult.ok ? "green" : "red"}>
+              {testResult.message}
+            </Tag>
+            {testResult.details ? (
+              <Text type="secondary">{testResult.details}</Text>
+            ) : null}
+            {testResult.content ? (
+              <pre className="test-output">{testResult.content}</pre>
+            ) : null}
+          </div>
+        ) : null}
+        {luaTestResult ? (
+          <div className="test-result-panel">
+            <Tag color={luaTestResult.ok ? "green" : "red"}>
+              {luaTestResult.message}
+            </Tag>
+            {luaTestResult.details ? (
+              <Text type="secondary">{luaTestResult.details}</Text>
+            ) : null}
+            {luaTestResult.content ? (
+              <pre className="test-output">{luaTestResult.content}</pre>
+            ) : null}
           </div>
         ) : null}
       </Modal>
@@ -1155,7 +1997,10 @@ export function AccountsPage({
 }
 
 function getDefaultTestModel(account: AccountRecord): string {
-  if (account.auth_mode === "codex_local_import" || account.provider_type === "openai-official") {
+  if (
+    account.auth_mode === "codex_local_import" ||
+    account.provider_type === "openai-official"
+  ) {
     return "gpt-5.4";
   }
   return "gpt-5.4";

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -132,6 +132,20 @@ export type AccountTestResult = {
   content?: string;
 };
 
+export type LuaUsageScriptRecord = {
+  key: string;
+  content: string;
+};
+
+export type LuaUsageScriptList = {
+  items: string[];
+};
+
+export type LuaUsageTestPayload = {
+  usage_config_json: string;
+  script_content: string;
+};
+
 export type PPChatTokenLogsPayload = {
   data: {
     logs: Array<{
@@ -252,7 +266,9 @@ export async function refreshAccountUsage(): Promise<void> {
   }
 }
 
-export function subscribeAccountRoutingStateChanged(handler: () => void): () => void {
+export function subscribeAccountRoutingStateChanged(
+  handler: () => void,
+): () => void {
   if (typeof window === "undefined" || typeof EventSource === "undefined") {
     return () => {};
   }
@@ -268,7 +284,9 @@ export function subscribeAccountRoutingStateChanged(handler: () => void): () => 
   };
 }
 
-export async function createAccount(payload: CreateAccountPayload): Promise<void> {
+export async function createAccount(
+  payload: CreateAccountPayload,
+): Promise<void> {
   const response = await fetch(apiPath("/accounts"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -281,7 +299,13 @@ export async function createAccount(payload: CreateAccountPayload): Promise<void
 
 export async function updateAccount(
   id: number,
-  payload: Partial<CreateAccountPayload> & { account_name?: string; status?: string; priority?: number; is_active?: boolean; supports_responses?: boolean },
+  payload: Partial<CreateAccountPayload> & {
+    account_name?: string;
+    status?: string;
+    priority?: number;
+    is_active?: boolean;
+    supports_responses?: boolean;
+  },
 ): Promise<void> {
   const response = await fetch(apiPath(`/accounts/${id}`), {
     method: "PUT",
@@ -329,7 +353,12 @@ export async function importSharedAccount(payload: string): Promise<void> {
 
 export type DashboardRangeKey = "24h" | "7d" | "30d";
 
-function dashboardQuery(range: DashboardRangeKey = "24h", accountID?: number, model?: string, limit?: number): string {
+function dashboardQuery(
+  range: DashboardRangeKey = "24h",
+  accountID?: number,
+  model?: string,
+  limit?: number,
+): string {
   const params = new URLSearchParams();
   params.set("range", range);
   if (accountID && accountID > 0) {
@@ -344,39 +373,71 @@ function dashboardQuery(range: DashboardRangeKey = "24h", accountID?: number, mo
   return params.toString();
 }
 
-export async function getDashboardSummary(range: DashboardRangeKey = "24h", accountID?: number, model?: string): Promise<UsageDashboardSummary> {
-  const response = await fetch(apiPath(`/dashboard/summary?${dashboardQuery(range, accountID, model)}`));
+export async function getDashboardSummary(
+  range: DashboardRangeKey = "24h",
+  accountID?: number,
+  model?: string,
+): Promise<UsageDashboardSummary> {
+  const response = await fetch(
+    apiPath(`/dashboard/summary?${dashboardQuery(range, accountID, model)}`),
+  );
   if (!response.ok) {
     throw new Error("failed to load dashboard summary");
   }
   return response.json();
 }
 
-export async function getDashboardTrends(range: DashboardRangeKey = "24h", accountID?: number, model?: string): Promise<UsageTrendPoint[]> {
-  const response = await fetch(apiPath(`/dashboard/trends?${dashboardQuery(range, accountID, model)}`));
+export async function getDashboardTrends(
+  range: DashboardRangeKey = "24h",
+  accountID?: number,
+  model?: string,
+): Promise<UsageTrendPoint[]> {
+  const response = await fetch(
+    apiPath(`/dashboard/trends?${dashboardQuery(range, accountID, model)}`),
+  );
   if (!response.ok) {
     throw new Error("failed to load dashboard trends");
   }
   return response.json();
 }
 
-export async function getDashboardRecentEvents(range: DashboardRangeKey = "24h", accountID?: number, model?: string, limit = 20): Promise<UsageEventRecord[]> {
-  const response = await fetch(apiPath(`/dashboard/recent-events?${dashboardQuery(range, accountID, model, limit)}`));
+export async function getDashboardRecentEvents(
+  range: DashboardRangeKey = "24h",
+  accountID?: number,
+  model?: string,
+  limit = 20,
+): Promise<UsageEventRecord[]> {
+  const response = await fetch(
+    apiPath(
+      `/dashboard/recent-events?${dashboardQuery(range, accountID, model, limit)}`,
+    ),
+  );
   if (!response.ok) {
     throw new Error("failed to load recent usage events");
   }
   return response.json();
 }
 
-export async function getDashboardModelDistribution(range: DashboardRangeKey = "24h", accountID?: number, model?: string): Promise<UsageModelDistributionPoint[]> {
-  const response = await fetch(apiPath(`/dashboard/model-distribution?${dashboardQuery(range, accountID, model)}`));
+export async function getDashboardModelDistribution(
+  range: DashboardRangeKey = "24h",
+  accountID?: number,
+  model?: string,
+): Promise<UsageModelDistributionPoint[]> {
+  const response = await fetch(
+    apiPath(
+      `/dashboard/model-distribution?${dashboardQuery(range, accountID, model)}`,
+    ),
+  );
   if (!response.ok) {
     throw new Error("failed to load model distribution");
   }
   return response.json();
 }
 
-export async function testAccount(id: number, payload: AccountChatTestPayload): Promise<AccountTestResult> {
+export async function testAccount(
+  id: number,
+  payload: AccountChatTestPayload,
+): Promise<AccountTestResult> {
   const response = await fetch(apiPath(`/accounts/${id}/test`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -394,8 +455,77 @@ export async function testAccount(id: number, payload: AccountChatTestPayload): 
   return data;
 }
 
-export async function fetchPPChatTokenLogs(accountID: number, page = 1, pageSize = 10): Promise<PPChatTokenLogsPayload> {
-  const response = await fetch(apiPath(`/accounts/${accountID}/ppchat-token-logs?page=${page}&page_size=${pageSize}`));
+export async function getLuaUsageScript(
+  key: string,
+): Promise<LuaUsageScriptRecord> {
+  const response = await fetch(
+    apiPath(`/accounts/usage-scripts/${encodeURIComponent(key)}`),
+  );
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to load lua usage script");
+  }
+  return response.json();
+}
+
+export async function listLuaUsageScripts(): Promise<LuaUsageScriptList> {
+  const response = await fetch(apiPath("/accounts/usage-scripts"));
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to list lua usage scripts");
+  }
+  return response.json();
+}
+
+export async function saveLuaUsageScript(
+  key: string,
+  content: string,
+): Promise<void> {
+  const response = await fetch(
+    apiPath(`/accounts/usage-scripts/${encodeURIComponent(key)}`),
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    },
+  );
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to save lua usage script");
+  }
+}
+
+export async function testLuaUsage(
+  id: number,
+  payload: LuaUsageTestPayload,
+): Promise<AccountTestResult> {
+  const response = await fetch(apiPath(`/accounts/${id}/usage-lua-test`), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const data = (await response.json()) as AccountTestResult;
+  if (!response.ok) {
+    return {
+      ok: false,
+      message: data.message || runtimeTranslate("测试失败"),
+      details: data.details || runtimeTranslate("请求 Lua 测试接口失败"),
+      content: data.content,
+    };
+  }
+  return data;
+}
+
+export async function fetchPPChatTokenLogs(
+  accountID: number,
+  page = 1,
+  pageSize = 10,
+): Promise<PPChatTokenLogsPayload> {
+  const response = await fetch(
+    apiPath(
+      `/accounts/${accountID}/ppchat-token-logs?page=${page}&page_size=${pageSize}`,
+    ),
+  );
   if (!response.ok) {
     const details = await response.text();
     throw new Error(details || "failed to fetch ppchat token logs");
@@ -423,7 +553,10 @@ export async function startOfficialAuth(): Promise<void> {
   }
 }
 
-export async function importLocalCodexAuth(file: File, accountName = "local-codex"): Promise<void> {
+export async function importLocalCodexAuth(
+  file: File,
+  accountName = "local-codex",
+): Promise<void> {
   const formData = new FormData();
   formData.append("account_name", accountName);
   formData.append("auth_file", file);
@@ -436,7 +569,9 @@ export async function importLocalCodexAuth(file: File, accountName = "local-code
   }
 }
 
-export async function importCurrentCodexAuth(accountName = "local-codex"): Promise<void> {
+export async function importCurrentCodexAuth(
+  accountName = "local-codex",
+): Promise<void> {
   const response = await fetch(apiPath("/accounts/import-current"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -478,8 +613,12 @@ export async function restoreCodexBackup(backupID: string): Promise<void> {
   }
 }
 
-export async function getCodexBackupFiles(backupID: string): Promise<CodexBackupFiles> {
-  const response = await fetch(apiPath(`/settings/codex/backups/${backupID}/files`));
+export async function getCodexBackupFiles(
+  backupID: string,
+): Promise<CodexBackupFiles> {
+  const response = await fetch(
+    apiPath(`/settings/codex/backups/${backupID}/files`),
+  );
   if (!response.ok) {
     const details = await response.text();
     throw new Error(details || "failed to fetch backup files");
@@ -503,7 +642,9 @@ export async function getAppSettings(): Promise<AppSettings> {
   return response.json();
 }
 
-export async function saveAppSettings(payload: AppSettings): Promise<AppSettings> {
+export async function saveAppSettings(
+  payload: AppSettings,
+): Promise<AppSettings> {
   const response = await fetch(apiPath("/settings/app"), {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -571,9 +712,12 @@ export async function importDatabaseSQL(raw: string): Promise<void> {
   }
 
   const trimmed = raw.trimStart();
-  const isAIGateJSONExchange = trimmed.startsWith("{") && raw.includes('"format":"aigate-db-exchange"');
+  const isAIGateJSONExchange =
+    trimmed.startsWith("{") && raw.includes('"format":"aigate-db-exchange"');
   if (isAIGateJSONExchange) {
-    throw new Error(runtimeTranslate("当前后端版本不支持 JSON 导入，请升级到最新版本后重试"));
+    throw new Error(
+      runtimeTranslate("当前后端版本不支持 JSON 导入，请升级到最新版本后重试"),
+    );
   }
 
   // Backward compatibility for legacy SQL import route.
@@ -620,9 +764,12 @@ export async function restoreDatabaseBackup(backupID: string): Promise<void> {
 }
 
 export async function deleteDatabaseBackup(backupID: string): Promise<void> {
-  const response = await fetch(apiPath(`/settings/database/backups/${encodeURIComponent(backupID)}`), {
-    method: "DELETE",
-  });
+  const response = await fetch(
+    apiPath(`/settings/database/backups/${encodeURIComponent(backupID)}`),
+    {
+      method: "DELETE",
+    },
+  );
   if (!response.ok) {
     const details = await response.text();
     throw new Error(details || "failed to delete database backup");
@@ -630,7 +777,9 @@ export async function deleteDatabaseBackup(backupID: string): Promise<void> {
 }
 
 export async function enableProxy(): Promise<ProxyStatus> {
-  const response = await fetch(apiPath("/settings/proxy/enable"), { method: "POST" });
+  const response = await fetch(apiPath("/settings/proxy/enable"), {
+    method: "POST",
+  });
   if (!response.ok) {
     const details = await response.text();
     throw new Error(details || "failed to enable proxy");
@@ -638,7 +787,10 @@ export async function enableProxy(): Promise<ProxyStatus> {
   return response.json();
 }
 
-export async function disableProxy(options?: { force?: boolean; skipRestore?: boolean }): Promise<ProxyStatus> {
+export async function disableProxy(options?: {
+  force?: boolean;
+  skipRestore?: boolean;
+}): Promise<ProxyStatus> {
   const params = new URLSearchParams();
   if (options?.force) {
     params.set("force", "1");
@@ -647,7 +799,9 @@ export async function disableProxy(options?: { force?: boolean; skipRestore?: bo
     params.set("skip_restore", "1");
   }
   const suffix = params.toString() ? `?${params.toString()}` : "";
-  const response = await fetch(apiPath(`/settings/proxy/disable${suffix}`), { method: "POST" });
+  const response = await fetch(apiPath(`/settings/proxy/disable${suffix}`), {
+    method: "POST",
+  });
   if (!response.ok) {
     const details = await response.text();
     throw new Error(details || "failed to disable proxy");

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1326,6 +1326,38 @@ html[data-theme-mode="dark"] .stats-chart-shell {
   border-top: 1px dashed #e5e7eb;
 }
 
+.lua-usage-panel {
+  margin-top: 18px;
+  padding: 16px;
+  border: 1px solid var(--panel-border);
+  border-radius: 18px;
+  background: var(--panel-soft);
+}
+
+.lua-usage-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.lua-usage-panel-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.lua-script-select-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.lua-script-select {
+  flex: 1 1 auto;
+}
+
 .account-detail-layout {
   display: grid;
   gap: 16px;


### PR DESCRIPTION
## Summary
- add managed Lua usage script storage, APIs, and runtime wiring
- add account edit UI for shared Lua scripts, testing, and AI skill copy flow
- harden SQLite startup for desktop workloads and isolate local `make backend` dev database

## Verification
- `cd backend && go test ./... -timeout 60s`
- `cd frontend && npm test -- --run`
- `cd frontend && npm run build`

## Notes
- Direct push to `main` is blocked by repository rules, so this PR carries the validated release changes.
- Tag `v1.1.11` has already been pushed and points to this commit.