### PR TITLE
Create macOS DMG when only app bundle is built

### DIFF
--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -39,6 +39,10 @@ DMG_PATH=""
 if [[ -n "$BUNDLE_DIR" ]]; then
   APP_PATH="$(find "$BUNDLE_DIR/macos" -maxdepth 1 -name "*.app" -type d | head -n1 || true)"
   DMG_PATH="$(find "$BUNDLE_DIR/dmg" -maxdepth 1 -name "*.dmg" -type f | head -n1 || true)"
+  if [[ -z "$DMG_PATH" && -n "$APP_PATH" ]]; then
+    mkdir -p "$BUNDLE_DIR/dmg"
+    DMG_PATH="$BUNDLE_DIR/dmg/$(basename "${APP_PATH%.app}").dmg"
+  fi
 fi
 
 extract_notary_field() {

--- a/scripts/test/notarize_macos_test.sh
+++ b/scripts/test/notarize_macos_test.sh
@@ -263,4 +263,23 @@ assert_contains "$log_native" "--icon AI Gate.app 170 275"
 assert_contains "$log_native" "--app-drop-link 630 275"
 assert_not_contains "$log_native" "No macOS app bundle found"
 
+repo_no_dmg="$tmp_dir/repo-no-dmg"
+bin_no_dmg="$tmp_dir/bin-no-dmg"
+log_no_dmg="$tmp_dir/no-dmg.log"
+make_repo "$repo_no_dmg"
+make_fake_bin "$bin_no_dmg"
+make_fake_bundle_dmg_script "$repo_no_dmg"
+rm -f "$repo_no_dmg/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
+
+(
+  cd "$repo_no_dmg"
+  CALL_LOG="$log_no_dmg" \
+  PATH="$bin_no_dmg:$PATH" \
+  bash scripts/desktop/notarize_macos.sh
+)
+
+assert_contains "$log_no_dmg" "bundle_dmg:--volname AI Gate Installer --background"
+assert_contains "$log_no_dmg" "$repo_no_dmg/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
+assert_not_contains "$log_no_dmg" "No dmg found, create zip for notarization"
+
 echo "PASS: notarize_macos_test"


### PR DESCRIPTION
## Summary
- create a DMG path when macOS packaging only builds the app bundle
- keep DMG generation inside the shared notarize/rebuild script
- cover the no-existing-dmg path with a shell test

## Verification
- bash scripts/test/notarize_macos_test.sh
- bash scripts/test/package_local_release_test.sh
- git diff --check
