### PR TITLE
Improve account usage refresh visibility and resilience

### DIFF
--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -386,6 +386,9 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 		SecondaryUsedPercent      float64    `json:"secondary_used_percent"`
 		PrimaryResetsAt           *time.Time `json:"primary_resets_at,omitempty"`
 		SecondaryResetsAt         *time.Time `json:"secondary_resets_at,omitempty"`
+		CheckedAt                 *time.Time `json:"checked_at,omitempty"`
+		Stale                     bool       `json:"stale"`
+		LastError                 string     `json:"last_error,omitempty"`
 		PPChatTodayUsedQuota      float64    `json:"ppchat_today_used_quota,omitempty"`
 		PPChatTodayAddedQuota     float64    `json:"ppchat_today_added_quota,omitempty"`
 		PPChatTodayRemainingQuota float64    `json:"ppchat_today_remaining_quota,omitempty"`
@@ -420,6 +423,9 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 			SecondaryUsedPercent:      snapshot.SecondaryUsedPercent,
 			PrimaryResetsAt:           snapshot.PrimaryResetsAt,
 			SecondaryResetsAt:         snapshot.SecondaryResetsAt,
+			CheckedAt:                 nilIfZeroTime(snapshot.CheckedAt),
+			Stale:                     snapshot.Stale,
+			LastError:                 snapshot.LastError,
 			PPChatTodayUsedQuota:      ppchatSummary.TodayUsedQuota,
 			PPChatTodayAddedQuota:     ppchatSummary.TodayAddedQuota,
 			PPChatTodayRemainingQuota: ppchatSummary.TodayRemainingQuota,
@@ -427,6 +433,14 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 	}
 
 	writeJSON(w, http.StatusOK, response)
