### PR TITLE
[codex] surface notarization failures before stapling

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Run release script tests
         run: |
           bash scripts/test/desktop_updater_config_test.sh
+          bash scripts/test/notarize_macos_test.sh
           bash scripts/test/release_apple_signing_test.sh
           bash scripts/test/release_updater_signing_key_test.sh
           bash scripts/test/release_version_helpers_test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Release script tests
         run: |
           bash scripts/test/desktop_updater_config_test.sh
+          bash scripts/test/notarize_macos_test.sh
           bash scripts/test/release_apple_signing_test.sh
           bash scripts/test/release_updater_signing_key_test.sh
           bash scripts/test/release_version_helpers_test.sh

--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -5,6 +5,24 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BUNDLE_DIR="$ROOT_DIR/desktop/src-tauri/target/universal-apple-darwin/release/bundle"
 APP_PATH="$(find "$BUNDLE_DIR/macos" -maxdepth 1 -name "*.app" -type d | head -n1 || true)"
 DMG_PATH="$(find "$BUNDLE_DIR/dmg" -maxdepth 1 -name "*.dmg" -type f | head -n1 || true)"
+NOTARY_TARGET_PATH=""
+
+extract_notary_field() {
+  local field="$1"
+  local json="$2"
+
+  python3 - "$field" "$json" <<'PY'
+import json
+import sys
+
+field = sys.argv[1]
+payload = sys.argv[2]
+data = json.loads(payload)
+value = data.get(field, "")
+if isinstance(value, str):
+    print(value)
+PY
+}
 
 if [[ -z "$APP_PATH" ]]; then
   echo "No macOS app bundle found, skip notarization"
@@ -27,24 +45,41 @@ fi
 
 if [[ -z "$DMG_PATH" ]]; then
   echo "No dmg found, create zip for notarization"
-  ZIP_PATH="$ROOT_DIR/desktop/src-tauri/target/aigate-macos.zip"
-  ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"
-  xcrun notarytool submit "$ZIP_PATH" \
-    --key "$APPLE_API_KEY_PATH" \
-    --key-id "$APPLE_API_KEY_ID" \
-    --issuer "$APPLE_API_ISSUER" \
-    --wait
+  NOTARY_TARGET_PATH="$ROOT_DIR/desktop/src-tauri/target/aigate-macos.zip"
+  ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$NOTARY_TARGET_PATH"
 else
-  xcrun notarytool submit "$DMG_PATH" \
-    --key "$APPLE_API_KEY_PATH" \
-    --key-id "$APPLE_API_KEY_ID" \
-    --issuer "$APPLE_API_ISSUER" \
-    --wait
+  NOTARY_TARGET_PATH="$DMG_PATH"
 fi
 
-xcrun stapler staple "$APP_PATH"
+submit_output="$(xcrun notarytool submit "$NOTARY_TARGET_PATH" \
+  --key "$APPLE_API_KEY_PATH" \
+  --key-id "$APPLE_API_KEY_ID" \
+  --issuer "$APPLE_API_ISSUER" \
+  --wait \
+  --output-format json)"
+
+notary_id="$(extract_notary_field id "$submit_output")"
+notary_status="$(extract_notary_field status "$submit_output")"
+
+if [[ -z "$notary_id" || -z "$notary_status" ]]; then
+  echo "Unexpected notarytool response:"
+  echo "$submit_output"
+  exit 1
+fi
+
+if [[ "$notary_status" != "Accepted" ]]; then
+  echo "Notarization failed with status: $notary_status"
+  xcrun notarytool log "$notary_id" \
+    --key "$APPLE_API_KEY_PATH" \
+    --key-id "$APPLE_API_KEY_ID" \
+    --issuer "$APPLE_API_ISSUER"
+  exit 1
+fi
+
 if [[ -n "$DMG_PATH" ]]; then
   xcrun stapler staple "$DMG_PATH"
+  spctl -a -t open -vv "$DMG_PATH"
+else
+  xcrun stapler staple "$APP_PATH"
+  spctl -a -t exec -vv "$APP_PATH"
 fi
-
-spctl -a -t exec -vv "$APP_PATH"

