### PR TITLE
Retry backend Go tests in CI

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: "1.23"
 
       - name: Run backend tests
-        run: go test ./...
+        run: bash ../scripts/ci/go_test_with_retry.sh
 
       - name: Build routerd
         run: go build ./cmd/routerd
@@ -54,6 +54,7 @@ jobs:
       - name: Run release script tests
         run: |
           bash scripts/test/desktop_updater_config_test.sh
+          bash scripts/test/go_test_with_retry_test.sh
           bash scripts/test/notarize_macos_test.sh
           bash scripts/test/release_apple_signing_test.sh
           bash scripts/test/release_updater_signing_key_test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm --prefix desktop ci
 
       - name: Backend tests
-        run: go test ./...
+        run: bash ../scripts/ci/go_test_with_retry.sh
         working-directory: backend
 
       - name: Frontend tests
@@ -48,6 +48,7 @@ jobs:
       - name: Release script tests
         run: |
           bash scripts/test/desktop_updater_config_test.sh
+          bash scripts/test/go_test_with_retry_test.sh
           bash scripts/test/notarize_macos_test.sh
           bash scripts/test/release_apple_signing_test.sh
           bash scripts/test/release_updater_signing_key_test.sh

--- a/scripts/ci/go_test_with_retry.sh
+++ b/scripts/ci/go_test_with_retry.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+max_attempts="${GO_TEST_MAX_ATTEMPTS:-3}"
+retry_delay_seconds="${GO_TEST_RETRY_DELAY_SECONDS:-5}"
+
+attempt=1
+while true; do
+  if go test ./...; then
+    exit 0
+  fi
+
+  if [[ "$attempt" -ge "$max_attempts" ]]; then
+    exit 1
+  fi
+
+  echo "go test failed on attempt $attempt/$max_attempts, retrying in ${retry_delay_seconds}s..." >&2
+  sleep "$retry_delay_seconds"
+  attempt=$((attempt + 1))
+done

--- a/scripts/test/go_test_with_retry_test.sh
+++ b/scripts/test/go_test_with_retry_test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/ci/go_test_with_retry.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -Fq "$pattern" "$file"; then
+    fail "expected $file to contain $pattern"
+  fi
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat >"$tmp_dir/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'go:%s\n' "$*" >>"$CALL_LOG"
+attempt_file="$TMP_ATTEMPT_FILE"
+attempt=0
+if [[ -f "$attempt_file" ]]; then
+  attempt="$(cat "$attempt_file")"
+fi
+attempt=$((attempt + 1))
+printf '%s' "$attempt" >"$attempt_file"
+if [[ "$attempt" -lt 2 ]]; then
+  echo "net/http: TLS handshake timeout" >&2
+  exit 1
+fi
+EOF
+chmod +x "$tmp_dir/go"
+
+CALL_LOG="$tmp_dir/calls.log" \
+TMP_ATTEMPT_FILE="$tmp_dir/attempt.txt" \
+PATH="$tmp_dir:$PATH" \
+GO_TEST_MAX_ATTEMPTS=3 \
+GO_TEST_RETRY_DELAY_SECONDS=0 \
+bash "$SCRIPT_PATH" >/tmp/go-test-retry.out 2>/tmp/go-test-retry.err
+
+assert_contains "$tmp_dir/calls.log" "go:test ./..."
+assert_contains /tmp/go-test-retry.err "go test failed on attempt 1/3"
+
+cat >"$tmp_dir/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOF
+chmod +x "$tmp_dir/go"
+
+if CALL_LOG="$tmp_dir/calls.log" \
+  TMP_ATTEMPT_FILE="$tmp_dir/attempt.txt" \
+  PATH="$tmp_dir:$PATH" \
+  GO_TEST_MAX_ATTEMPTS=2 \
+  GO_TEST_RETRY_DELAY_SECONDS=0 \
+  bash "$SCRIPT_PATH" >/tmp/go-test-retry-fail.out 2>/tmp/go-test-retry-fail.err; then
+  fail "expected go_test_with_retry.sh to fail after exhausting retries"
+fi
+
+assert_contains /tmp/go-test-retry-fail.err "go test failed on attempt 1/2"
+
+echo "PASS: go_test_with_retry_test"


### PR DESCRIPTION
## Summary
- add a retry wrapper for backend Go tests in CI
- use the wrapper in dev CI and release workflows
- cover the retry behavior with a shell test

## Verification
- bash scripts/test/go_test_with_retry_test.sh
- bash scripts/test/package_local_release_test.sh
- bash scripts/test/notarize_macos_test.sh
- bash ../scripts/ci/go_test_with_retry.sh (from backend)
- git diff --check
