### PR TITLE
feat: refresh usage on network and resume recovery

### DIFF
--- a/docs/plans/2026-03-20-usage-resume-network-refresh.md
+++ b/docs/plans/2026-03-20-usage-resume-network-refresh.md
@@ -1,0 +1,29 @@
+# Usage Refresh On Network And Resume
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Trigger an immediate account usage refresh when the app comes back online or appears to resume after being hidden or sleeping.
+
+**Architecture:** Keep the refresh orchestration in `frontend/src/App.tsx` so it works even when the accounts page is not currently visible. Reuse the existing backend `POST /accounts/usage/refresh` endpoint, then bump the existing `accountsSyncToken` so mounted pages silently reload the latest usage snapshots.
+
+**Tech Stack:** React, Vitest, existing REST API endpoints in the frontend shell.
+
+---
+
+## Design Summary
+
+- Add a debounced immediate usage refresh queue in `App`.
+- Coalesce concurrent refresh triggers so online/resume bursts do not fan out into repeated backend calls.
+- Trigger the queue from:
+  - `window.online`
+  - `document.visibilitychange` when the page returns from a sufficiently long hidden period
+  - a lightweight timer-gap detector as a fallback for sleep/wake cases that do not emit visibility transitions cleanly
+- Keep failures silent and rely on the next trigger or normal polling to retry.
+- Reuse `accountsSyncToken` after each immediate refresh so existing pages update without a separate state channel.
+
+## Verification
+
+- `npm --prefix frontend test -- --run src/App.test.tsx`
+- `npm --prefix frontend test -- --run src/features/accounts/AccountsPage.test.tsx`
+- `npm --prefix frontend test`
+- `npm --prefix frontend run build`

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -13,7 +13,11 @@ vi.mock("./features/updates/updateService", () => ({
 }));
 
 import { App } from "./App";
-import { loadDesktopShellContext, refreshDesktopTrayState, subscribeDesktopBackendStateChanged } from "./lib/desktop-shell";
+import {
+  loadDesktopShellContext,
+  refreshDesktopTrayState,
+  subscribeDesktopBackendStateChanged,
+} from "./lib/desktop-shell";
 
 vi.mock("./features/accounts/AccountsPage", () => ({
   AccountsPage: ({
@@ -1107,6 +1111,148 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getByText(/accounts-sync:1/)).toBeInTheDocument();
       expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+  });
+
+  it("triggers an immediate usage refresh when the browser comes back online", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/proxy/status") {
+          return Promise.resolve(new Response(JSON.stringify({ enabled: false }), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/app") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                launch_at_login: false,
+                silent_start: false,
+                close_to_tray: true,
+                show_proxy_switch_on_home: true,
+                show_home_update_indicator: false,
+                status_refresh_interval_seconds: 3600,
+                usage_request_timeout_seconds: 15,
+                proxy_host: "127.0.0.1",
+                proxy_port: 6789,
+                auto_failover_enabled: true,
+                auto_backup_interval_hours: 24,
+                backup_retention_count: 10,
+                audit_limit_message: 200,
+                audit_limit_function_call: 100,
+                audit_limit_function_call_output: 100,
+                audit_limit_reasoning: 40,
+                audit_limit_custom_tool_call: 100,
+                audit_limit_custom_tool_call_output: 100,
+                language: "zh-CN",
+                theme_mode: "system",
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts/usage") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        return Promise.resolve(new Response(null, { status: 404 }));
+      }),
+    );
+    vi.mocked(subscribeDesktopBackendStateChanged).mockResolvedValue(() => {});
+
+    render(<App />);
+
+    expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:6789/ai-router/api/accounts/usage/refresh",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(screen.getByText(/accounts-sync:1/)).toBeInTheDocument();
+    });
+  });
+
+  it("triggers an immediate usage refresh when the page becomes visible after a long hidden period", async () => {
+    let currentTime = new Date("2026-03-20T09:00:00Z").getTime();
+    vi.spyOn(Date, "now").mockImplementation(() => currentTime);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/proxy/status") {
+          return Promise.resolve(new Response(JSON.stringify({ enabled: false }), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/settings/app") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                launch_at_login: false,
+                silent_start: false,
+                close_to_tray: true,
+                show_proxy_switch_on_home: true,
+                show_home_update_indicator: false,
+                status_refresh_interval_seconds: 3600,
+                usage_request_timeout_seconds: 15,
+                proxy_host: "127.0.0.1",
+                proxy_port: 6789,
+                auto_failover_enabled: true,
+                auto_backup_interval_hours: 24,
+                backup_retention_count: 10,
+                audit_limit_message: 200,
+                audit_limit_function_call: 100,
+                audit_limit_function_call_output: 100,
+                audit_limit_reasoning: 40,
+                audit_limit_custom_tool_call: 100,
+                audit_limit_custom_tool_call_output: 100,
+                language: "zh-CN",
+                theme_mode: "system",
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        if (url === "http://127.0.0.1:6789/ai-router/api/accounts/usage") {
+          return Promise.resolve(new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } }));
+        }
+        return Promise.resolve(new Response(null, { status: 404 }));
+      }),
+    );
+    vi.mocked(subscribeDesktopBackendStateChanged).mockResolvedValue(() => {});
+
+    render(<App />);
+
+    expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
+
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "hidden",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      currentTime += 16_000;
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:6789/ai-router/api/accounts/usage/refresh",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(screen.getByText(/accounts-sync:1/)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import { StatsPage } from "./features/stats/StatsPage";
 import { HomeUpdatePanel } from "./features/updates/HomeUpdatePanel";
 import { createDesktopUpdateService, type DesktopUpdateInfo } from "./features/updates/updateService";
 import appLogo from "./assets/aigate_1024_1024.png";
