### PR TITLE
fix(accounts): constrain usage health tooltip

### DIFF
--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -1910,13 +1910,20 @@ describe("AccountsPage", () => {
     renderAccountsPage();
 
     expect(await screen.findByText("official-main")).toBeInTheDocument();
+    const primaryResetTime = primaryReset.toLocaleTimeString("zh-CN", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    const primaryResetDateTime = `${primaryReset.toLocaleDateString("zh-CN", {
+      month: "numeric",
+      day: "numeric",
+    })} ${primaryResetTime}`;
     expect(
       screen.getByText(
-        primaryReset.toLocaleTimeString("zh-CN", {
-          hour: "2-digit",
-          minute: "2-digit",
-          hour12: false,
-        }),
+        (_content, element) =>
+          element?.textContent === primaryResetTime ||
+          element?.textContent === primaryResetDateTime,
       ),
     ).toBeInTheDocument();
     expect(
@@ -1932,13 +1939,13 @@ describe("AccountsPage", () => {
     const detailModal = await screen.findByRole("dialog", {
       name: "账户详情",
     });
+    const detailPrimaryValue = `77% · ${primaryResetTime}`;
+    const detailPrimaryDateTimeValue = `77% · ${primaryResetDateTime}`;
     expect(
       within(detailModal).getByText(
-        `77% · ${primaryReset.toLocaleTimeString("zh-CN", {
-          hour: "2-digit",
-          minute: "2-digit",
-          hour12: false,
-        })}`,
+        (_content, element) =>
+          element?.textContent === detailPrimaryValue ||
+          element?.textContent === detailPrimaryDateTimeValue,
       ),
     ).toBeInTheDocument();
     expect(
@@ -2015,7 +2022,8 @@ describe("AccountsPage", () => {
                 secondary_used_percent: 30,
                 checked_at: checkedAt.toISOString(),
                 stale: true,
-                last_error: "upstream timeout",
+                last_error:
+                  'do_usage_request: GET "https://his.ppchat.vip/api/token-logs?page=1&page_size=1&token_key=sk-abcdefghijklmnopqrstuvwxyz123456": context deadline exceeded',
               },
             ]),
             { status: 200, headers: { "Content-Type": "application/json" } },
@@ -2032,7 +2040,12 @@ describe("AccountsPage", () => {
     expect(await screen.findByText("official-main")).toBeInTheDocument();
     fireEvent.mouseEnter(screen.getByLabelText("official-main-usage-health"));
 
-    expect(await screen.findByText("upstream timeout")).toBeInTheDocument();
+    expect(
+      await screen.findByText((content) => content.includes("token_key=sk-***")),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/token_key=sk-abcdefghijklmnopqrstuvwxyz123456/),
+    ).not.toBeInTheDocument();
   });
 
   it("renders ppchat daily remaining usage meter on the card", async () => {

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -463,6 +463,7 @@ function renderUsageHealthTooltip(
   language: AppLanguage,
 ) {
   const checkedAt = formatCheckedAt(record.checked_at, language);
+  const errorMessage = maskSensitiveErrorText(record.last_error || "");
   if (!record.checked_at) {
     return <span>{checkedAt}</span>;
   }
@@ -470,12 +471,31 @@ function renderUsageHealthTooltip(
     <div className="account-usage-health-tooltip">
       <div>{checkedAt}</div>
       {record.stale ? (
-        <div>{record.last_error || (language === "en-US" ? "Refresh failed" : "刷新失败")}</div>
+        <div>{errorMessage || (language === "en-US" ? "Refresh failed" : "刷新失败")}</div>
       ) : (
         <div>{language === "en-US" ? "Refresh healthy" : "刷新正常"}</div>
       )}
     </div>
   );
+}
+
+function maskSensitiveErrorText(value: string): string {
+  if (!value) {
+    return "";
+  }
+  return value
+    .replace(
+      /\b(token(?:_key)?=)([^&\s"]+)/gi,
+      (_match, prefix: string, secret: string) => `${prefix}${maskSecretValue(secret)}`,
+    )
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, (secret) => maskSecretValue(secret));
+}
+
+function maskSecretValue(secret: string): string {
+  if (/^sk-/i.test(secret)) {
+    return "sk-***";
+  }
+  return "***";
 }
 
 function formatInteger(language: AppLanguage, value: number): string {
@@ -1395,6 +1415,13 @@ export function AccountsPage({
                 <Text type="secondary" className="account-base-url">
                   <Tooltip
                     mouseEnterDelay={0.15}
+                    placement="topLeft"
+                    getPopupContainer={() => document.body}
+                    styles={{
+                      body: {
+                        maxWidth: 320,
+                      },
+                    }}
                     title={renderUsageHealthTooltip(record, language)}
                   >
                     <span

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1205,6 +1205,9 @@ html[data-theme-mode="dark"] .stats-chart-shell {
   gap: 4px;
   font-size: 12px;
   line-height: 1.45;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .account-side-slot {


### PR DESCRIPTION
## Summary\n- constrain account usage health tooltips so long refresh errors do not overflow the card viewport\n- mask sensitive token values in stale refresh error details before rendering in the UI\n- relax reset-time assertions so account page tests stay valid across day boundaries\n\n## Verification\n- npm test\n- npm run build\n- go test ./...