### PR TITLE
fix: separate routing cooldown from account availability

### DIFF
--- a/backend/internal/accounts/repository.go
+++ b/backend/internal/accounts/repository.go
@@ -18,6 +18,7 @@ type Repository interface {
 	SetActive(id int64) error
 	UpdateStatus(id int64, status Status) error
 	UpdateCooldown(id int64, until *time.Time) error
+	UpdateCooldownReason(id int64, reason string) error
 }
 
 type SQLiteRepository struct {
@@ -34,6 +35,7 @@ func NewSQLiteRepository(db *sql.DB, cipher ...*secrets.Cipher) *SQLiteRepositor
 }
 
 func (r *SQLiteRepository) Create(account Account) error {
+	account = normalizeDurableAccountState(account)
 	account.SupportsResponses = account.NativeResponsesCapable()
 	credentialRef, err := r.encrypt(account.CredentialRef)
 	if err != nil {
@@ -41,8 +43,8 @@ func (r *SQLiteRepository) Create(account Account) error {
 	}
 
 	_, err = r.db.Exec(
-		`INSERT INTO accounts (provider_type, account_name, source_icon, auth_mode, credential_ref, account_driver, usage_driver, usage_config_json, base_url, status, priority, is_active, supports_responses, cooldown_until)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO accounts (provider_type, account_name, source_icon, auth_mode, credential_ref, account_driver, usage_driver, usage_config_json, base_url, status, priority, is_active, supports_responses, cooldown_until, cooldown_reason)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		account.ProviderType,
 		account.AccountName,
 		account.SourceIcon,
@@ -57,6 +59,7 @@ func (r *SQLiteRepository) Create(account Account) error {
 		boolToInt(account.IsActive),
 		boolToInt(account.SupportsResponses),
 		nullTime(account.CooldownUntil),
+		account.CooldownReason,
 	)
 	if err != nil {
 		return fmt.Errorf("insert account: %w", err)
@@ -66,7 +69,7 @@ func (r *SQLiteRepository) Create(account Account) error {
 
 func (r *SQLiteRepository) List() ([]Account, error) {
 	records, err := r.db.Query(
-		`SELECT id, provider_type, account_name, source_icon, auth_mode, credential_ref, account_driver, usage_driver, usage_config_json, base_url, status, priority, is_active, supports_responses, cooldown_until, created_at
+		`SELECT id, provider_type, account_name, source_icon, auth_mode, credential_ref, account_driver, usage_driver, usage_config_json, base_url, status, priority, is_active, supports_responses, cooldown_until, cooldown_reason, created_at
 		 FROM accounts
 		 ORDER BY priority DESC, id ASC`,
 	)
@@ -98,6 +101,7 @@ func (r *SQLiteRepository) List() ([]Account, error) {
 			&isActive,
 			&supportsResponses,
 			&cooldown,
+			&account.CooldownReason,
 			&account.CreatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan account: %w", err)
@@ -111,6 +115,7 @@ func (r *SQLiteRepository) List() ([]Account, error) {
 			value := cooldown.Time.UTC()
 			account.CooldownUntil = &value
 		}
+		account = normalizeDurableAccountState(account)
 		account.CredentialRef, err = r.decrypt(account.CredentialRef)
 		if err != nil {
 			return nil, err
@@ -128,7 +133,7 @@ func (r *SQLiteRepository) List() ([]Account, error) {
 
 func (r *SQLiteRepository) GetByID(id int64) (Account, error) {
 	row := r.db.QueryRow(
-		`SELECT id, provider_type, account_name, source_icon, auth_mode, credential_ref, account_driver, usage_driver, usage_config_json, base_url, status, priority, is_active, supports_responses, cooldown_until, created_at
+		`SELECT id, provider_type, account_name, source_icon, auth_mode, credential_ref, account_driver, usage_driver, usage_config_json, base_url, status, priority, is_active, supports_responses, cooldown_until, cooldown_reason, created_at
 		 FROM accounts WHERE id = ?`,
 		id,
 	)
@@ -153,6 +158,7 @@ func (r *SQLiteRepository) GetByID(id int64) (Account, error) {
 		&isActive,
 		&supportsResponses,
 		&cooldown,
+		&account.CooldownReason,
 		&account.CreatedAt,
 	); err != nil {
 		return Account{}, fmt.Errorf("select account: %w", err)
@@ -166,6 +172,7 @@ func (r *SQLiteRepository) GetByID(id int64) (Account, error) {
 		value := cooldown.Time.UTC()
 		account.CooldownUntil = &value
 	}
+	account = normalizeDurableAccountState(account)
 	var err error
 	account.CredentialRef, err = r.decrypt(account.CredentialRef)
 	if err != nil {
@@ -175,6 +182,7 @@ func (r *SQLiteRepository) GetByID(id int64) (Account, error) {
 }
 
 func (r *SQLiteRepository) Update(account Account) error {
+	account = normalizeDurableAccountState(account)
 	account.SupportsResponses = account.NativeResponsesCapable()
 	credentialRef, err := r.encrypt(account.CredentialRef)
 	if err != nil {
@@ -183,7 +191,7 @@ func (r *SQLiteRepository) Update(account Account) error {
 
 	_, err = r.db.Exec(
 		`UPDATE accounts
-		 SET account_name = ?, source_icon = ?, base_url = ?, credential_ref = ?, account_driver = ?, usage_driver = ?, usage_config_json = ?, status = ?, priority = ?, is_active = ?, supports_responses = ?, cooldown_until = ?
+		 SET account_name = ?, source_icon = ?, base_url = ?, credential_ref = ?, account_driver = ?, usage_driver = ?, usage_config_json = ?, status = ?, priority = ?, is_active = ?, supports_responses = ?, cooldown_until = ?, cooldown_reason = ?
 		 WHERE id = ?`,
 		account.AccountName,
 		account.SourceIcon,
@@ -197,6 +205,7 @@ func (r *SQLiteRepository) Update(account Account) error {
 		boolToInt(account.IsActive),
 		boolToInt(account.SupportsResponses),
 		nullTime(account.CooldownUntil),
+		account.CooldownReason,
 		account.ID,
 	)
 	if err != nil {
@@ -289,6 +298,21 @@ func (r *SQLiteRepository) UpdateCooldown(id int64, until *time.Time) error {
 		return fmt.Errorf("update account cooldown: %w", err)
 	}
 	return nil
+}
+
+func (r *SQLiteRepository) UpdateCooldownReason(id int64, reason string) error {
+	_, err := r.db.Exec(`UPDATE accounts SET cooldown_reason = ? WHERE id = ?`, reason, id)
+	if err != nil {
+		return fmt.Errorf("update account cooldown reason: %w", err)
+	}
+	return nil
+}
+
+func normalizeDurableAccountState(account Account) Account {
+	if account.Status == StatusCooldown {
+		account.Status = StatusActive
+	}
+	return account
 }
 
 func boolToInt(value bool) int {

--- a/backend/internal/accounts/repository_test.go
+++ b/backend/internal/accounts/repository_test.go
@@ -37,14 +37,15 @@ func TestSQLiteRepositoryCreateAndListAccounts(t *testing.T) {
 	}
 
 	thirdParty := accounts.Account{
-		ProviderType:  accounts.ProviderOpenAICompatible,
-		AccountName:   "mirror-east",
-		AuthMode:      accounts.AuthModeAPIKey,
-		Status:        accounts.StatusCooldown,
-		BaseURL:       "https://example.test/v1",
-		CredentialRef: "cred-2",
-		CooldownUntil: &cooldownUntil,
-		Priority:      5,
+		ProviderType:   accounts.ProviderOpenAICompatible,
+		AccountName:    "mirror-east",
+		AuthMode:       accounts.AuthModeAPIKey,
+		Status:         accounts.StatusActive,
+		BaseURL:        "https://example.test/v1",
+		CredentialRef:  "cred-2",
+		CooldownUntil:  &cooldownUntil,
+		CooldownReason: "capacity_failed",
+		Priority:       5,
 	}
 	if err := repo.Create(thirdParty); err != nil {
 		t.Fatalf("Create(thirdParty) returned error: %v", err)
@@ -62,11 +63,14 @@ func TestSQLiteRepositoryCreateAndListAccounts(t *testing.T) {
 	if got[0].AuthMode != accounts.AuthModeOAuth {
 		t.Fatalf("got[0].AuthMode = %q, want %q", got[0].AuthMode, accounts.AuthModeOAuth)
 	}
-	if got[1].Status != accounts.StatusCooldown {
-		t.Fatalf("got[1].Status = %q, want %q", got[1].Status, accounts.StatusCooldown)
+	if got[1].Status != accounts.StatusActive {
+		t.Fatalf("got[1].Status = %q, want %q", got[1].Status, accounts.StatusActive)
 	}
 	if got[1].CooldownUntil == nil || !got[1].CooldownUntil.Equal(cooldownUntil) {
 		t.Fatalf("got[1].CooldownUntil = %v, want %v", got[1].CooldownUntil, cooldownUntil)
+	}
+	if got[1].CooldownReason != "capacity_failed" {
+		t.Fatalf("got[1].CooldownReason = %q, want capacity_failed", got[1].CooldownReason)
 	}
 }
 

--- a/backend/internal/accounts/types.go
+++ b/backend/internal/accounts/types.go
@@ -43,9 +43,14 @@ type Account struct {
 	IsActive          bool
 	SupportsResponses bool
 	CooldownUntil     *time.Time
+	CooldownReason    string
 	CreatedAt         time.Time
 }
 
 func (a Account) NativeResponsesCapable() bool {
 	return a.SupportsResponses || a.ProviderType == ProviderOpenAIOfficial || a.AuthMode == AuthModeLocalImport
+}
+
+func (a Account) RoutingCooldownActive(now time.Time) bool {
+	return a.CooldownUntil != nil && a.CooldownUntil.UTC().After(now.UTC())
 }

--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -301,34 +301,36 @@ func (h *AccountsHandler) listAccounts(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	type responseItem struct {
-		ID                       int64                 `json:"id"`
-		ProviderType             accounts.ProviderType `json:"provider_type"`
-		AccountName              string                `json:"account_name"`
-		AuthMode                 accounts.AuthMode     `json:"auth_mode"`
-		SourceIcon               string                `json:"source_icon"`
-		BaseURL                  string                `json:"base_url"`
-		Status                   accounts.Status       `json:"status"`
-		CooldownRemainingSeconds *int64                `json:"cooldown_remaining_seconds,omitempty"`
-		Balance                  float64               `json:"balance"`
-		QuotaRemaining           float64               `json:"quota_remaining"`
-		RPMRemaining             float64               `json:"rpm_remaining"`
-		TPMRemaining             float64               `json:"tpm_remaining"`
-		HealthScore              float64               `json:"health_score"`
-		RecentErrorRate          float64               `json:"recent_error_rate"`
-		LastTotalTokens          float64               `json:"last_total_tokens"`
-		LastInputTokens          float64               `json:"last_input_tokens"`
-		LastOutputTokens         float64               `json:"last_output_tokens"`
-		ModelContextWindow       float64               `json:"model_context_window"`
-		PrimaryUsedPercent       float64               `json:"primary_used_percent"`
-		SecondaryUsedPercent     float64               `json:"secondary_used_percent"`
-		PrimaryResetsAt          *time.Time            `json:"primary_resets_at,omitempty"`
-		SecondaryResetsAt        *time.Time            `json:"secondary_resets_at,omitempty"`
-		AccountDriver            string                `json:"account_driver"`
-		UsageDriver              string                `json:"usage_driver"`
-		UsageConfigJSON          string                `json:"usage_config_json"`
-		Priority                 int                   `json:"priority"`
-		IsActive                 bool                  `json:"is_active"`
-		SupportsResponses        bool                  `json:"supports_responses"`
+		ID                              int64                 `json:"id"`
+		ProviderType                    accounts.ProviderType `json:"provider_type"`
+		AccountName                     string                `json:"account_name"`
+		AuthMode                        accounts.AuthMode     `json:"auth_mode"`
+		SourceIcon                      string                `json:"source_icon"`
+		BaseURL                         string                `json:"base_url"`
+		Status                          accounts.Status       `json:"status"`
+		CooldownRemainingSeconds        *int64                `json:"cooldown_remaining_seconds,omitempty"`
+		RoutingCooldownRemainingSeconds *int64                `json:"routing_cooldown_remaining_seconds,omitempty"`
+		RoutingCooldownReason           string                `json:"routing_cooldown_reason,omitempty"`
+		Balance                         float64               `json:"balance"`
+		QuotaRemaining                  float64               `json:"quota_remaining"`
+		RPMRemaining                    float64               `json:"rpm_remaining"`
+		TPMRemaining                    float64               `json:"tpm_remaining"`
+		HealthScore                     float64               `json:"health_score"`
+		RecentErrorRate                 float64               `json:"recent_error_rate"`
+		LastTotalTokens                 float64               `json:"last_total_tokens"`
+		LastInputTokens                 float64               `json:"last_input_tokens"`
+		LastOutputTokens                float64               `json:"last_output_tokens"`
+		ModelContextWindow              float64               `json:"model_context_window"`
+		PrimaryUsedPercent              float64               `json:"primary_used_percent"`
+		SecondaryUsedPercent            float64               `json:"secondary_used_percent"`
+		PrimaryResetsAt                 *time.Time            `json:"primary_resets_at,omitempty"`
+		SecondaryResetsAt               *time.Time            `json:"secondary_resets_at,omitempty"`
+		AccountDriver                   string                `json:"account_driver"`
+		UsageDriver                     string                `json:"usage_driver"`
+		UsageConfigJSON                 string                `json:"usage_config_json"`
+		Priority                        int                   `json:"priority"`
+		IsActive                        bool                  `json:"is_active"`
+		SupportsResponses               bool                  `json:"supports_responses"`
 	}
 
 	response := make([]responseItem, 0, len(accountList))
@@ -368,6 +370,8 @@ func (h *AccountsHandler) listAccounts(w http.ResponseWriter, _ *http.Request) {
 				remaining = 0
 			}
 			item.CooldownRemainingSeconds = &remaining
+			item.RoutingCooldownRemainingSeconds = &remaining
+			item.RoutingCooldownReason = account.CooldownReason
 		}
 		response = append(response, item)
 	}
@@ -1413,6 +1417,7 @@ func (h *AccountsHandler) duplicateAccount(w http.ResponseWriter, r *http.Reques
 	duplicate.AccountName = nextDuplicatedAccountName(source.AccountName, accountList)
 	duplicate.IsActive = false
 	duplicate.CooldownUntil = nil
+	duplicate.CooldownReason = ""
 
 	if err := h.repo.Create(duplicate); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -76,12 +76,13 @@ func TestAccountsHandler(t *testing.T) {
 
 	cooldownUntil := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
 	if err := repo.Create(accounts.Account{
-		ProviderType:  accounts.ProviderOpenAIOfficial,
-		AccountName:   "official-secondary",
-		AuthMode:      accounts.AuthModeOAuth,
-		CredentialRef: "cred-oauth",
-		Status:        accounts.StatusCooldown,
-		CooldownUntil: &cooldownUntil,
+		ProviderType:   accounts.ProviderOpenAIOfficial,
+		AccountName:    "official-secondary",
+		AuthMode:       accounts.AuthModeOAuth,
+		CredentialRef:  "cred-oauth",
+		Status:         accounts.StatusActive,
+		CooldownUntil:  &cooldownUntil,
+		CooldownReason: "rate_limited",
 	}); err != nil {
 		t.Fatalf("Create returned error: %v", err)
 	}
@@ -126,8 +127,11 @@ func TestAccountsHandler(t *testing.T) {
 	if listed[0]["usage_config_json"] != "{\"script\":\"adapters/vendor.lua\"}" {
 		t.Fatalf("usage_config_json = %v, want serialized config", listed[0]["usage_config_json"])
 	}
-	if listed[1]["cooldown_remaining_seconds"] == nil {
-		t.Fatal("cooldown_remaining_seconds missing from cooldown account")
+	if listed[1]["status"] != string(accounts.StatusActive) {
+		t.Fatalf("status = %v, want active", listed[1]["status"])
+	}
+	if listed[1]["routing_cooldown_remaining_seconds"] == nil {
+		t.Fatal("routing_cooldown_remaining_seconds missing from routed cooldown account")
 	}
 	if listed[1]["balance"].(float64) != 0 {
 		t.Fatalf("balance = %v, want 0", listed[1]["balance"])
@@ -616,7 +620,8 @@ func TestAccountsHandlerShareExportsPortablePayload(t *testing.T) {
 		AccountDriver:     "builtin_api_key",
 		UsageDriver:       "lua",
 		UsageConfigJSON:   `{"script":"adapters/vendor.lua"}`,
-		Status:            accounts.StatusCooldown,
+		Status:            accounts.StatusActive,
+		CooldownReason:    "capacity_failed",
 		Priority:          9,
 		IsActive:          true,
 		SupportsResponses: true,

--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -695,13 +695,15 @@ func (h *ResponsesHandler) buildCandidates(accountList []accounts.Account) []rou
 }
 
 func (h *ResponsesHandler) skipReasonForThinCandidate(candidate routing.Candidate) (string, bool) {
+	now := time.Now().UTC()
 	switch candidate.Account.Status {
 	case accounts.StatusDisabled:
 		return "status=disabled", true
 	case accounts.StatusInvalid:
 		return "status=invalid", true
-	case accounts.StatusCooldown:
-		return "status=cooldown", true
+	}
+	if candidate.Account.RoutingCooldownActive(now) {
+		return "routing_cooldown", true
 	}
 	if officialRemainingBelowThreshold(candidate) {
 		return "official_remaining_below_3pct", true
@@ -725,7 +727,10 @@ func officialRemainingBelowThreshold(candidate routing.Candidate) bool {
 }
 
 func shouldCooldownThinCandidate(candidate routing.Candidate, reason string) bool {
-	return reason == "official_remaining_below_3pct" || reason == "status=cooldown"
+	if reason == "routing_cooldown" {
+		return false
+	}
+	return reason == "official_remaining_below_3pct"
 }
 
 func shouldFailoverOnThinError(err error) bool {
@@ -744,11 +749,11 @@ func shouldFailoverOnThinStatus(status string) bool {
 
 func (h *ResponsesHandler) markThinCandidateCooldown(account accounts.Account, snapshot usage.Snapshot, reason string) (bool, error) {
 	until := computeThinCandidateCooldownUntil(snapshot, reason)
-	if account.Status == accounts.StatusCooldown && account.CooldownUntil != nil && until != nil && account.CooldownUntil.Equal(*until) {
+	if account.CooldownUntil != nil && until != nil && account.CooldownUntil.Equal(*until) && account.CooldownReason == reason {
 		return false, nil
 	}
-	account.Status = accounts.StatusCooldown
 	account.CooldownUntil = until
+	account.CooldownReason = reason
 	if err := h.accounts.Update(account); err != nil {
 		return false, err
 	}
@@ -771,7 +776,7 @@ func computeThinCandidateCooldownUntil(snapshot usage.Snapshot, reason string) *
 	case "rate_limited":
 		until := routing.ComputeCooldownUntil(now, routing.CooldownReasonRateLimit, nil, thinResponsesRateLimitCooldownWindow)
 		return &until
-	case "status=cooldown":
+	case "routing_cooldown":
 		resetAt := latestRelevantResetAt(snapshot)
 		if resetAt == nil {
 			return nil

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -1184,11 +1184,14 @@ func TestResponsesHandlerThinModeFailsOverAfterOfficialUsageLimit(t *testing.T) 
 	if err != nil {
 		t.Fatalf("GetByID returned error: %v", err)
 	}
-	if primaryAccount.Status != accounts.StatusCooldown {
-		t.Fatalf("status = %q, want %q", primaryAccount.Status, accounts.StatusCooldown)
+	if primaryAccount.Status != accounts.StatusActive {
+		t.Fatalf("status = %q, want %q", primaryAccount.Status, accounts.StatusActive)
 	}
 	if primaryAccount.CooldownUntil == nil {
 		t.Fatal("CooldownUntil = nil, want cooldown timestamp")
+	}
+	if primaryAccount.CooldownReason != "usage_limited" {
+		t.Fatalf("CooldownReason = %q, want usage_limited", primaryAccount.CooldownReason)
 	}
 	fallbackAccount, err := accountRepo.GetByID(2)
 	if err != nil {
@@ -1338,8 +1341,14 @@ func TestResponsesHandlerThinModeFailsOverAfterThirdPartyForbiddenQuotaError(t *
 	if err != nil {
 		t.Fatalf("GetByID returned error: %v", err)
 	}
-	if primaryAccount.Status != accounts.StatusCooldown {
-		t.Fatalf("status = %q, want %q", primaryAccount.Status, accounts.StatusCooldown)
+	if primaryAccount.Status != accounts.StatusActive {
+		t.Fatalf("status = %q, want %q", primaryAccount.Status, accounts.StatusActive)
+	}
+	if primaryAccount.CooldownUntil == nil {
+		t.Fatal("CooldownUntil = nil, want cooldown timestamp")
+	}
+	if primaryAccount.CooldownReason != "capacity_failed" {
+		t.Fatalf("CooldownReason = %q, want capacity_failed", primaryAccount.CooldownReason)
 	}
 
 	events, err := usageRepo.ListRecentEvents(usage.EventFilter{Limit: 10})

--- a/backend/internal/routing/cooldown.go
+++ b/backend/internal/routing/cooldown.go
@@ -21,11 +21,12 @@ func ComputeCooldownUntil(now time.Time, _ CooldownReason, resetAt *time.Time, f
 }
 
 func ShouldProbeRecovery(account accounts.Account, now time.Time) bool {
-	if account.Status != accounts.StatusCooldown {
+	switch account.Status {
+	case accounts.StatusDisabled, accounts.StatusInvalid:
 		return false
 	}
 	if account.CooldownUntil == nil {
-		return true
+		return false
 	}
 	return !account.CooldownUntil.UTC().After(now.UTC())
 }

--- a/backend/internal/routing/cooldown_test.go
+++ b/backend/internal/routing/cooldown_test.go
@@ -55,10 +55,10 @@ func TestShouldProbeRecovery(t *testing.T) {
 	expired := now.Add(-1 * time.Minute)
 	future := now.Add(1 * time.Minute)
 
-	if !routing.ShouldProbeRecovery(accounts.Account{Status: accounts.StatusCooldown, CooldownUntil: &expired}, now) {
+	if !routing.ShouldProbeRecovery(accounts.Account{Status: accounts.StatusActive, CooldownUntil: &expired}, now) {
 		t.Fatal("ShouldProbeRecovery() = false, want true for expired cooldown")
 	}
-	if routing.ShouldProbeRecovery(accounts.Account{Status: accounts.StatusCooldown, CooldownUntil: &future}, now) {
+	if routing.ShouldProbeRecovery(accounts.Account{Status: accounts.StatusActive, CooldownUntil: &future}, now) {
 		t.Fatal("ShouldProbeRecovery() = true, want false for active cooldown")
 	}
 	if routing.ShouldProbeRecovery(accounts.Account{Status: accounts.StatusDisabled, CooldownUntil: &expired}, now) {

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -12,14 +12,15 @@ type AccountRepository interface {
 	List() ([]accounts.Account, error)
 	UpdateStatus(id int64, status accounts.Status) error
 	UpdateCooldown(id int64, until *time.Time) error
+	UpdateCooldownReason(id int64, reason string) error
 }
 
 type ProbeFunc func(ctx context.Context, account accounts.Account) error
 
 type RecoveryJob struct {
-	repo           AccountRepository
-	probe          ProbeFunc
-	retryWindow    time.Duration
+	repo        AccountRepository
+	probe       ProbeFunc
+	retryWindow time.Duration
 }
 
 func NewRecoveryJob(repo AccountRepository, probe ProbeFunc, retryWindow time.Duration) *RecoveryJob {
@@ -49,10 +50,10 @@ func (j *RecoveryJob) Run(ctx context.Context, now time.Time) error {
 			continue
 		}
 
-		if err := j.repo.UpdateStatus(account.ID, accounts.StatusActive); err != nil {
+		if err := j.repo.UpdateCooldown(account.ID, nil); err != nil {
 			return err
 		}
-		if err := j.repo.UpdateCooldown(account.ID, nil); err != nil {
+		if err := j.repo.UpdateCooldownReason(account.ID, ""); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -17,7 +17,7 @@ func TestRunCooldownRecoveryRestoresRecoveredAccounts(t *testing.T) {
 	expired := now.Add(-1 * time.Minute)
 	repo := &stubAccountRepo{
 		accounts: []accounts.Account{
-			{ID: 1, AccountName: "recoverable", Status: accounts.StatusCooldown, CooldownUntil: &expired},
+			{ID: 1, AccountName: "recoverable", Status: accounts.StatusActive, CooldownUntil: &expired, CooldownReason: "rate_limited"},
 		},
 	}
 
@@ -32,8 +32,11 @@ func TestRunCooldownRecoveryRestoresRecoveredAccounts(t *testing.T) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 
-	if repo.statusUpdates[1] != accounts.StatusActive {
-		t.Fatalf("status update = %q, want %q", repo.statusUpdates[1], accounts.StatusActive)
+	if repo.cooldownUpdates[1] != nil {
+		t.Fatalf("cooldown update = %v, want nil", repo.cooldownUpdates[1])
+	}
+	if repo.cooldownReasonUpdates[1] != "" {
+		t.Fatalf("cooldown reason update = %q, want empty", repo.cooldownReasonUpdates[1])
 	}
 }
 
@@ -44,7 +47,7 @@ func TestRunCooldownRecoveryExtendsCooldownOnFailedProbe(t *testing.T) {
 	expired := now.Add(-1 * time.Minute)
 	repo := &stubAccountRepo{
 		accounts: []accounts.Account{
-			{ID: 2, AccountName: "still-cooling", Status: accounts.StatusCooldown, CooldownUntil: &expired},
+			{ID: 2, AccountName: "still-cooling", Status: accounts.StatusActive, CooldownUntil: &expired},
 		},
 	}
 
@@ -91,9 +94,10 @@ func TestRunCooldownRecoverySkipsDisabledAndInvalid(t *testing.T) {
 }
 
 type stubAccountRepo struct {
-	accounts         []accounts.Account
-	statusUpdates    map[int64]accounts.Status
-	cooldownUpdates  map[int64]*time.Time
+	accounts              []accounts.Account
+	statusUpdates         map[int64]accounts.Status
+	cooldownUpdates       map[int64]*time.Time
+	cooldownReasonUpdates map[int64]string
 }
 
 func (r *stubAccountRepo) List() ([]accounts.Account, error) {
@@ -113,5 +117,13 @@ func (r *stubAccountRepo) UpdateCooldown(id int64, until *time.Time) error {
 		r.cooldownUpdates = make(map[int64]*time.Time)
 	}
 	r.cooldownUpdates[id] = until
+	return nil
+}
+
+func (r *stubAccountRepo) UpdateCooldownReason(id int64, reason string) error {
+	if r.cooldownReasonUpdates == nil {
+		r.cooldownReasonUpdates = make(map[int64]string)
+	}
+	r.cooldownReasonUpdates[id] = reason
 	return nil
 }

--- a/backend/internal/settings/failover.go
+++ b/backend/internal/settings/failover.go
@@ -1,6 +1,8 @@
 package settings
 
 import (
+	"time"
+
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
 	"github.com/gcssloop/codex-router/backend/internal/routing"
 )
@@ -50,9 +52,9 @@ func OrderCandidates(repo ReadRepository, candidates []routing.Candidate) ([]rou
 
 func eligibleForExplicitQueue(account accounts.Account) bool {
 	switch account.Status {
-	case accounts.StatusDisabled, accounts.StatusInvalid, accounts.StatusCooldown:
+	case accounts.StatusDisabled, accounts.StatusInvalid:
 		return false
 	default:
-		return true
+		return !account.RoutingCooldownActive(time.Now().UTC())
 	}
 }

--- a/backend/internal/settings/failover_test.go
+++ b/backend/internal/settings/failover_test.go
@@ -3,12 +3,13 @@ package settings_test
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
+	"github.com/gcssloop/codex-router/backend/internal/routing"
 	"github.com/gcssloop/codex-router/backend/internal/settings"
 	sqlitestore "github.com/gcssloop/codex-router/backend/internal/store/sqlite"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
-	"github.com/gcssloop/codex-router/backend/internal/routing"
 )
 
 func TestOrderCandidatesUsesExplicitQueueWhenEnabled(t *testing.T) {
@@ -34,7 +35,7 @@ func TestOrderCandidatesUsesExplicitQueueWhenEnabled(t *testing.T) {
 
 	ordered, err := settings.OrderCandidates(repo, []routing.Candidate{
 		{Account: accounts.Account{ID: 1, Status: accounts.StatusActive, Priority: 100}, Snapshot: usage.Snapshot{HealthScore: 0.9}},
-		{Account: accounts.Account{ID: 2, Status: accounts.StatusCooldown, Priority: 99}, Snapshot: usage.Snapshot{HealthScore: 0.8}},
+		{Account: accounts.Account{ID: 2, Status: accounts.StatusActive, Priority: 99, CooldownUntil: timePtr()}, Snapshot: usage.Snapshot{HealthScore: 0.8}},
 		{Account: accounts.Account{ID: 3, Status: accounts.StatusDegraded, Priority: 98}, Snapshot: usage.Snapshot{HealthScore: 0.7}},
 		{Account: accounts.Account{ID: 4, Status: accounts.StatusDisabled, Priority: 97}, Snapshot: usage.Snapshot{HealthScore: 0.6}},
 	})
@@ -48,6 +49,11 @@ func TestOrderCandidatesUsesExplicitQueueWhenEnabled(t *testing.T) {
 	if ordered[0].Account.ID != 3 || ordered[1].Account.ID != 1 {
 		t.Fatalf("ordered ids = [%d %d], want [3 1]", ordered[0].Account.ID, ordered[1].Account.ID)
 	}
+}
+
+func timePtr() *time.Time {
+	value := time.Now().UTC().Add(5 * time.Minute)
+	return &value
 }
 
 func TestOrderCandidatesFallsBackToScoredOrderWhenDisabled(t *testing.T) {

--- a/backend/internal/store/sqlite/store.go
+++ b/backend/internal/store/sqlite/store.go
@@ -121,6 +121,7 @@ func (s *Store) migrate() error {
 		{table: "accounts", name: "account_driver", definition: "TEXT NOT NULL DEFAULT ''"},
 		{table: "accounts", name: "usage_driver", definition: "TEXT NOT NULL DEFAULT ''"},
 		{table: "accounts", name: "usage_config_json", definition: "TEXT NOT NULL DEFAULT ''"},
+		{table: "accounts", name: "cooldown_reason", definition: "TEXT NOT NULL DEFAULT ''"},
 		{table: "app_settings", name: "show_home_update_indicator", definition: "INTEGER NOT NULL DEFAULT 1"},
 		{table: "app_settings", name: "status_refresh_interval_seconds", definition: "INTEGER NOT NULL DEFAULT 60"},
 		{table: "app_settings", name: "usage_request_timeout_seconds", definition: "INTEGER NOT NULL DEFAULT 15"},
@@ -139,6 +140,9 @@ func (s *Store) migrate() error {
 		if err := s.addColumnIfMissing(column.table, column.name, column.definition); err != nil {
 			return err
 		}
+	}
+	if _, err := s.db.Exec(`UPDATE accounts SET status = 'active' WHERE status = 'cooldown'`); err != nil {
+		return fmt.Errorf("normalize account cooldown status: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/usage/refresh/orchestrator.go
+++ b/backend/internal/usage/refresh/orchestrator.go
@@ -11,11 +11,17 @@ import (
 	"github.com/gcssloop/codex-router/backend/internal/settings"
 	"github.com/gcssloop/codex-router/backend/internal/usage"
 	"github.com/gcssloop/codex-router/backend/internal/usage/normalize"
+	"github.com/gcssloop/codex-router/backend/internal/usagedrv"
 	"github.com/gcssloop/codex-router/backend/internal/usagedrv/registry"
 )
 
 type accountLister interface {
 	List() ([]accounts.Account, error)
+}
+
+type cooldownWriter interface {
+	UpdateCooldown(id int64, until *time.Time) error
+	UpdateCooldownReason(id int64, reason string) error
 }
 
 type snapshotRepository interface {
@@ -177,6 +183,14 @@ func (o *Orchestrator) refreshOne(ctx context.Context, account accounts.Account,
 	if err := o.usage.Save(normalize.FromRaw(account.ID, raw, runAt)); err != nil {
 		return fmt.Errorf("save fresh snapshot: %w", err)
 	}
+	if writer, ok := o.accounts.(cooldownWriter); ok && account.CooldownUntil != nil && shouldClearCooldownAfterRefresh(account, raw) {
+		if err := writer.UpdateCooldown(account.ID, nil); err != nil {
+			return fmt.Errorf("clear routing cooldown: %w", err)
+		}
+		if err := writer.UpdateCooldownReason(account.ID, ""); err != nil {
+			return fmt.Errorf("clear routing cooldown reason: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -200,4 +214,23 @@ func (o *Orchestrator) markFailure(accountID int64, runAt time.Time, cause error
 		return fmt.Errorf("save stale snapshot: %w", err)
 	}
 	return cause
+}
+
+func shouldClearCooldownAfterRefresh(account accounts.Account, raw usagedrv.RawUsageResult) bool {
+	if account.AuthMode == accounts.AuthModeOAuth || account.AuthMode == accounts.AuthModeLocalImport {
+		return false
+	}
+	if raw.Limits.QuotaRemaining != nil {
+		return *raw.Limits.QuotaRemaining > 0
+	}
+	if raw.Limits.RPMRemaining != nil {
+		return *raw.Limits.RPMRemaining > 0
+	}
+	if raw.Limits.TPMRemaining != nil {
+		return *raw.Limits.TPMRemaining > 0
+	}
+	if raw.Limits.Balance != nil {
+		return *raw.Limits.Balance > 0
+	}
+	return false
 }

--- a/docs/plans/2026-03-24-routing-cooldown-separation-design.md
+++ b/docs/plans/2026-03-24-routing-cooldown-separation-design.md
@@ -1,0 +1,83 @@
+# Routing Cooldown Separation Design
+
+## Goal
+
+Separate persistent account state from temporary routing cooldown so the UI does not report a third-party account as unavailable when the account still has quota and can still be used manually.
+
+## Problem
+
+The current implementation stores temporary routing avoidance in `accounts.status = cooldown`. The account list UI reads that persisted status directly, while usage and remaining quota are read from usage snapshots. This creates inconsistent cards such as "has remaining quota" but "cooling down".
+
+It is worse for third-party providers such as PPChat because:
+- usage refresh and request routing use different upstream signals
+- `chat/completions` can still succeed even if `/responses` previously wrote cooldown
+- scheduler recovery only waits for `cooldown_until`; it does not actively verify recovery
+
+## Design
+
+### Account state model
+
+Keep `accounts.status` for durable account state only:
+- `active`
+- `invalid`
+- `disabled`
+
+Add routing cooldown fields to `accounts`:
+- `routing_cooldown_until DATETIME NULL`
+- `routing_cooldown_reason TEXT NOT NULL DEFAULT ''`
+
+This preserves routing behavior without polluting the main account state.
+
+### Routing behavior
+
+For `/responses` thin routing:
+- skip candidates when `routing_cooldown_until > now`
+- write and clear only routing cooldown fields
+- do not set `accounts.status = cooldown`
+
+Cooldown write rules:
+- official low-remaining preemptive cooldown remains supported
+- hard quota and real rate-limit responses can set routing cooldown
+- soft/network/upstream errors do not persist routing cooldown for third-party accounts
+
+### Recovery behavior
+
+Scheduler recovery should restore expired routing cooldowns by clearing the routing cooldown fields.
+
+For third-party usage refresh:
+- when refresh succeeds and the account has a healthy usage snapshot with positive remaining quota, clear expired or stale routing cooldown if present
+- do not mutate `status`
+
+### API and UI
+
+Account list payload should expose:
+- `status`
+- `routing_cooldown_remaining_seconds`
+- `routing_cooldown_reason`
+
+UI rules:
+- main badge uses durable `status`
+- routing cooldown is a secondary badge or helper text
+- usage meters continue to use snapshot data
+
+This keeps the visual hierarchy consistent:
+- account state first
+- routing avoidance second
+- quota/usage independent
+
+## Testing
+
+Add regression coverage for:
+- `/responses` writes routing cooldown without mutating account `status`
+- active PPChat account with routing cooldown still shows main status as active in list payload
+- cooldown candidate skipping uses routing cooldown fields instead of `status`
+- recovery job clears expired routing cooldown without changing active accounts incorrectly
+- third-party soft errors do not persist routing cooldown
+
+## Rollout
+
+1. Add schema and repository support.
+2. Update routing and scheduler logic.
+3. Update API payloads and frontend rendering.
+4. Run backend and frontend verification.
+5. Release through the normal branch, PR, tag, and release workflow.

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -108,6 +108,14 @@ const statusTextMap: Record<string, string> = {
   disabled: "已停用",
 };
 
+const routingCooldownTextMap: Record<string, string> = {
+  official_remaining_below_3pct: "路由冷却",
+  usage_limited: "路由冷却",
+  capacity_failed: "路由冷却",
+  rate_limited: "路由冷却",
+  routing_cooldown: "路由冷却",
+};
+
 const authModeTextMap: Record<string, string> = {
   api_key: "API Key",
   oauth: "官方授权",
@@ -511,6 +519,16 @@ function formatDeletedAccountMessage(
   return language === "en-US"
     ? `Deleted account ${accountName}`
     : `已删除账户 ${accountName}`;
+}
+
+function getRoutingCooldownSeconds(record: AccountRecord): number | undefined {
+  return (
+    record.routing_cooldown_remaining_seconds ?? record.cooldown_remaining_seconds
+  );
+}
+
+function getRoutingCooldownLabel(record: AccountRecord): string {
+  return routingCooldownTextMap[record.routing_cooldown_reason ?? ""] ?? "路由冷却";
 }
 
 function formatActiveAccountMessage(
@@ -1408,6 +1426,9 @@ export function AccountsPage({
                   <Tag color={statusColorMap[record.status] ?? "default"}>
                     {t(statusTextMap[record.status] ?? record.status)}
                   </Tag>
+                  {getRoutingCooldownSeconds(record) ? (
+                    <Tag color="gold">{t(getRoutingCooldownLabel(record))}</Tag>
+                  ) : null}
                   {record.is_active ? (
                     <Tag color="green">{t("当前使用中")}</Tag>
                   ) : null}
@@ -1799,6 +1820,14 @@ export function AccountsPage({
                       statusTextMap[detailAccount.status] ??
                         detailAccount.status,
                     )}
+                  </Descriptions.Item>
+                  <Descriptions.Item label={t("路由状态")}>
+                    {getRoutingCooldownSeconds(detailAccount)
+                      ? `${t(getRoutingCooldownLabel(detailAccount))} · ${Math.max(
+                          Math.floor((getRoutingCooldownSeconds(detailAccount) ?? 0) / 60),
+                          0,
+                        )}m`
+                      : t("正常")}
                   </Descriptions.Item>
                   <Descriptions.Item label={t("认证方式")}>
                     {t(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,8 @@ export type AccountRecord = {
   is_active: boolean;
   supports_responses?: boolean;
   cooldown_remaining_seconds?: number;
+  routing_cooldown_remaining_seconds?: number;
+  routing_cooldown_reason?: string;
   balance: number;
   quota_remaining: number;
   rpm_remaining: number;


### PR DESCRIPTION
## Summary
- keep durable account status separate from temporary routing cooldown
- avoid showing third-party accounts as unavailable when only routing cooldown is active
- clear stale third-party routing cooldown after healthy usage refresh

## Verification
- go test ./...
- pnpm -C frontend test -- --run AccountsPage MonitoringPage
- pnpm -C frontend build