### PR TITLE
[codex] fix macos release keychain import on bash 3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,10 @@ jobs:
             -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple: -s -k "$APPLE_KEYCHAIN_PASSWORD" "$APPLE_KEYCHAIN_PATH"
 
-          mapfile -t existing_keychains < <(security list-keychains -d user | sed 's/^[[:space:]]*//; s/"//g')
+          existing_keychains=()
+          while IFS= read -r keychain; do
+            existing_keychains+=("$keychain")
+          done < <(security list-keychains -d user | sed 's/^[[:space:]]*//; s/"//g')
           security list-keychains -d user -s "$APPLE_KEYCHAIN_PATH" "${existing_keychains[@]}"
           security default-keychain -d user -s "$APPLE_KEYCHAIN_PATH"
 

--- a/scripts/test/release_apple_signing_test.sh
+++ b/scripts/test/release_apple_signing_test.sh
@@ -9,6 +9,13 @@ fail() {
   exit 1
 }
 
+assert_not_contains() {
+  local pattern="$1"
+  if grep -Fq "$pattern" "$WORKFLOW_PATH"; then
+    fail "expected release workflow to not contain: $pattern"
+  fi
+}
+
 assert_contains() {
   local pattern="$1"
   if ! grep -Fq "$pattern" "$WORKFLOW_PATH"; then
@@ -24,6 +31,9 @@ assert_contains 'security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD"'
 assert_contains 'security import "$apple_cert_path"'
 assert_contains 'security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD"'
 assert_contains 'security set-key-partition-list -S apple-tool:,apple: -s -k "$APPLE_KEYCHAIN_PASSWORD"'
+assert_not_contains 'mapfile -t existing_keychains'
+assert_contains 'existing_keychains=()'
+assert_contains 'while IFS= read -r keychain; do'
 assert_contains 'security list-keychains -d user -s'
 assert_contains "name: Notarize macOS bundle"
 


### PR DESCRIPTION
## What changed
- replace `mapfile` with a Bash 3.2-compatible keychain collection loop in the macOS release workflow
- extend the Apple signing workflow regression test to block `mapfile` from reappearing

## Why
GitHub's macOS runner still uses the system Bash where `mapfile` is unavailable. The certificate import step succeeded, but the workflow failed before notarization because the shell could not execute `mapfile`.

## Validation
- bash scripts/test/release_apple_signing_test.sh
- bash scripts/test/release_updater_signing_key_test.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- git diff --check