+}
+
+func nilIfZeroTime(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	normalized := value.UTC()
+	return &normalized
 }
 
 type ppchatUsageSummary struct {

--- a/backend/internal/usage/refresh/orchestrator.go
+++ b/backend/internal/usage/refresh/orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
@@ -26,7 +27,12 @@ type Orchestrator struct {
 	usage    snapshotRepository
 	registry *registry.Registry
 	now      func() time.Time
+	timeout  time.Duration
+	workers  int
 }
+
+const defaultPerAccountTimeout = 5 * time.Second
+const defaultRefreshWorkers = 4
 
 func NewOrchestrator(accountsRepo accountLister, usageRepo snapshotRepository, driverRegistry *registry.Registry) *Orchestrator {
 	return &Orchestrator{
@@ -34,7 +40,25 @@ func NewOrchestrator(accountsRepo accountLister, usageRepo snapshotRepository, d
 		usage:    usageRepo,
 		registry: driverRegistry,
 		now:      func() time.Time { return time.Now().UTC() },
+		timeout:  defaultPerAccountTimeout,
+		workers:  defaultRefreshWorkers,
 	}
+}
+
+func NewOrchestratorWithTimeout(accountsRepo accountLister, usageRepo snapshotRepository, driverRegistry *registry.Registry, timeout time.Duration) *Orchestrator {
+	orchestrator := NewOrchestrator(accountsRepo, usageRepo, driverRegistry)
+	if timeout > 0 {
+		orchestrator.timeout = timeout
+	}
+	return orchestrator
+}
+
+func NewOrchestratorWithOptions(accountsRepo accountLister, usageRepo snapshotRepository, driverRegistry *registry.Registry, timeout time.Duration, workers int) *Orchestrator {
+	orchestrator := NewOrchestratorWithTimeout(accountsRepo, usageRepo, driverRegistry, timeout)
+	if workers > 0 {
+		orchestrator.workers = workers
+	}
+	return orchestrator
 }
 
 func (o *Orchestrator) Run(ctx context.Context, runAt time.Time) error {
@@ -50,16 +74,72 @@ func (o *Orchestrator) Run(ctx context.Context, runAt time.Time) error {
 	}
 	runAt = runAt.UTC()
 
-	var errs []error
-	for _, account := range accountsList {
-		if err := o.refreshOne(ctx, account, runAt); err != nil {
-			errs = append(errs, fmt.Errorf("account %d (%s): %w", account.ID, account.AccountName, err))
+	if len(accountsList) == 0 {
+		return nil
+	}
+	workers := o.workers
+	if workers <= 0 {
+		workers = 1
+	}
+	if workers > len(accountsList) {
+		workers = len(accountsList)
+	}
+
+	type job struct {
+		index   int
+		account accounts.Account
+	}
+	type result struct {
+		index int
+		err   error
+	}
+
+	jobs := make(chan job)
+	results := make(chan result, len(accountsList))
+	var group sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for work := range jobs {
+				err := o.refreshOne(ctx, work.account, runAt)
+				if err != nil {
+					err = fmt.Errorf("account %d (%s): %w", work.account.ID, work.account.AccountName, err)
+				}
+				results <- result{index: work.index, err: err}
+			}
+		}()
+	}
+
+	go func() {
+		for index, account := range accountsList {
+			jobs <- job{index: index, account: account}
+		}
+		close(jobs)
+		group.Wait()
+		close(results)
+	}()
+
+	errs := make([]error, len(accountsList))
+	for result := range results {
+		errs[result.index] = result.err
+	}
+
+	ordered := make([]error, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			ordered = append(ordered, err)
 		}
 	}
-	return errors.Join(errs...)
+	return errors.Join(ordered...)
 }
 
 func (o *Orchestrator) refreshOne(ctx context.Context, account accounts.Account, runAt time.Time) error {
+	if o.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, o.timeout)
+		defer cancel()
+	}
 	accountDriver, err := o.registry.AccountDriverFor(account)
 	if err != nil {
 		return o.markFailure(account.ID, runAt, err)

--- a/backend/internal/usage/refresh/orchestrator_test.go
+++ b/backend/internal/usage/refresh/orchestrator_test.go
@@ -3,7 +3,10 @@ package refresh_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,6 +27,7 @@ func (r stubAccountRepo) List() ([]accounts.Account, error) {
 }
 
 type stubUsageRepo struct {
+	mu     sync.Mutex
 	saved  []usage.Snapshot
 	latest map[int64]usage.Snapshot
 }
@@ -39,12 +43,16 @@ func newStubUsageRepo(initial ...usage.Snapshot) *stubUsageRepo {
 }
 
 func (r *stubUsageRepo) Save(snapshot usage.Snapshot) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.saved = append(r.saved, snapshot)
 	r.latest[snapshot.AccountID] = snapshot
 	return nil
 }
 
 func (r *stubUsageRepo) GetLatest(accountID int64) (usage.Snapshot, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	snapshot, ok := r.latest[accountID]
 	if !ok {
 		return usage.Snapshot{}, errors.New("not found")
@@ -144,11 +152,12 @@ func TestOrchestratorRefreshesBuiltInAndLuaAccounts(t *testing.T) {
 	if len(usageRepo.saved) != 2 {
 		t.Fatalf("saved snapshots = %d, want 2", len(usageRepo.saved))
 	}
-	if usageRepo.saved[0].AccountID != 1 || usageRepo.saved[0].QuotaRemaining != 1200 {
-		t.Fatalf("first snapshot = %+v, want account 1 quota 1200", usageRepo.saved[0])
+	savedByAccount := snapshotsByAccount(usageRepo.saved)
+	if savedByAccount[1].QuotaRemaining != 1200 {
+		t.Fatalf("account 1 snapshot = %+v, want quota 1200", savedByAccount[1])
 	}
-	if usageRepo.saved[1].AccountID != 2 || usageRepo.saved[1].Balance != 9.5 {
-		t.Fatalf("second snapshot = %+v, want account 2 balance 9.5", usageRepo.saved[1])
+	if savedByAccount[2].Balance != 9.5 {
+		t.Fatalf("account 2 snapshot = %+v, want balance 9.5", savedByAccount[2])
 	}
 }
 
@@ -211,7 +220,8 @@ func TestOrchestratorContinuesAfterFailureAndPreservesStaleSnapshot(t *testing.T
 	if len(usageRepo.saved) != 2 {
 		t.Fatalf("saved snapshots = %d, want 2", len(usageRepo.saved))
 	}
-	stale := usageRepo.saved[0]
+	savedByAccount := snapshotsByAccount(usageRepo.saved)
+	stale := savedByAccount[1]
 	if stale.AccountID != 1 || !stale.Stale {
 		t.Fatalf("stale snapshot = %+v, want stale account 1 snapshot", stale)
 	}
@@ -221,8 +231,8 @@ func TestOrchestratorContinuesAfterFailureAndPreservesStaleSnapshot(t *testing.T
 	if stale.LastError != "quota endpoint failed" {
 		t.Fatalf("stale last_error = %q, want quota endpoint failed", stale.LastError)
 	}
-	if usageRepo.saved[1].AccountID != 2 || usageRepo.saved[1].QuotaRemaining != 88 {
-		t.Fatalf("healthy snapshot = %+v, want account 2 quota 88", usageRepo.saved[1])
+	if savedByAccount[2].AccountID != 2 || savedByAccount[2].QuotaRemaining != 88 {
+		t.Fatalf("healthy snapshot = %+v, want account 2 quota 88", savedByAccount[2])
 	}
 }
 
@@ -269,6 +279,172 @@ func TestOrchestratorUsesFallbackSnapshotWhenNoPreviousSnapshotExists(t *testing
 	if snapshot.Source != "inferred" || snapshot.Confidence != "low" {
 		t.Fatalf("fallback metadata = source=%q confidence=%q, want inferred/low", snapshot.Source, snapshot.Confidence)
 	}
+}
+
+func TestOrchestratorTimesOutSingleAccountAndContinues(t *testing.T) {
+	t.Parallel()
+
+	reg := newRegistry(t,
+		[]accountdrv.AccountDriver{
+			stubAccountDriver{
+				name: "builtin_api_key",
+				supports: func(account accounts.Account) bool {
+					return account.AuthMode == accounts.AuthModeAPIKey
+				},
+				resolve: func(context.Context, accounts.Account) (accountdrv.ResolvedCredential, error) {
+					return accountdrv.ResolvedCredential{AccessToken: "token"}, nil
+				},
+			},
+		},
+		[]usagedrv.UsageDriver{
+			stubUsageDriver{
+				name: "builtin_ppchat",
+				fetch: func(ctx context.Context, account accounts.Account, _ accountdrv.ResolvedCredential) (usagedrv.RawUsageResult, error) {
+					if account.ID == 1 {
+						<-ctx.Done()
+						return usagedrv.RawUsageResult{}, fmt.Errorf("usage fetch timeout: %w", ctx.Err())
+					}
+					quota := 42.0
+					return usagedrv.RawUsageResult{
+						Source:     "remote",
+						Confidence: "high",
+						Limits: usagedrv.UsageLimits{
+							QuotaRemaining: &quota,
+						},
+					}, nil
+				},
+			},
+		},
+	)
+
+	usageRepo := newStubUsageRepo()
+	orchestrator := refresh.NewOrchestratorWithTimeout(stubAccountRepo{accounts: []accounts.Account{
+		{ID: 1, AccountName: "hung", AuthMode: accounts.AuthModeAPIKey, UsageDriver: "builtin_ppchat"},
+		{ID: 2, AccountName: "healthy", AuthMode: accounts.AuthModeAPIKey, UsageDriver: "builtin_ppchat"},
+	}}, usageRepo, reg, 20*time.Millisecond)
+
+	now := time.Date(2026, 3, 19, 9, 0, 0, 0, time.UTC)
+	start := time.Now()
+	err := orchestrator.Run(context.Background(), now)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("Run returned nil error, want timeout error")
+	}
+	if !strings.Contains(err.Error(), "deadline exceeded") {
+		t.Fatalf("error = %q, want deadline exceeded", err.Error())
+	}
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("Run took %s, want under 250ms", elapsed)
+	}
+	if len(usageRepo.saved) != 2 {
+		t.Fatalf("saved snapshots = %d, want 2", len(usageRepo.saved))
+	}
+	savedByAccount := snapshotsByAccount(usageRepo.saved)
+	if !savedByAccount[1].Stale || savedByAccount[1].AccountID != 1 {
+		t.Fatalf("account 1 snapshot = %+v, want stale account 1 snapshot", savedByAccount[1])
+	}
+	if savedByAccount[2].AccountID != 2 || savedByAccount[2].QuotaRemaining != 42 {
+		t.Fatalf("account 2 snapshot = %+v, want healthy account 2 quota 42", savedByAccount[2])
+	}
+}
+
+func TestOrchestratorLimitsConcurrentRefreshes(t *testing.T) {
+	t.Parallel()
+
+	var current atomic.Int32
+	var maxSeen atomic.Int32
+	started := make(chan int64, 3)
+	release := make(chan struct{})
+
+	reg := newRegistry(t,
+		[]accountdrv.AccountDriver{
+			stubAccountDriver{
+				name: "builtin_api_key",
+				supports: func(account accounts.Account) bool {
+					return account.AuthMode == accounts.AuthModeAPIKey
+				},
+				resolve: func(context.Context, accounts.Account) (accountdrv.ResolvedCredential, error) {
+					return accountdrv.ResolvedCredential{AccessToken: "token"}, nil
+				},
+			},
+		},
+		[]usagedrv.UsageDriver{
+			stubUsageDriver{
+				name: "builtin_ppchat",
+				fetch: func(_ context.Context, account accounts.Account, _ accountdrv.ResolvedCredential) (usagedrv.RawUsageResult, error) {
+					active := current.Add(1)
+					for {
+						existing := maxSeen.Load()
+						if active <= existing || maxSeen.CompareAndSwap(existing, active) {
+							break
+						}
+					}
+					started <- account.ID
+					<-release
+					current.Add(-1)
+					quota := float64(account.ID)
+					return usagedrv.RawUsageResult{
+						Source:     "remote",
+						Confidence: "high",
+						Limits: usagedrv.UsageLimits{
+							QuotaRemaining: &quota,
+						},
+					}, nil
+				},
+			},
+		},
+	)
+
+	usageRepo := newStubUsageRepo()
+	orchestrator := refresh.NewOrchestratorWithOptions(stubAccountRepo{accounts: []accounts.Account{
+		{ID: 1, AccountName: "one", AuthMode: accounts.AuthModeAPIKey, UsageDriver: "builtin_ppchat"},
+		{ID: 2, AccountName: "two", AuthMode: accounts.AuthModeAPIKey, UsageDriver: "builtin_ppchat"},
+		{ID: 3, AccountName: "three", AuthMode: accounts.AuthModeAPIKey, UsageDriver: "builtin_ppchat"},
+	}}, usageRepo, reg, 100*time.Millisecond, 2)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- orchestrator.Run(context.Background(), time.Date(2026, 3, 19, 10, 0, 0, 0, time.UTC))
+	}()
+
+	seen := map[int64]bool{}
+	for len(seen) < 2 {
+		select {
+		case id := <-started:
+			seen[id] = true
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timed out waiting for first two refreshes to start")
+		}
+	}
+
+	select {
+	case id := <-started:
+		t.Fatalf("third refresh started before slot released: account=%d", id)
+	case <-time.After(40 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Run did not complete after releasing workers")
+	}
+
+	if maxSeen.Load() != 2 {
+		t.Fatalf("max concurrent refreshes = %d, want 2", maxSeen.Load())
+	}
+}
+
+func snapshotsByAccount(saved []usage.Snapshot) map[int64]usage.Snapshot {
+	indexed := make(map[int64]usage.Snapshot, len(saved))
+	for _, snapshot := range saved {
+		indexed[snapshot.AccountID] = snapshot
+	}
+	return indexed
 }
 
 func newRegistry(t *testing.T, accountDrivers []accountdrv.AccountDriver, usageDrivers []usagedrv.UsageDriver) *registry.Registry {

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -1910,6 +1910,23 @@ describe("AccountsPage", () => {
     renderAccountsPage();
 
     expect(await screen.findByText("official-main")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        primaryReset.toLocaleTimeString("zh-CN", {
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+        }),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        secondaryReset.toLocaleDateString("zh-CN", {
+          month: "numeric",
+          day: "numeric",
+        }),
+      ),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "详情-official-main" }));
 
     const detailModal = await screen.findByRole("dialog", {
@@ -1934,7 +1951,99 @@ describe("AccountsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows usage health details from the status dot tooltip", async () => {
+    const checkedAt = new Date("2026-03-19T08:35:00.000Z");
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "codex",
+        account_name: "official-main",
+        source_icon: "openai",
+        auth_mode: "codex_local_import",
+        base_url: "https://chatgpt.com/backend-api/codex",
+        status: "active",
+        is_active: true,
+        priority: 1,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 1,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 20,
+        secondary_used_percent: 30,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                account_id: 1,
+                balance: 0,
+                quota_remaining: 0,
+                rpm_remaining: 0,
+                tpm_remaining: 0,
+                health_score: 1,
+                recent_error_rate: 0,
+                last_total_tokens: 0,
+                last_input_tokens: 0,
+                last_output_tokens: 0,
+                model_context_window: 0,
+                primary_used_percent: 20,
+                secondary_used_percent: 30,
+                checked_at: checkedAt.toISOString(),
+                stale: true,
+                last_error: "upstream timeout",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("official-main")).toBeInTheDocument();
+    fireEvent.mouseEnter(screen.getByLabelText("official-main-usage-health"));
+
+    expect(await screen.findByText("upstream timeout")).toBeInTheDocument();
+  });
+
   it("renders ppchat daily remaining usage meter on the card", async () => {
+    const nextMidnight = new Date();
+    nextMidnight.setHours(24, 0, 0, 0);
+    const expectedReset = nextMidnight.toLocaleTimeString("zh-CN", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+
     const accountList = [
       {
         id: 1,
@@ -2013,6 +2122,7 @@ describe("AccountsPage", () => {
 
     expect(await screen.findByText("ppchat-main")).toBeInTheDocument();
     expect(await screen.findByText("1D")).toBeInTheDocument();
+    expect(screen.getByText(expectedReset)).toBeInTheDocument();
     expect(screen.getByText("93%")).toBeInTheDocument();
     expect(document.querySelector(".account-usage-mini")).toHaveClass(
       "account-usage-mini-single",

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -24,6 +24,7 @@ import {
   Skeleton,
   Statistic,
   Tag,
+  Tooltip,
   Typography,
   message,
 } from "antd";
@@ -354,6 +355,9 @@ function mergeDisplayUsage(
     secondary_used_percent: previous.secondary_used_percent,
     primary_resets_at: previous.primary_resets_at,
     secondary_resets_at: previous.secondary_resets_at,
+    checked_at: previous.checked_at,
+    stale: previous.stale,
+    last_error: previous.last_error,
     ppchat_today_used_quota: previous.ppchat_today_used_quota,
     ppchat_today_added_quota: previous.ppchat_today_added_quota,
     ppchat_today_remaining_quota: previous.ppchat_today_remaining_quota,
@@ -402,6 +406,76 @@ function formatResetDate(value: string | undefined, language: AppLanguage) {
     month: "numeric",
     day: "numeric",
   });
+}
+
+function formatTomorrowMidnight(language: AppLanguage, now = new Date()) {
+  const nextMidnight = new Date(now);
+  nextMidnight.setHours(24, 0, 0, 0);
+  return nextMidnight.toLocaleTimeString(language, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function formatCheckedAt(value: string | undefined, language: AppLanguage) {
+  if (!value) {
+    return language === "en-US" ? "No usage data yet" : "尚无 usage 数据";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return language === "en-US" ? "Unknown refresh time" : "刷新时间未知";
+  }
+  return date.toLocaleString(language, {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function getUsageHealthState(
+  record: Pick<AccountRecord, "checked_at" | "stale">,
+): "ok" | "warning" | "danger" | "unknown" {
+  if (!record.checked_at) {
+    return "unknown";
+  }
+  if (record.stale) {
+    return "danger";
+  }
+  const checkedAt = new Date(record.checked_at);
+  if (Number.isNaN(checkedAt.getTime())) {
+    return "unknown";
+  }
+  const ageMinutes = (Date.now() - checkedAt.getTime()) / 60000;
+  if (ageMinutes <= 10) {
+    return "ok";
+  }
+  if (ageMinutes <= 30) {
+    return "warning";
+  }
+  return "danger";
+}
+
+function renderUsageHealthTooltip(
+  record: Pick<AccountRecord, "checked_at" | "stale" | "last_error">,
+  language: AppLanguage,
+) {
+  const checkedAt = formatCheckedAt(record.checked_at, language);
+  if (!record.checked_at) {
+    return <span>{checkedAt}</span>;
+  }
+  return (
+    <div className="account-usage-health-tooltip">
+      <div>{checkedAt}</div>
+      {record.stale ? (
+        <div>{record.last_error || (language === "en-US" ? "Refresh failed" : "刷新失败")}</div>
+      ) : (
+        <div>{language === "en-US" ? "Refresh healthy" : "刷新正常"}</div>
+      )}
+    </div>
+  );
 }
 
 function formatInteger(language: AppLanguage, value: number): string {
@@ -1236,15 +1310,18 @@ export function AccountsPage({
   ) {
     const actionsVisible = visibleActionAccountID === record.id;
     const sourceIcon = sourceIconMap[normalizeSourceIcon(record.source_icon)];
+    const usageHealthState = getUsageHealthState(record);
     const usageWindows = isOfficialAccount(record)
       ? [
           {
             label: "5H",
             remainingPercent: clampPercent(100 - record.primary_used_percent),
+            resetLabel: formatResetTime(record.primary_resets_at, language),
           },
           {
             label: "7D",
             remainingPercent: clampPercent(100 - record.secondary_used_percent),
+            resetLabel: formatResetDate(record.secondary_resets_at, language),
           },
         ]
       : isPPChatAccount(record) && (record.ppchat_today_added_quota ?? 0) > 0
@@ -1256,6 +1333,7 @@ export function AccountsPage({
                   Math.max(record.ppchat_today_added_quota ?? 0, 1)) *
                   100,
               ),
+              resetLabel: formatTomorrowMidnight(language),
             },
           ]
         : [];
@@ -1315,6 +1393,15 @@ export function AccountsPage({
                   ) : null}
                 </div>
                 <Text type="secondary" className="account-base-url">
+                  <Tooltip
+                    mouseEnterDelay={0.15}
+                    title={renderUsageHealthTooltip(record, language)}
+                  >
+                    <span
+                      className={`account-usage-health-dot is-${usageHealthState}`}
+                      aria-label={`${record.account_name}-usage-health`}
+                    />
+                  </Tooltip>
                   {record.base_url || t("OpenAI 官方")}
                 </Text>
               </div>
@@ -1329,18 +1416,23 @@ export function AccountsPage({
                       <span className="account-usage-mini-label">
                         {item.label}
                       </span>
+                      <span className="account-usage-mini-reset">
+                        {item.resetLabel || ""}
+                      </span>
                       <span
                         className={`account-usage-mini-value is-${getRemainingTone(item.remainingPercent)}`}
                       >{`${Math.round(item.remainingPercent)}%`}</span>
                     </div>
-                    <div
-                      className="account-usage-mini-track"
-                      aria-label={`${record.account_name}-${item.label}`}
-                    >
+                    <div className="account-usage-mini-meter">
                       <div
-                        className={`account-usage-mini-fill is-${getRemainingTone(item.remainingPercent)}`}
-                        style={{ width: `${item.remainingPercent}%` }}
-                      />
+                        className="account-usage-mini-track"
+                        aria-label={`${record.account_name}-${item.label}`}
+                      >
+                        <div
+                          className={`account-usage-mini-fill is-${getRemainingTone(item.remainingPercent)}`}
+                          style={{ width: `${item.remainingPercent}%` }}
+                        />
+                      </div>
                     </div>
                   </div>
                 ))}

--- a/frontend/src/features/stats/StatsPage.test.tsx
+++ b/frontend/src/features/stats/StatsPage.test.tsx
@@ -74,7 +74,8 @@ describe("StatsPage", () => {
     expect(screen.getByText("输入 Token")).toBeInTheDocument();
     expect(screen.getByText("输出 Token")).toBeInTheDocument();
     expect(screen.getByText("预估费用")).toBeInTheDocument();
-    expect(screen.getByText("余额变化")).toBeInTheDocument();
+    expect(screen.queryByText("余额变化")).not.toBeInTheDocument();
+    expect(screen.getByText("US$1.23")).toBeInTheDocument();
     expect(screen.queryByText("总 Token")).not.toBeInTheDocument();
     expect(screen.queryByText("额度变化")).not.toBeInTheDocument();
     expect(screen.getByText("模型分布")).toBeInTheDocument();

--- a/frontend/src/features/stats/StatsPage.tsx
+++ b/frontend/src/features/stats/StatsPage.tsx
@@ -39,16 +39,9 @@ function formatCurrency(language: AppLanguage, value: number): string {
   return new Intl.NumberFormat(language, {
     style: "currency",
     currency: "USD",
-    maximumFractionDigits: 4,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   }).format(value);
-}
-
-function formatSigned(language: AppLanguage, value: number): string {
-  const formatter = new Intl.NumberFormat(language, { maximumFractionDigits: 2 });
-  if (value > 0) {
-    return `+${formatter.format(value)}`;
-  }
-  return formatter.format(value);
 }
 
 function eventStatusColor(status: string): string {
@@ -149,20 +142,15 @@ export function StatsPage({ language, t }: StatsPageProps) {
       value: summary ? formatCurrency(language, summary.estimated_cost) : "--",
       hint: t("按模型费率估算"),
     },
-    {
-      label: t("余额变化"),
-      value: summary ? formatSigned(language, summary.balance_delta) : "--",
-      hint: t("与费用视角分开展示"),
-    },
   ];
 
   return (
     <div className="dashboard-page stats-page">
-      <div className="stats-header">
-        <div>
-          <div className="stats-title">{t("Token 与费用统计")}</div>
-          <div className="stats-subtitle">{t("聚焦请求量、输入输出 Token、预估费用与余额变化。")}</div>
-        </div>
+          <div className="stats-header">
+            <div>
+              <div className="stats-title">{t("Token 与费用统计")}</div>
+              <div className="stats-subtitle">{t("聚焦请求量、输入输出 Token 与预估费用。")}</div>
+            </div>
         <div className="stats-filters">
           <Segmented
             options={[

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,6 +30,9 @@ export type AccountRecord = {
   secondary_used_percent: number;
   primary_resets_at?: string;
   secondary_resets_at?: string;
+  checked_at?: string;
+  stale?: boolean;
+  last_error?: string;
   ppchat_today_used_quota?: number;
   ppchat_today_added_quota?: number;
   ppchat_today_remaining_quota?: number;
@@ -51,6 +54,9 @@ export type AccountUsageRecord = {
   secondary_used_percent: number;
   primary_resets_at?: string;
   secondary_resets_at?: string;
+  checked_at?: string;
+  stale?: boolean;
+  last_error?: string;
   ppchat_today_used_quota?: number;
   ppchat_today_added_quota?: number;
   ppchat_today_remaining_quota?: number;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1168,10 +1168,43 @@ html[data-theme-mode="dark"] .stats-chart-shell {
 }
 
 .account-base-url {
-  display: block;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   margin-top: 2px;
   font-size: 12px;
   line-height: 1.35;
+}
+
+.account-usage-health-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+  background: rgba(148, 163, 184, 0.8);
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.14);
+}
+
+.account-usage-health-dot.is-ok {
+  background: #4bb583;
+  box-shadow: 0 0 0 3px rgba(75, 181, 131, 0.16);
+}
+
+.account-usage-health-dot.is-warning {
+  background: #d97706;
+  box-shadow: 0 0 0 3px rgba(217, 119, 6, 0.14);
+}
+
+.account-usage-health-dot.is-danger {
+  background: #dc2626;
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.14);
+}
+
+.account-usage-health-tooltip {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .account-side-slot {
@@ -1205,9 +1238,14 @@ html[data-theme-mode="dark"] .stats-chart-shell {
   gap: 4px;
 }
 
+.account-usage-mini-meter {
+  margin-top: 4px;
+}
+
 .account-usage-mini-head {
+  position: relative;
   display: flex;
-  align-items: center;
+  align-items: end;
   justify-content: space-between;
   gap: 8px;
   font-size: 11px;
@@ -1239,6 +1277,23 @@ html[data-theme-mode="dark"] .stats-chart-shell {
   border-radius: 999px;
   background: rgba(148, 163, 184, 0.18);
   overflow: hidden;
+}
+
+.account-usage-mini-reset {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  min-width: 0;
+  transform: translateX(-50%);
+  color: rgba(100, 116, 139, 0.66);
+  font-size: 9px;
+  line-height: 1;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
 }
 
 .account-usage-mini-fill {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -401,7 +401,7 @@ html[data-theme-mode="dark"] .top-home-update-dot {
 
 .stats-summary-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 12px;
 }
 

--- a/frontend/src/styles.tokens.test.ts
+++ b/frontend/src/styles.tokens.test.ts
@@ -33,6 +33,7 @@ describe("shared control geometry", () => {
     expect(css).toMatch(/\.stats-page\s*\{[^}]*gap:\s*16px;/s);
     expect(css).toMatch(/\.stats-title\s*\{[^}]*font-size:\s*24px;/s);
     expect(css).toMatch(/\.stats-summary-grid\s*\{[^}]*gap:\s*12px;/s);
+    expect(css).toMatch(/\.stats-summary-grid\s*\{[^}]*grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(220px,\s*1fr\)\);/s);
     expect(css).toMatch(/\.stats-summary-card,\s*\.stats-panel\s*\{[^}]*border-radius:\s*16px;/s);
     expect(css).toMatch(/\.stats-summary-card\.ant-card\s*\.ant-card-body,\s*\.stats-panel\.ant-card\s*\.ant-card-body\s*\{[^}]*padding:\s*16px\s+18px;/s);
     expect(css).toMatch(/\.stats-card-value\s*\{[^}]*margin-top:\s*8px;[^}]*font-size:\s*22px;/s);


### PR DESCRIPTION
## Summary
- add per-account timeout and limited-concurrency usage refresh orchestration
- expose usage refresh snapshot metadata to the accounts API
- surface usage health and reset timing on account cards

## Verification
- go test ./internal/api
- go test ./internal/usage/refresh
- npm test -- --run src/features/accounts/AccountsPage.test.tsx