### PR TITLE
test: stabilize stats empty state assertions

### DIFF
--- a/frontend/src/features/stats/StatsPage.test.tsx
+++ b/frontend/src/features/stats/StatsPage.test.tsx
@@ -101,8 +101,8 @@ describe("StatsPage", () => {
     render(<StatsPage language="zh-CN" t={t} />);
 
     expect(await screen.findByText("Token 与费用统计")).toBeInTheDocument();
-    expect(screen.getByText("暂无趋势数据")).toBeInTheDocument();
-    expect(screen.getByText("暂无模型数据")).toBeInTheDocument();
-    expect(screen.getByText("暂无最近记录")).toBeInTheDocument();
+    expect(await screen.findByText("暂无趋势数据")).toBeInTheDocument();
+    expect(await screen.findByText("暂无模型数据")).toBeInTheDocument();
+    expect(await screen.findByText("暂无最近记录")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- wait for stats empty-state text to render before asserting in CI
- fix the flaky frontend test that broke release test job

## Verification
- `cd frontend && npm test -- --run src/features/stats/StatsPage.test.tsx`
- `cd frontend && npm test -- --run`