### PR TITLE
ci: rebuild dmg after signing macos app

### DIFF
--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -32,6 +32,21 @@ sign_binary() {
     "$path"
 }
 
+rebuild_dmg_from_signed_app() {
+  local app_path="$1"
+  local dmg_path="$2"
+  local volume_name
+
+  volume_name="$(basename "$app_path" .app)"
+  rm -f "$dmg_path"
+  hdiutil create \
+    -volname "$volume_name" \
+    -srcfolder "$app_path" \
+    -ov \
+    -format UDZO \
+    -o "$dmg_path"
+}
+
 if [[ -z "$APP_PATH" ]]; then
   echo "No macOS app bundle found, skip notarization"
   exit 0
@@ -49,6 +64,10 @@ if [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]]; then
   sign_binary "$APP_PATH"
 else
   echo "APPLE_SIGNING_IDENTITY not set, skip explicit codesign"
+fi
+
+if [[ -n "$DMG_PATH" ]]; then
+  rebuild_dmg_from_signed_app "$APP_PATH" "$DMG_PATH"
 fi
 
 if [[ -z "${APPLE_API_KEY_PATH:-}" || -z "${APPLE_API_KEY_ID:-}" || -z "${APPLE_API_ISSUER:-}" ]]; then

--- a/scripts/test/notarize_macos_test.sh
+++ b/scripts/test/notarize_macos_test.sh
@@ -67,6 +67,25 @@ printf 'ditto:%s\n' "$*" >>"$CALL_LOG"
 EOF
   chmod +x "$bin_dir/ditto"
 
+  cat >"$bin_dir/hdiutil" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'hdiutil:%s\n' "$*" >>"$CALL_LOG"
+out=""
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "-o" ]]; then
+    out="$arg"
+    break
+  fi
+  prev="$arg"
+done
+if [[ -n "$out" ]]; then
+  : >"$out"
+fi
+EOF
+  chmod +x "$bin_dir/hdiutil"
+
   cat >"$bin_dir/xcrun" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -154,6 +173,7 @@ make_fake_bin "$bin_accept"
 )
 
 assert_contains "$log_accept" "xcrun:notarytool submit"
+assert_contains "$log_accept" "hdiutil:create -volname AI Gate -srcfolder $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app -ov -format UDZO -o $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 assert_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 assert_not_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
 assert_contains "$log_accept" "spctl:-a -t open -vv $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"


### PR DESCRIPTION
## Summary\n- rebuild the macOS dmg after re-signing the app bundle\n- ensure notarization submits the signed dmg contents instead of stale pre-sign artifacts\n- cover the rebuilt dmg path in the shell test\n\n## Verification\n- bash scripts/test/notarize_macos_test.sh\n- bash scripts/test/release_apple_signing_test.sh\n- bash scripts/test/release_updater_signing_key_test.sh\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/dev-ci.yml")'\n- git diff --check