-import { type AppSettings, disableProxy, enableProxy, getAppSettings, getProxyStatus, subscribeAccountRoutingStateChanged } from "./lib/api";
+import { type AppSettings, disableProxy, enableProxy, getAppSettings, getProxyStatus, refreshAccountUsage, subscribeAccountRoutingStateChanged } from "./lib/api";
 import { loadDesktopShellContext, refreshDesktopTrayState, subscribeDesktopBackendStateChanged } from "./lib/desktop-shell";
 import { createTranslator, getAntdLocale, normalizeLanguage } from "./lib/i18n";
 import { setAPIBase } from "./lib/paths";
@@ -18,6 +18,10 @@ import "./styles.css";
 const appSettingsBootstrapRetryDelays = [0, 150, 300, 600, 1_000];
 const homeUpdateCheckIntervalMs = 60 * 60 * 1_000;
 const defaultStatusRefreshIntervalSeconds = 60;
+const immediateUsageRefreshDebounceMs = 400;
+const resumeGapWatchIntervalMs = 5_000;
+const resumeGapThresholdMs = 30_000;
+const hiddenResumeThresholdMs = 15_000;
 
 type AppView = "accounts" | "stats" | "settings";
 
@@ -42,6 +46,10 @@ export function App() {
   const [homeUpdateModalOpen, setHomeUpdateModalOpen] = useState(false);
   const updateService = useMemo(() => createDesktopUpdateService(), []);
   const previousViewRef = useRef<AppView>("accounts");
+  const immediateUsageRefreshInFlightRef = useRef(false);
+  const immediateUsageRefreshPendingRef = useRef(false);
+  const immediateUsageRefreshTimerRef = useRef<number | null>(null);
+  const hiddenSinceRef = useRef<number | null>(null);
   const language = normalizeLanguage(appSettings?.language);
   const t = createTranslator(language);
   const themeMode = appSettings?.theme_mode ?? "system";
@@ -85,6 +93,47 @@ export function App() {
       setHomeUpdate(null);
     }
   }, [updateService]);
