### PR TITLE
feat(settings): add configurable usage refresh timeout

### DIFF
--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gcssloop/codex-router/backend/internal/providers"
 	providercodex "github.com/gcssloop/codex-router/backend/internal/providers/codex"
 	provideropenai "github.com/gcssloop/codex-router/backend/internal/providers/openai"
+	"github.com/gcssloop/codex-router/backend/internal/settings"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
 	luadrv "github.com/gcssloop/codex-router/backend/internal/usagedrv/lua"
 	driverregistry "github.com/gcssloop/codex-router/backend/internal/usagedrv/registry"
@@ -36,10 +37,15 @@ type AccountsHandler struct {
 	client      *http.Client
 	stateEvents *StateEventBus
 	refresher   AccountsUsageRefresher
+	settings    accountsSettingsReader
 	refreshTTL  time.Duration
 	drivers     *driverregistry.Registry
 	luaScripts  *luadrv.ManagedScriptStore
 	luaRuntime  *luadrv.Runtime
+}
+
+type accountsSettingsReader interface {
+	GetAppSettings() (settings.AppSettings, error)
 }
 
 type AccountsHandlerOption func(*AccountsHandler)
@@ -53,6 +59,12 @@ func WithAccountsStateEvents(bus *StateEventBus) AccountsHandlerOption {
 func WithAccountsUsageRefresher(refresher AccountsUsageRefresher) AccountsHandlerOption {
 	return func(handler *AccountsHandler) {
 		handler.refresher = refresher
+	}
+}
+
+func WithAccountsSettings(repo accountsSettingsReader) AccountsHandlerOption {
+	return func(handler *AccountsHandler) {
+		handler.settings = repo
 	}
 }
 
@@ -94,7 +106,7 @@ func NewAccountsHandler(repo accounts.Repository, usage AccountsUsage, connector
 		connector:  connector,
 		stateStore: stateStore,
 		client:     http.DefaultClient,
-		refreshTTL: 5 * time.Second,
+		refreshTTL: 15 * time.Second,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -491,8 +503,13 @@ func (h *AccountsHandler) refreshAccountsUsage(w http.ResponseWriter, r *http.Re
 		return
 	}
 	timeout := h.refreshTTL
+	if h.settings != nil {
+		if appSettings, err := h.settings.GetAppSettings(); err == nil && appSettings.UsageRequestTimeoutSeconds > 0 {
+			timeout = time.Duration(appSettings.UsageRequestTimeoutSeconds) * time.Second
+		}
+	}
 	if timeout <= 0 {
-		timeout = 5 * time.Second
+		timeout = 15 * time.Second
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()

--- a/backend/internal/api/accounts_handler_internal_test.go
+++ b/backend/internal/api/accounts_handler_internal_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gcssloop/codex-router/backend/internal/settings"
+)
+
+func TestNewAccountsHandlerDefaultsToFifteenSecondRefreshTTL(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAccountsHandler(nil, nil, nil, nil)
+	if handler.refreshTTL != 15*time.Second {
+		t.Fatalf("refreshTTL = %s, want %s", handler.refreshTTL, 15*time.Second)
+	}
+}
+
+type accountsSettingsStub struct {
+	value settings.AppSettings
+}
+
+func (s accountsSettingsStub) GetAppSettings() (settings.AppSettings, error) {
+	return s.value, nil
+}
+
+type refresherStub struct {
+	deadline time.Time
+}
+
+func (s *refresherStub) Run(ctx context.Context, _ time.Time) error {
+	s.deadline, _ = ctx.Deadline()
+	return nil
+}
+
+func TestAccountsHandlerRefreshUsesLatestSettingsTimeout(t *testing.T) {
+	t.Parallel()
+
+	current := settings.DefaultAppSettings()
+	current.UsageRequestTimeoutSeconds = 3
+	refresher := &refresherStub{}
+	handler := NewAccountsHandler(nil, nil, nil, nil, WithAccountsUsageRefresher(refresher), WithAccountsSettings(accountsSettingsStub{value: current}))
+
+	start := time.Now()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/accounts/usage/refresh", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("POST /accounts/usage/refresh status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if refresher.deadline.IsZero() {
+		t.Fatal("refresh deadline was not captured")
+	}
+	remaining := time.Until(refresher.deadline)
+	if remaining < 2*time.Second || remaining > 4*time.Second {
+		t.Fatalf("remaining timeout = %s, want about 3s (start=%s)", remaining, start)
+	}
+}

--- a/backend/internal/api/settings_handler.go
+++ b/backend/internal/api/settings_handler.go
@@ -615,6 +615,15 @@ func normalizeAppSettings(value settings.AppSettings) settings.AppSettings {
 	if value.StatusRefreshIntervalSeconds > 3600 {
 		value.StatusRefreshIntervalSeconds = 3600
 	}
+	if value.UsageRequestTimeoutSeconds <= 0 {
+		value.UsageRequestTimeoutSeconds = defaults.UsageRequestTimeoutSeconds
+	}
+	if value.UsageRequestTimeoutSeconds < 3 {
+		value.UsageRequestTimeoutSeconds = 3
+	}
+	if value.UsageRequestTimeoutSeconds > 300 {
+		value.UsageRequestTimeoutSeconds = 300
+	}
 	if value.Language != "en-US" {
 		value.Language = defaults.Language
 	}

--- a/backend/internal/api/settings_handler_test.go
+++ b/backend/internal/api/settings_handler_test.go
@@ -45,6 +45,7 @@ func TestSettingsHandlerGetAndPutAppSettings(t *testing.T) {
 		"close_to_tray": false,
 		"show_proxy_switch_on_home": false,
 		"show_home_update_indicator": false,
+		"usage_request_timeout_seconds": 18,
 		"proxy_host": "localhost",
 		"proxy_port": 15721,
 		"auto_failover_enabled": true,
@@ -65,7 +66,7 @@ func TestSettingsHandlerGetAndPutAppSettings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAppSettings returned error: %v", err)
 	}
-	if !stored.LaunchAtLogin || !stored.SilentStart || stored.CloseToTray || stored.ShowProxySwitchOnHome || stored.ShowHomeUpdateIndicator || stored.ProxyHost != "localhost" || stored.ProxyPort != 15721 || !stored.AutoFailoverEnabled || stored.AutoBackupIntervalHours != 12 || stored.BackupRetentionCount != 7 || stored.Language != "en-US" || stored.ThemeMode != "dark" {
+	if !stored.LaunchAtLogin || !stored.SilentStart || stored.CloseToTray || stored.ShowProxySwitchOnHome || stored.ShowHomeUpdateIndicator || stored.UsageRequestTimeoutSeconds != 18 || stored.ProxyHost != "localhost" || stored.ProxyPort != 15721 || !stored.AutoFailoverEnabled || stored.AutoBackupIntervalHours != 12 || stored.BackupRetentionCount != 7 || stored.Language != "en-US" || stored.ThemeMode != "dark" {
 		t.Fatalf("stored settings = %+v, want updated values", stored)
 	}
 }

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -97,7 +97,7 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 		_ = store.Close()
 		return nil, err
 	}
-	refreshOrchestrator := refresh.NewOrchestrator(accountRepo, usageRepo, driverRegistry)
+	refreshOrchestrator := refresh.NewOrchestratorWithSettings(accountRepo, usageRepo, driverRegistry, settingsRepo)
 	accountsHandler := api.NewAccountsHandler(
 		accountRepo,
 		usageRepo,
@@ -105,6 +105,7 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 		stateStore,
 		api.WithAccountsStateEvents(stateEvents),
 		api.WithAccountsUsageRefresher(refreshOrchestrator),
+		api.WithAccountsSettings(settingsRepo),
 		api.WithAccountsDriverRegistry(driverRegistry),
 		api.WithAccountsLuaScriptRoot(luaScriptRoot),
 	)

--- a/backend/internal/settings/repository.go
+++ b/backend/internal/settings/repository.go
@@ -19,6 +19,7 @@ type AppSettings struct {
 	ShowProxySwitchOnHome        bool                   `json:"show_proxy_switch_on_home"`
 	ShowHomeUpdateIndicator      bool                   `json:"show_home_update_indicator"`
 	StatusRefreshIntervalSeconds int                    `json:"status_refresh_interval_seconds"`
+	UsageRequestTimeoutSeconds   int                    `json:"usage_request_timeout_seconds"`
 	ProxyHost                    string                 `json:"proxy_host"`
 	ProxyPort                    int                    `json:"proxy_port"`
 	AutoFailoverEnabled          bool                   `json:"auto_failover_enabled"`
@@ -55,6 +56,7 @@ func DefaultAppSettings() AppSettings {
 		ShowProxySwitchOnHome:        true,
 		ShowHomeUpdateIndicator:      true,
 		StatusRefreshIntervalSeconds: 60,
+		UsageRequestTimeoutSeconds:   15,
 		ProxyHost:                    "127.0.0.1",
 		ProxyPort:                    6789,
 		AutoFailoverEnabled:          true,
@@ -67,7 +69,7 @@ func DefaultAppSettings() AppSettings {
 
 func (r *SQLiteRepository) GetAppSettings() (AppSettings, error) {
 	row := r.db.QueryRow(
-		`SELECT launch_at_login, silent_start, close_to_tray, show_proxy_switch_on_home, show_home_update_indicator, status_refresh_interval_seconds, proxy_host, proxy_port, auto_failover_enabled, auto_backup_interval_hours, backup_retention_count,
+		`SELECT launch_at_login, silent_start, close_to_tray, show_proxy_switch_on_home, show_home_update_indicator, status_refresh_interval_seconds, usage_request_timeout_seconds, proxy_host, proxy_port, auto_failover_enabled, auto_backup_interval_hours, backup_retention_count,
 		        language, theme_mode, provider_pricing, account_pricing
 		 FROM app_settings WHERE id = 1`,
 	)
@@ -78,6 +80,7 @@ func (r *SQLiteRepository) GetAppSettings() (AppSettings, error) {
 	var showProxySwitchOnHome int
 	var showHomeUpdateIndicator int
 	var statusRefreshIntervalSeconds int
+	var usageRequestTimeoutSeconds int
 	var proxyHost string
 	var proxyPort int
 	var autoFailoverEnabled int
@@ -95,6 +98,7 @@ func (r *SQLiteRepository) GetAppSettings() (AppSettings, error) {
 		&showProxySwitchOnHome,
 		&showHomeUpdateIndicator,
 		&statusRefreshIntervalSeconds,
+		&usageRequestTimeoutSeconds,
 		&proxyHost,
 		&proxyPort,
 		&autoFailoverEnabled,
@@ -127,6 +131,7 @@ func (r *SQLiteRepository) GetAppSettings() (AppSettings, error) {
 		ShowProxySwitchOnHome:        showProxySwitchOnHome == 1,
 		ShowHomeUpdateIndicator:      showHomeUpdateIndicator == 1,
 		StatusRefreshIntervalSeconds: statusRefreshIntervalSeconds,
+		UsageRequestTimeoutSeconds:   usageRequestTimeoutSeconds,
 		ProxyHost:                    proxyHost,
 		ProxyPort:                    proxyPort,
 		AutoFailoverEnabled:          autoFailoverEnabled == 1,
@@ -151,9 +156,9 @@ func (r *SQLiteRepository) SaveAppSettings(value AppSettings) error {
 	}
 	_, err = r.db.Exec(
 		`INSERT INTO app_settings (
-			id, launch_at_login, silent_start, close_to_tray, show_proxy_switch_on_home, show_home_update_indicator, status_refresh_interval_seconds, proxy_host, proxy_port, auto_failover_enabled, auto_backup_interval_hours, backup_retention_count,
+			id, launch_at_login, silent_start, close_to_tray, show_proxy_switch_on_home, show_home_update_indicator, status_refresh_interval_seconds, usage_request_timeout_seconds, proxy_host, proxy_port, auto_failover_enabled, auto_backup_interval_hours, backup_retention_count,
 			language, theme_mode, provider_pricing, account_pricing, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			launch_at_login = excluded.launch_at_login,
 			silent_start = excluded.silent_start,
@@ -161,6 +166,7 @@ func (r *SQLiteRepository) SaveAppSettings(value AppSettings) error {
 			show_proxy_switch_on_home = excluded.show_proxy_switch_on_home,
 			show_home_update_indicator = excluded.show_home_update_indicator,
 			status_refresh_interval_seconds = excluded.status_refresh_interval_seconds,
+			usage_request_timeout_seconds = excluded.usage_request_timeout_seconds,
 			proxy_host = excluded.proxy_host,
 			proxy_port = excluded.proxy_port,
 			auto_failover_enabled = excluded.auto_failover_enabled,
@@ -178,6 +184,7 @@ func (r *SQLiteRepository) SaveAppSettings(value AppSettings) error {
 		boolToInt(value.ShowProxySwitchOnHome),
 		boolToInt(value.ShowHomeUpdateIndicator),
 		value.StatusRefreshIntervalSeconds,
+		value.UsageRequestTimeoutSeconds,
 		value.ProxyHost,
 		value.ProxyPort,
 		boolToInt(value.AutoFailoverEnabled),
@@ -266,6 +273,15 @@ func sanitize(value AppSettings) AppSettings {
 	}
 	if value.StatusRefreshIntervalSeconds > 3600 {
 		value.StatusRefreshIntervalSeconds = 3600
+	}
+	if value.UsageRequestTimeoutSeconds <= 0 {
+		value.UsageRequestTimeoutSeconds = defaults.UsageRequestTimeoutSeconds
+	}
+	if value.UsageRequestTimeoutSeconds < 3 {
+		value.UsageRequestTimeoutSeconds = 3
+	}
+	if value.UsageRequestTimeoutSeconds > 300 {
+		value.UsageRequestTimeoutSeconds = 300
 	}
 	if value.Language != "en-US" {
 		value.Language = defaults.Language

--- a/backend/internal/settings/repository_test.go
+++ b/backend/internal/settings/repository_test.go
@@ -60,6 +60,7 @@ func TestRepositoryPersistsAppSettingsAndQueue(t *testing.T) {
 		ShowProxySwitchOnHome:        false,
 		ShowHomeUpdateIndicator:      false,
 		StatusRefreshIntervalSeconds: 15,
+		UsageRequestTimeoutSeconds:   22,
 		ProxyHost:                    "localhost",
 		ProxyPort:                    15721,
 		AutoFailoverEnabled:          true,
@@ -138,6 +139,47 @@ func TestRepositoryClampsStatusRefreshInterval(t *testing.T) {
 	}
 	if high.StatusRefreshIntervalSeconds != 3600 {
 		t.Fatalf("high.StatusRefreshIntervalSeconds = %d, want 3600", high.StatusRefreshIntervalSeconds)
+	}
+}
+
+func TestRepositoryClampsUsageRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	repo := settings.NewSQLiteRepository(store.DB())
+
+	value := settings.DefaultAppSettings()
+	value.UsageRequestTimeoutSeconds = 1
+	if err := repo.SaveAppSettings(value); err != nil {
+		t.Fatalf("SaveAppSettings(low) returned error: %v", err)
+	}
+
+	low, err := repo.GetAppSettings()
+	if err != nil {
+		t.Fatalf("GetAppSettings(low) returned error: %v", err)
+	}
+	if low.UsageRequestTimeoutSeconds != 3 {
+		t.Fatalf("low.UsageRequestTimeoutSeconds = %d, want 3", low.UsageRequestTimeoutSeconds)
+	}
+
+	value.UsageRequestTimeoutSeconds = 999
+	if err := repo.SaveAppSettings(value); err != nil {
+		t.Fatalf("SaveAppSettings(high) returned error: %v", err)
+	}
+
+	high, err := repo.GetAppSettings()
+	if err != nil {
+		t.Fatalf("GetAppSettings(high) returned error: %v", err)
+	}
+	if high.UsageRequestTimeoutSeconds != 300 {
+		t.Fatalf("high.UsageRequestTimeoutSeconds = %d, want 300", high.UsageRequestTimeoutSeconds)
 	}
 }
 

--- a/backend/internal/store/sqlite/migrations.go
+++ b/backend/internal/store/sqlite/migrations.go
@@ -121,6 +121,7 @@ var schemaStatements = []string{
 		show_proxy_switch_on_home INTEGER NOT NULL DEFAULT 1,
 		show_home_update_indicator INTEGER NOT NULL DEFAULT 1,
 		status_refresh_interval_seconds INTEGER NOT NULL DEFAULT 60,
+		usage_request_timeout_seconds INTEGER NOT NULL DEFAULT 15,
 		proxy_host TEXT NOT NULL DEFAULT '127.0.0.1',
 		proxy_port INTEGER NOT NULL DEFAULT 6789,
 		auto_failover_enabled INTEGER NOT NULL DEFAULT 0,

--- a/backend/internal/store/sqlite/store.go
+++ b/backend/internal/store/sqlite/store.go
@@ -123,6 +123,7 @@ func (s *Store) migrate() error {
 		{table: "accounts", name: "usage_config_json", definition: "TEXT NOT NULL DEFAULT ''"},
 		{table: "app_settings", name: "show_home_update_indicator", definition: "INTEGER NOT NULL DEFAULT 1"},
 		{table: "app_settings", name: "status_refresh_interval_seconds", definition: "INTEGER NOT NULL DEFAULT 60"},
+		{table: "app_settings", name: "usage_request_timeout_seconds", definition: "INTEGER NOT NULL DEFAULT 15"},
 		{table: "app_settings", name: "audit_limit_message", definition: "INTEGER NOT NULL DEFAULT 200"},
 		{table: "app_settings", name: "audit_limit_function_call", definition: "INTEGER NOT NULL DEFAULT 100"},
 		{table: "app_settings", name: "audit_limit_function_call_output", definition: "INTEGER NOT NULL DEFAULT 100"},

--- a/backend/internal/usage/refresh/orchestrator.go
+++ b/backend/internal/usage/refresh/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
+	"github.com/gcssloop/codex-router/backend/internal/settings"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
 	"github.com/gcssloop/codex-router/backend/internal/usage/normalize"
 	"github.com/gcssloop/codex-router/backend/internal/usagedrv/registry"
@@ -22,16 +23,21 @@ type snapshotRepository interface {
 	GetLatest(accountID int64) (usage.Snapshot, error)
 }
 
+type settingsReader interface {
+	GetAppSettings() (settings.AppSettings, error)
+}
+
 type Orchestrator struct {
 	accounts accountLister
 	usage    snapshotRepository
 	registry *registry.Registry
+	settings settingsReader
 	now      func() time.Time
 	timeout  time.Duration
 	workers  int
 }
 
-const defaultPerAccountTimeout = 5 * time.Second
+const defaultPerAccountTimeout = 15 * time.Second
 const defaultRefreshWorkers = 4
 
 func NewOrchestrator(accountsRepo accountLister, usageRepo snapshotRepository, driverRegistry *registry.Registry) *Orchestrator {
@@ -43,6 +49,12 @@ func NewOrchestrator(accountsRepo accountLister, usageRepo snapshotRepository, d
 		timeout:  defaultPerAccountTimeout,
 		workers:  defaultRefreshWorkers,
 	}
+}
+
+func NewOrchestratorWithSettings(accountsRepo accountLister, usageRepo snapshotRepository, driverRegistry *registry.Registry, settingsRepo settingsReader) *Orchestrator {
+	orchestrator := NewOrchestrator(accountsRepo, usageRepo, driverRegistry)
+	orchestrator.settings = settingsRepo
+	return orchestrator
 }
 
 func NewOrchestratorWithTimeout(accountsRepo accountLister, usageRepo snapshotRepository, driverRegistry *registry.Registry, timeout time.Duration) *Orchestrator {
@@ -135,9 +147,15 @@ func (o *Orchestrator) Run(ctx context.Context, runAt time.Time) error {
 }
 
 func (o *Orchestrator) refreshOne(ctx context.Context, account accounts.Account, runAt time.Time) error {
-	if o.timeout > 0 {
+	timeout := o.timeout
+	if o.settings != nil {
+		if appSettings, err := o.settings.GetAppSettings(); err == nil && appSettings.UsageRequestTimeoutSeconds > 0 {
+			timeout = time.Duration(appSettings.UsageRequestTimeoutSeconds) * time.Second
+		}
+	}
+	if timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, o.timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
 	accountDriver, err := o.registry.AccountDriverFor(account)

--- a/backend/internal/usage/refresh/orchestrator_internal_test.go
+++ b/backend/internal/usage/refresh/orchestrator_internal_test.go
@@ -1,0 +1,15 @@
+package refresh
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewOrchestratorDefaultsToFifteenSecondTimeout(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := NewOrchestrator(nil, nil, nil)
+	if orchestrator.timeout != 15*time.Second {
+		t.Fatalf("timeout = %s, want %s", orchestrator.timeout, 15*time.Second)
+	}
+}

--- a/backend/internal/usage/refresh/orchestrator_test.go
+++ b/backend/internal/usage/refresh/orchestrator_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gcssloop/codex-router/backend/internal/accountdrv"
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
+	"github.com/gcssloop/codex-router/backend/internal/settings"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
 	"github.com/gcssloop/codex-router/backend/internal/usage/refresh"
 	"github.com/gcssloop/codex-router/backend/internal/usagedrv"
@@ -30,6 +31,27 @@ type stubUsageRepo struct {
 	mu     sync.Mutex
 	saved  []usage.Snapshot
 	latest map[int64]usage.Snapshot
+}
+
+type stubSettingsRepo struct {
+	mu    sync.Mutex
+	value settings.AppSettings
+}
+
+func newStubSettingsRepo(value settings.AppSettings) *stubSettingsRepo {
+	return &stubSettingsRepo{value: value}
+}
+
+func (r *stubSettingsRepo) GetAppSettings() (settings.AppSettings, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.value, nil
+}
+
+func (r *stubSettingsRepo) Set(value settings.AppSettings) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.value = value
 }
 
 func newStubUsageRepo(initial ...usage.Snapshot) *stubUsageRepo {
@@ -436,6 +458,64 @@ func TestOrchestratorLimitsConcurrentRefreshes(t *testing.T) {
 
 	if maxSeen.Load() != 2 {
 		t.Fatalf("max concurrent refreshes = %d, want 2", maxSeen.Load())
+	}
+}
+
+func TestOrchestratorAppliesUpdatedSettingsTimeoutWithoutRestart(t *testing.T) {
+	t.Parallel()
+
+	reg := newRegistry(t,
+		[]accountdrv.AccountDriver{
+			stubAccountDriver{
+				name: "builtin_api_key",
+				supports: func(account accounts.Account) bool {
+					return account.AuthMode == accounts.AuthModeAPIKey
+				},
+				resolve: func(context.Context, accounts.Account) (accountdrv.ResolvedCredential, error) {
+					return accountdrv.ResolvedCredential{AccessToken: "token"}, nil
+				},
+			},
+		},
+		[]usagedrv.UsageDriver{
+			stubUsageDriver{
+				name: "builtin_ppchat",
+				fetch: func(ctx context.Context, account accounts.Account, _ accountdrv.ResolvedCredential) (usagedrv.RawUsageResult, error) {
+					<-ctx.Done()
+					return usagedrv.RawUsageResult{}, fmt.Errorf("usage fetch timeout: %w", ctx.Err())
+				},
+			},
+		},
+	)
+
+	usageRepo := newStubUsageRepo()
+	appSettings := settings.DefaultAppSettings()
+	appSettings.UsageRequestTimeoutSeconds = 1
+	settingsRepo := newStubSettingsRepo(appSettings)
+	orchestrator := refresh.NewOrchestratorWithSettings(stubAccountRepo{accounts: []accounts.Account{
+		{ID: 1, AccountName: "hung", AuthMode: accounts.AuthModeAPIKey, UsageDriver: "builtin_ppchat"},
+	}}, usageRepo, reg, settingsRepo)
+
+	start := time.Now()
+	err := orchestrator.Run(context.Background(), time.Date(2026, 3, 20, 2, 0, 0, 0, time.UTC))
+	firstElapsed := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "deadline exceeded") {
+		t.Fatalf("first Run error = %v, want deadline exceeded", err)
+	}
+	if firstElapsed < 900*time.Millisecond || firstElapsed > 2*time.Second {
+		t.Fatalf("first Run took %s, want about 1s", firstElapsed)
+	}
+
+	appSettings.UsageRequestTimeoutSeconds = 3
+	settingsRepo.Set(appSettings)
+
+	start = time.Now()
+	err = orchestrator.Run(context.Background(), time.Date(2026, 3, 20, 2, 1, 0, 0, time.UTC))
+	secondElapsed := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "deadline exceeded") {
+		t.Fatalf("second Run error = %v, want deadline exceeded", err)
+	}
+	if secondElapsed < 2900*time.Millisecond || secondElapsed > 4*time.Second {
+		t.Fatalf("second Run took %s, want about 3s after settings update", secondElapsed)
 	}
 }
 

--- a/docs/plans/2026-03-20-usage-timeout-settings.md
+++ b/docs/plans/2026-03-20-usage-timeout-settings.md
@@ -1,0 +1,35 @@
+# Usage Timeout Settings Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a configurable usage refresh timeout in settings and apply it immediately without restarting the backend.
+
+**Architecture:** Persist `usage_request_timeout_seconds` in `app_settings`, expose it through `/settings/app`, and have both the manual refresh handler and the background usage refresh orchestrator read the latest value from the settings repository on each run. Surface the setting in the existing Settings page account-status card.
+
+**Tech Stack:** Go backend, SQLite settings repository, React + Ant Design frontend, Vitest, Go test.
+
+---
+
+### Task 1: Persist the new app setting
+- Modify `backend/internal/settings/repository.go`
+- Modify `backend/internal/store/sqlite/migrations.go`
+- Modify `backend/internal/store/sqlite/store.go`
+- Test `backend/internal/settings/repository_test.go`
+
+### Task 2: Apply the timeout dynamically in refresh flows
+- Modify `backend/internal/usage/refresh/orchestrator.go`
+- Modify `backend/internal/api/accounts_handler.go`
+- Modify `backend/internal/bootstrap/bootstrap.go`
+- Test `backend/internal/usage/refresh/orchestrator_test.go`
+- Test `backend/internal/api/settings_handler_test.go`
+- Test `backend/internal/api/accounts_handler_internal_test.go`
+
+### Task 3: Expose and edit the setting in the frontend
+- Modify `frontend/src/lib/api.ts`
+- Modify `frontend/src/features/settings/SettingsPage.tsx`
+- Test `frontend/src/features/settings/SettingsPage.test.tsx`
+
+### Task 4: Verify end-to-end behavior
+- Run `go test ./...`
+- Run `npm test -- --run src/features/settings/SettingsPage.test.tsx`
+- Run `npm test`

--- a/frontend/src/features/settings/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/SettingsPage.test.tsx
@@ -18,6 +18,7 @@ const baseSettings = {
   show_proxy_switch_on_home: true,
   show_home_update_indicator: true,
   status_refresh_interval_seconds: 60,
+  usage_request_timeout_seconds: 15,
   proxy_host: "127.0.0.1",
   proxy_port: 6789,
   auto_failover_enabled: true,
@@ -488,6 +489,7 @@ describe("SettingsPage", () => {
 
     fireEvent.click(await screen.findByRole("tab", { name: "数据" }));
     fireEvent.change(await screen.findByLabelText("状态刷新间隔（秒）"), { target: { value: "5" } });
+    fireEvent.change(await screen.findByLabelText("Usage 请求超时（秒）"), { target: { value: "18" } });
     fireEvent.click(screen.getByRole("button", { name: "保存设置" }));
 
     await waitFor(() => {
@@ -495,12 +497,12 @@ describe("SettingsPage", () => {
         "/ai-router/api/settings/app",
         expect.objectContaining({
           method: "PUT",
-          body: JSON.stringify({ ...baseSettings, status_refresh_interval_seconds: 5 }),
+          body: JSON.stringify({ ...baseSettings, status_refresh_interval_seconds: 5, usage_request_timeout_seconds: 18 }),
         }),
       );
     });
 
-    expect(onSettingsChanged).toHaveBeenCalledWith({ ...baseSettings, status_refresh_interval_seconds: 5 });
+    expect(onSettingsChanged).toHaveBeenCalledWith({ ...baseSettings, status_refresh_interval_seconds: 5, usage_request_timeout_seconds: 18 });
   });
 
   it("renders recent desktop logs inside a bounded scroll panel", async () => {

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -182,6 +182,7 @@ export function SettingsPage({
       ...initialSettings,
       provider_pricing: initialSettings.provider_pricing ?? {},
       account_pricing: initialSettings.account_pricing ?? {},
+      usage_request_timeout_seconds: initialSettings.usage_request_timeout_seconds ?? 15,
     });
   }, [initialSettings]);
 
@@ -612,6 +613,21 @@ export function SettingsPage({
                   onChange={(value) =>
                     updateDraft({
                       status_refresh_interval_seconds: Math.min(Math.max(Number(value) || 60, 5), 3600),
+                    })
+                  }
+                  className="settings-number"
+                />
+              </label>
+              <label className="settings-field">
+                <span className="settings-field-label">{t("Usage 请求超时（秒）")}</span>
+                <InputNumber
+                  aria-label={t("Usage 请求超时（秒）")}
+                  min={3}
+                  max={300}
+                  value={draftSettings.usage_request_timeout_seconds ?? 15}
+                  onChange={(value) =>
+                    updateDraft({
+                      usage_request_timeout_seconds: Math.min(Math.max(Number(value) || 15, 3), 300),
                     })
                   }
                   className="settings-number"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -223,6 +223,7 @@ export type AppSettings = {
   show_proxy_switch_on_home: boolean;
   show_home_update_indicator: boolean;
   status_refresh_interval_seconds: number;
+  usage_request_timeout_seconds?: number;
   proxy_host: string;
   proxy_port: number;
   auto_failover_enabled: boolean;


### PR DESCRIPTION
## Summary\n- add persisted usage refresh timeout settings with runtime application for manual and scheduled usage refresh\n- expose the timeout control in settings and apply it immediately after save without restart\n- cover repository clamping, handler serialization, and dynamic refresh timeout updates with tests\n\n## Verification\n- go test ./...\n- npm test -- --run src/features/settings/SettingsPage.test.tsx\n- npm test\n- npm run build