### PR TITLE
fix: stabilize account actions, share copy, and official reset display

### DIFF
--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -427,6 +427,220 @@ describe("AccountsPage", () => {
     });
   });
 
+  it("falls back to document copy when navigator clipboard is unavailable", async () => {
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    const originalExecCommand = document.execCommand;
+    Object.defineProperty(document, "execCommand", {
+      value: vi.fn(() => true),
+      configurable: true,
+    });
+    const execCommand = document.execCommand as unknown as ReturnType<
+      typeof vi.fn
+    >;
+
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-compatible",
+        account_name: "mirror-east",
+        source_icon: "ppchat",
+        auth_mode: "api_key",
+        base_url: "https://code.ppchat.vip/v1",
+        account_driver: "builtin_api_key",
+        usage_driver: "lua",
+        usage_config_json: '{"script":"adapters/vendor.lua"}',
+        status: "active",
+        is_active: false,
+        priority: 2,
+        supports_responses: true,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 0,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/1/share" &&
+        init?.method === "POST"
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ payload: '{"kind":"aigate-account-share"}' }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("mirror-east")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "分享-mirror-east" }));
+    const confirmModal = await screen.findByRole("dialog", {
+      name: "分享账户",
+    });
+    fireEvent.click(
+      within(confirmModal).getByRole("button", { name: "确认分享" }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/1/share",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(execCommand).toHaveBeenCalledWith("copy");
+    });
+
+    Object.defineProperty(document, "execCommand", {
+      value: originalExecCommand,
+      configurable: true,
+    });
+  });
+
+  it("keeps only one account action tray visible at a time", async () => {
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-compatible",
+        account_name: "mirror-east",
+        source_icon: "openai",
+        auth_mode: "api_key",
+        base_url: "https://one.example/v1",
+        status: "active",
+        is_active: false,
+        priority: 2,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 1,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+      {
+        id: 2,
+        provider_type: "openai-compatible",
+        account_name: "mirror-west",
+        source_icon: "claude_code",
+        auth_mode: "api_key",
+        base_url: "https://two.example/v1",
+        status: "active",
+        is_active: false,
+        priority: 1,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 1,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("mirror-east")).toBeInTheDocument();
+    const firstCard = screen
+      .getByText("mirror-east")
+      .closest(".account-card-item") as HTMLElement;
+    const secondCard = screen
+      .getByText("mirror-west")
+      .closest(".account-card-item") as HTMLElement;
+
+    fireEvent.focus(screen.getByRole("button", { name: "编辑-mirror-east" }));
+    expect(firstCard.dataset.actionsVisible).toBe("true");
+    expect(secondCard.dataset.actionsVisible).toBe("false");
+
+    fireEvent.mouseEnter(secondCard);
+    expect(firstCard.dataset.actionsVisible).toBe("false");
+    expect(secondCard.dataset.actionsVisible).toBe("true");
+
+    fireEvent.mouseLeave(secondCard);
+    expect(secondCard.dataset.actionsVisible).toBe("false");
+  });
+
   it("supports editing lua usage config, copying AI skill context, and testing lua output", async () => {
     const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, "clipboard", {
@@ -1376,6 +1590,111 @@ describe("AccountsPage", () => {
 
     expect(await screen.findByText("80%")).toBeInTheDocument();
     expect(screen.getByText("90%")).toBeInTheDocument();
+  });
+
+  it("formats official reset windows with time for 5H and date for 7D", async () => {
+    const now = new Date();
+    const primaryReset = new Date(now.getTime() + 60 * 60 * 1000);
+    const secondaryReset = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "codex",
+        account_name: "official-main",
+        source_icon: "openai",
+        auth_mode: "codex_local_import",
+        base_url: "",
+        status: "active",
+        is_active: true,
+        priority: 1,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 1,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 23,
+        secondary_used_percent: 67,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                account_id: 1,
+                balance: 0,
+                quota_remaining: 0,
+                rpm_remaining: 0,
+                tpm_remaining: 0,
+                health_score: 1,
+                recent_error_rate: 0,
+                last_total_tokens: 0,
+                last_input_tokens: 0,
+                last_output_tokens: 0,
+                model_context_window: 0,
+                primary_used_percent: 23,
+                secondary_used_percent: 67,
+                primary_resets_at: primaryReset.toISOString(),
+                secondary_resets_at: secondaryReset.toISOString(),
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("official-main")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "详情-official-main" }));
+
+    const detailModal = await screen.findByRole("dialog", {
+      name: "账户详情",
+    });
+    expect(
+      within(detailModal).getByText(
+        `77% · ${primaryReset.toLocaleTimeString("zh-CN", {
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+        })}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(detailModal).getByText(
+        `33% · ${secondaryReset.toLocaleDateString("zh-CN", {
+          month: "numeric",
+          day: "numeric",
+        })}`,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("renders ppchat daily remaining usage meter on the card", async () => {

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -53,6 +53,8 @@ import {
   useState,
   type ButtonHTMLAttributes,
   type CSSProperties,
+  type FocusEvent as ReactFocusEvent,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from "react";
 
@@ -77,6 +79,7 @@ import {
   type PPChatTokenLogsPayload,
   type AccountTestResult,
 } from "../../lib/api";
+import { writeClipboardText } from "../../lib/clipboard";
 import { refreshDesktopTrayState } from "../../lib/desktop-shell";
 import type { AppLanguage, Translator } from "../../lib/i18n";
 import sourceClaudeCodeIcon from "../../assets/providers/claude-code.png";
@@ -357,7 +360,7 @@ function mergeDisplayUsage(
   };
 }
 
-function formatResetAt(value: string | undefined, language: AppLanguage) {
+function formatResetTime(value: string | undefined, language: AppLanguage) {
   if (!value) {
     return "--";
   }
@@ -376,6 +379,24 @@ function formatResetAt(value: string | undefined, language: AppLanguage) {
       minute: "2-digit",
       hour12: false,
     });
+  }
+  return `${date.toLocaleDateString(language, {
+    month: "numeric",
+    day: "numeric",
+  })} ${date.toLocaleTimeString(language, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })}`;
+}
+
+function formatResetDate(value: string | undefined, language: AppLanguage) {
+  if (!value) {
+    return "--";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "--";
   }
   return date.toLocaleDateString(language, {
     month: "numeric",
@@ -542,6 +563,9 @@ export function AccountsPage({
   const [draggingAccountID, setDraggingAccountID] = useState<number | null>(
     null,
   );
+  const [visibleActionAccountID, setVisibleActionAccountID] = useState<
+    number | null
+  >(null);
 
   const [thirdPartyForm] = Form.useForm();
   const [officialForm] = Form.useForm();
@@ -890,9 +914,6 @@ export function AccountsPage({
     if (!editingAccount) {
       return;
     }
-    if (!navigator.clipboard?.writeText) {
-      throw new Error(t("当前环境不支持剪切板写入"));
-    }
     const usageConfigJSON = (() => {
       try {
         return stringifyLuaConfigDraft(luaConfigDraft || "{}", luaScriptKey);
@@ -900,7 +921,7 @@ export function AccountsPage({
         return editingAccount.usage_config_json || "{}";
       }
     })();
-    await navigator.clipboard.writeText(
+    await writeClipboardText(
       buildLuaSkillPrompt(editingAccount, luaScriptKey.trim(), usageConfigJSON),
     );
     void messageApi.success(t("已复制 AI Skill"));
@@ -1028,14 +1049,53 @@ export function AccountsPage({
       cancelText: t("取消"),
       centered: true,
       onOk: async () => {
-        if (!navigator.clipboard?.writeText) {
-          throw new Error(t("当前环境不支持剪切板写入"));
-        }
         const response = await shareAccount(record.id);
-        await navigator.clipboard.writeText(response.payload);
+        await writeClipboardText(response.payload);
         void messageApi.success(t("已复制账户分享信息"));
       },
     });
+  }
+
+  function showActionTray(accountID: number) {
+    setVisibleActionAccountID(accountID);
+  }
+
+  function hideActionTray(accountID: number) {
+    setVisibleActionAccountID((current) =>
+      current === accountID ? null : current,
+    );
+  }
+
+  function handleCardFocus(accountID: number) {
+    showActionTray(accountID);
+  }
+
+  function handleCardBlur(
+    accountID: number,
+    event: ReactFocusEvent<HTMLDivElement>,
+  ) {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) {
+      return;
+    }
+    hideActionTray(accountID);
+  }
+
+  function handleCardMouseEnter(accountID: number) {
+    showActionTray(accountID);
+  }
+
+  function handleCardMouseLeave(
+    accountID: number,
+    event: ReactMouseEvent<HTMLDivElement>,
+  ) {
+    if (
+      typeof document !== "undefined" &&
+      event.currentTarget.contains(document.activeElement)
+    ) {
+      return;
+    }
+    hideActionTray(accountID);
   }
 
   function handleDragStart(event: DragStartEvent) {
@@ -1174,6 +1234,7 @@ export function AccountsPage({
     record: AccountRecord,
     options: AccountCardRenderOptions = {},
   ) {
+    const actionsVisible = visibleActionAccountID === record.id;
     const sourceIcon = sourceIconMap[normalizeSourceIcon(record.source_icon)];
     const usageWindows = isOfficialAccount(record)
       ? [
@@ -1204,6 +1265,21 @@ export function AccountsPage({
         ref={options.cardRef}
         className={`account-card-item ${record.is_active ? "active-account-card" : ""} ${options.className ?? ""}`.trim()}
         style={options.style}
+        data-actions-visible={actionsVisible ? "true" : "false"}
+        onFocus={options.actionsDisabled ? undefined : () => handleCardFocus(record.id)}
+        onBlur={
+          options.actionsDisabled
+            ? undefined
+            : (event) => handleCardBlur(record.id, event)
+        }
+        onMouseEnter={
+          options.actionsDisabled ? undefined : () => handleCardMouseEnter(record.id)
+        }
+        onMouseLeave={
+          options.actionsDisabled
+            ? undefined
+            : (event) => handleCardMouseLeave(record.id, event)
+        }
       >
         <Card variant="borderless" className="account-card-surface">
           <div className="account-card-shell">
@@ -1616,11 +1692,11 @@ export function AccountsPage({
                   </Descriptions.Item>
                   <Descriptions.Item label={t("5 小时剩余")}>
                     {(100 - detailAccount.primary_used_percent).toFixed(0)}% ·{" "}
-                    {formatResetAt(detailAccount.primary_resets_at, language)}
+                    {formatResetTime(detailAccount.primary_resets_at, language)}
                   </Descriptions.Item>
                   <Descriptions.Item label={t("1 周剩余")}>
                     {(100 - detailAccount.secondary_used_percent).toFixed(0)}% ·{" "}
-                    {formatResetAt(detailAccount.secondary_resets_at, language)}
+                    {formatResetDate(detailAccount.secondary_resets_at, language)}
                   </Descriptions.Item>
                 </Descriptions>
               </Card>

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,35 @@
+import { runtimeTranslate } from "./i18n";
+
+export async function writeClipboardText(value: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  if (typeof document !== "undefined") {
+    const textarea = document.createElement("textarea");
+    textarea.value = value;
+    textarea.setAttribute("readonly", "true");
+    textarea.setAttribute("aria-hidden", "true");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    try {
+      if (
+        typeof document.execCommand === "function" &&
+        document.execCommand("copy")
+      ) {
+        return;
+      }
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+
+  throw new Error(runtimeTranslate("复制失败，请检查系统剪贴板权限"));
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1268,14 +1268,12 @@ html[data-theme-mode="dark"] .stats-chart-shell {
   transition: opacity 0.16s ease;
 }
 
-.account-card-item:hover .account-usage-mini,
-.account-card-item:focus-within .account-usage-mini {
+.account-card-item[data-actions-visible="true"] .account-usage-mini {
   opacity: 0;
   pointer-events: none;
 }
 
-.account-card-item:hover .account-actions,
-.account-card-item:focus-within .account-actions {
+.account-card-item[data-actions-visible="true"] .account-actions {
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- stabilize account card action tray visibility so only one tray stays visible
- add clipboard fallback for desktop/share and Lua skill copy
- format official 5H reset as time and 7D reset as date
- add frontend tests covering the regressions

## Verification
- cd frontend && npm test -- --run
- cd frontend && npm run build