### PR TITLE
[codex] sign nested macos binaries before notarization

### DIFF
--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -24,6 +24,14 @@ if isinstance(value, str):
 PY
 }
 
+sign_binary() {
+  local path="$1"
+
+  codesign --force --options runtime --timestamp \
+    --sign "$APPLE_SIGNING_IDENTITY" \
+    "$path"
+}
+
 if [[ -z "$APP_PATH" ]]; then
   echo "No macOS app bundle found, skip notarization"
   exit 0
@@ -31,9 +39,14 @@ fi
 
 if [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]]; then
   echo "Code signing app with identity: $APPLE_SIGNING_IDENTITY"
-  codesign --force --deep --options runtime --timestamp \
-    --sign "$APPLE_SIGNING_IDENTITY" \
-    "$APP_PATH"
+  while IFS= read -r executable_path; do
+    sign_binary "$executable_path"
+  done < <(
+    find "$APP_PATH/Contents/MacOS" "$APP_PATH/Contents/Resources/bin" \
+      -type f -perm -111 2>/dev/null | sort
+  )
+
+  sign_binary "$APP_PATH"
 else
   echo "APPLE_SIGNING_IDENTITY not set, skip explicit codesign"
 fi

--- a/scripts/test/notarize_macos_test.sh
+++ b/scripts/test/notarize_macos_test.sh
@@ -32,7 +32,13 @@ make_repo() {
     "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg"
   cp "$SOURCE_SCRIPT" "$repo_dir/scripts/desktop/notarize_macos.sh"
   chmod +x "$repo_dir/scripts/desktop/notarize_macos.sh"
-  mkdir -p "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
+  mkdir -p "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/MacOS"
+  mkdir -p "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/Resources/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/MacOS/aigate-desktop"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/Resources/bin/routerd-universal-apple-darwin"
+  chmod +x \
+    "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/MacOS/aigate-desktop" \
+    "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/Resources/bin/routerd-universal-apple-darwin"
   : > "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 }
 
@@ -151,5 +157,9 @@ assert_contains "$log_accept" "xcrun:notarytool submit"
 assert_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 assert_not_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
 assert_contains "$log_accept" "spctl:-a -t open -vv $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
+assert_contains "$log_accept" "codesign:--force --options runtime --timestamp --sign Developer ID Application: Example Developer (TEAMID1234) $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/MacOS/aigate-desktop"
+assert_contains "$log_accept" "codesign:--force --options runtime --timestamp --sign Developer ID Application: Example Developer (TEAMID1234) $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/Resources/bin/routerd-universal-apple-darwin"
+assert_contains "$log_accept" "codesign:--force --options runtime --timestamp --sign Developer ID Application: Example Developer (TEAMID1234) $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
+assert_not_contains "$log_accept" "codesign:--force --deep --options runtime --timestamp"
 
 echo "PASS: notarize_macos_test"


### PR DESCRIPTION
## What changed
- sign nested executables inside the macOS app bundle before signing the outer `.app`
- stop relying on `codesign --deep` for notarization readiness
- extend the notarization regression test to require nested binary signing and forbid `--deep`

## Why
Apple's notarization log showed that both `aigate-desktop` and `routerd-universal-apple-darwin` were effectively unsigned for notarization purposes. The workflow only signed the outer app bundle, which is insufficient for these embedded executables.

## Validation
- bash scripts/test/notarize_macos_test.sh
- bash scripts/test/release_apple_signing_test.sh
- bash scripts/test/release_updater_signing_key_test.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/dev-ci.yml")'
- git diff --check