+
+  const runImmediateUsageRefresh = useCallback(async () => {
+    if (immediateUsageRefreshInFlightRef.current) {
+      immediateUsageRefreshPendingRef.current = true;
+      return;
+    }
+    immediateUsageRefreshInFlightRef.current = true;
+    try {
+      do {
+        immediateUsageRefreshPendingRef.current = false;
+        try {
+          await refreshAccountUsage();
+        } catch {
+          // Network and wake-up recovery should stay silent and retry on the next trigger.
+        }
+        setAccountsSyncToken((value) => value + 1);
+        void refreshDesktopTrayState();
+      } while (immediateUsageRefreshPendingRef.current);
+    } finally {
+      immediateUsageRefreshInFlightRef.current = false;
+    }
+  }, []);
+
+  const queueImmediateUsageRefresh = useCallback(
+    (trigger: "online" | "resume_gap" | "visibility_resume") => {
+      if (!shellReady || typeof window === "undefined") {
+        return;
+      }
+      if (trigger === "online" && typeof navigator !== "undefined" && navigator.onLine === false) {
+        return;
+      }
+      if (immediateUsageRefreshTimerRef.current !== null) {
+        window.clearTimeout(immediateUsageRefreshTimerRef.current);
+      }
+      immediateUsageRefreshTimerRef.current = window.setTimeout(() => {
+        immediateUsageRefreshTimerRef.current = null;
+        void runImmediateUsageRefresh();
+      }, immediateUsageRefreshDebounceMs);
+    },
+    [runImmediateUsageRefresh, shellReady],
+  );
 
   useEffect(() => {
     let disposed = false;
@@ -174,6 +223,49 @@ export function App() {
       unlisten?.();
     };
   }, [shellReady]);
+
+  useEffect(() => {
+    if (!shellReady || typeof window === "undefined") {
+      return;
+    }
+
+    let lastTickAt = Date.now();
+    const handleOnline = () => {
+      queueImmediateUsageRefresh("online");
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenSinceRef.current = Date.now();
+        return;
+      }
+      const hiddenSince = hiddenSinceRef.current;
+      hiddenSinceRef.current = null;
+      if (hiddenSince !== null && Date.now() - hiddenSince >= hiddenResumeThresholdMs) {
+        queueImmediateUsageRefresh("visibility_resume");
+      }
+    };
+    const timer = window.setInterval(() => {
+      const now = Date.now();
+      const elapsed = now - lastTickAt;
+      lastTickAt = now;
+      if (elapsed >= resumeGapThresholdMs) {
+        queueImmediateUsageRefresh("resume_gap");
+      }
+    }, resumeGapWatchIntervalMs);
+
+    window.addEventListener("online", handleOnline);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.clearInterval(timer);
+      if (immediateUsageRefreshTimerRef.current !== null) {
+        window.clearTimeout(immediateUsageRefreshTimerRef.current);
+        immediateUsageRefreshTimerRef.current = null;
+      }
+      hiddenSinceRef.current = null;
+    };
+  }, [queueImmediateUsageRefresh, shellReady]);
 
   useEffect(() => {
     if (!appSettings) {

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -1958,6 +1958,7 @@ describe("AccountsPage", () => {
     ).toBeInTheDocument();
   });
 
+
   it("shows usage health details from the status dot tooltip", async () => {
     const checkedAt = new Date("2026-03-19T08:35:00.000Z");
     const accountList = [


### PR DESCRIPTION
## Summary
- trigger an immediate usage refresh when the app comes back online
- trigger an immediate usage refresh after a long hidden/resume transition
- debounce and coalesce burst refresh triggers, then fan back into the existing account sync flow
- document the design in docs/plans

## Verification
- npm --prefix frontend test -- --run src/App.test.tsx
- npm --prefix frontend test -- --run src/features/accounts/AccountsPage.test.tsx
- npm --prefix frontend test
- npm --prefix frontend run build