### PR TITLE
ci: sign rebuilt macos dmg before notarization

### DIFF
--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -47,6 +47,14 @@ rebuild_dmg_from_signed_app() {
     -o "$dmg_path"
 }
 
+sign_dmg() {
+  local path="$1"
+
+  codesign --force --timestamp \
+    --sign "$APPLE_SIGNING_IDENTITY" \
+    "$path"
+}
+
 if [[ -z "$APP_PATH" ]]; then
   echo "No macOS app bundle found, skip notarization"
   exit 0
@@ -68,6 +76,9 @@ fi
 
 if [[ -n "$DMG_PATH" ]]; then
   rebuild_dmg_from_signed_app "$APP_PATH" "$DMG_PATH"
+  if [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]]; then
+    sign_dmg "$DMG_PATH"
+  fi
 fi
 
 if [[ -z "${APPLE_API_KEY_PATH:-}" || -z "${APPLE_API_KEY_ID:-}" || -z "${APPLE_API_ISSUER:-}" ]]; then

--- a/scripts/test/notarize_macos_test.sh
+++ b/scripts/test/notarize_macos_test.sh
@@ -174,6 +174,7 @@ make_fake_bin "$bin_accept"
 
 assert_contains "$log_accept" "xcrun:notarytool submit"
 assert_contains "$log_accept" "hdiutil:create -volname AI Gate -srcfolder $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app -ov -format UDZO -o $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
+assert_contains "$log_accept" "codesign:--force --timestamp --sign Developer ID Application: Example Developer (TEAMID1234) $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 assert_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 assert_not_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
 assert_contains "$log_accept" "spctl:-a -t open --context context:primary-signature -vv $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"


### PR DESCRIPTION
## Summary\n- sign the rebuilt macOS dmg before notarization submission\n- keep dmg gatekeeper validation aligned with the notarized artifact\n- extend shell coverage so the dmg signature step cannot regress\n\n## Verification\n- bash scripts/test/notarize_macos_test.sh\n- bash scripts/test/release_apple_signing_test.sh\n- bash scripts/test/release_updater_signing_key_test.sh\n- git diff --check