--- a/scripts/test/notarize_macos_test.sh
+++ b/scripts/test/notarize_macos_test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_SCRIPT="$ROOT_DIR/scripts/desktop/notarize_macos.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -Fq "$pattern" "$file"; then
+    fail "expected $file to contain: $pattern"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  if grep -Fq "$pattern" "$file"; then
+    fail "expected $file to not contain: $pattern"
+  fi
+}
+
+make_repo() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir/scripts/desktop" \
+    "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos" \
+    "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg"
+  cp "$SOURCE_SCRIPT" "$repo_dir/scripts/desktop/notarize_macos.sh"
+  chmod +x "$repo_dir/scripts/desktop/notarize_macos.sh"
+  mkdir -p "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
+  : > "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
+}
+
+make_fake_bin() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat >"$bin_dir/codesign" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'codesign:%s\n' "$*" >>"$CALL_LOG"
+EOF
+  chmod +x "$bin_dir/codesign"
+
+  cat >"$bin_dir/spctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'spctl:%s\n' "$*" >>"$CALL_LOG"
+EOF
+  chmod +x "$bin_dir/spctl"
+
+  cat >"$bin_dir/ditto" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ditto:%s\n' "$*" >>"$CALL_LOG"
+EOF
+  chmod +x "$bin_dir/ditto"
+
+  cat >"$bin_dir/xcrun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'xcrun:%s\n' "$*" >>"$CALL_LOG"
+
+if [[ "$1" == "notarytool" && "$2" == "submit" ]]; then
+  case "${NOTARY_STATUS:-Accepted}" in
+    Accepted)
+      printf '{"id":"submission-123","status":"Accepted"}\n'
+      ;;
+    Invalid)
+      printf '{"id":"submission-123","status":"Invalid"}\n'
+      ;;
+    *)
+      printf '{"id":"submission-123","status":"%s"}\n' "${NOTARY_STATUS}"
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "$1" == "notarytool" && "$2" == "log" ]]; then
+  printf 'notary-log:%s\n' "$*" >>"$CALL_LOG"
+  printf '{"issues":[{"message":"mock invalid"}]}\n'
+  exit 0
+fi
+
+if [[ "$1" == "stapler" && "$2" == "staple" ]]; then
+  printf 'stapler:%s\n' "$3" >>"$CALL_LOG"
+  exit 0
+fi
+
+fail() {
+  echo "unexpected xcrun invocation: $*" >&2
+  exit 1
+}
+
+fail "$@"
+EOF
+  chmod +x "$bin_dir/xcrun"
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+repo_invalid="$tmp_dir/repo-invalid"
+bin_invalid="$tmp_dir/bin-invalid"
+log_invalid="$tmp_dir/invalid.log"
+make_repo "$repo_invalid"
+make_fake_bin "$bin_invalid"
+
+if (
+  cd "$repo_invalid"
+  CALL_LOG="$log_invalid" \
+  PATH="$bin_invalid:$PATH" \
+  APPLE_SIGNING_IDENTITY="Developer ID Application: Example Developer (TEAMID1234)" \
+  APPLE_API_KEY_PATH="$tmp_dir/AuthKey.p8" \
+  APPLE_API_KEY_ID="ABC123DEFG" \
+  APPLE_API_ISSUER="00000000-0000-0000-0000-000000000000" \
+  NOTARY_STATUS="Invalid" \
+  bash scripts/desktop/notarize_macos.sh
+); then
+  fail "notarize_macos.sh should fail when notary status is Invalid"
+fi
+
+assert_contains "$log_invalid" "xcrun:notarytool submit"
+assert_contains "$log_invalid" "xcrun:notarytool log submission-123"
+assert_not_contains "$log_invalid" "stapler:"
+
+repo_accept="$tmp_dir/repo-accept"
+bin_accept="$tmp_dir/bin-accept"
+log_accept="$tmp_dir/accept.log"
+make_repo "$repo_accept"
+make_fake_bin "$bin_accept"
+
+(
+  cd "$repo_accept"
+  CALL_LOG="$log_accept" \
+  PATH="$bin_accept:$PATH" \
+  APPLE_SIGNING_IDENTITY="Developer ID Application: Example Developer (TEAMID1234)" \
+  APPLE_API_KEY_PATH="$tmp_dir/AuthKey.p8" \
+  APPLE_API_KEY_ID="ABC123DEFG" \
+  APPLE_API_ISSUER="00000000-0000-0000-0000-000000000000" \
+  NOTARY_STATUS="Accepted" \
+  bash scripts/desktop/notarize_macos.sh
+)
+
+assert_contains "$log_accept" "xcrun:notarytool submit"
+assert_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
+assert_not_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
+assert_contains "$log_accept" "spctl:-a -t open -vv $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
+
+echo "PASS: notarize_macos_test"


### PR DESCRIPTION
## What changed
- parse `notarytool submit` JSON output in `notarize_macos.sh`
- fail immediately and print `notarytool log` when notarization status is not `Accepted`
- staple and validate the notarized dmg when a dmg is present instead of stapling the inner app first
- add a regression test covering invalid notarization and dmg stapling behavior
- run the new notarization regression test in dev CI and release workflow tests

## Why
The previous release run hid the real notarization failure because the script continued to `stapler` after Apple returned `Invalid`. That produced a generic stapler error instead of the actual notarization reason.

## Validation
- bash scripts/test/desktop_updater_config_test.sh
- bash scripts/test/notarize_macos_test.sh
- bash scripts/test/release_apple_signing_test.sh
- bash scripts/test/release_updater_signing_key_test.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/dev-ci.yml")'
- git diff --check
