### PR TITLE
Fix CI DMG packaging layout generation

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -8,7 +8,8 @@
       "name": "aigate-desktop",
       "version": "1.1.37",
       "devDependencies": {
-        "@tauri-apps/cli": "^2.8.0"
+        "@tauri-apps/cli": "^2.8.0",
+        "appdmg": "^0.6.6"
       }
     },
     "node_modules/@tauri-apps/cli": {
@@ -226,6 +227,543 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/appdmg": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.6.tgz",
+      "integrity": "sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==",
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "async": "^1.4.2",
+        "ds-store": "^0.1.5",
+        "execa": "^1.0.0",
+        "fs-temp": "^1.0.0",
+        "fs-xattr": "^0.3.0",
+        "image-size": "^0.7.4",
+        "is-my-json-valid": "^2.20.0",
+        "minimist": "^1.1.3",
+        "parse-color": "^1.0.0",
+        "path-exists": "^4.0.0",
+        "repeat-string": "^1.5.4"
+      },
+      "bin": {
+        "appdmg": "bin/appdmg.js"
+      },
+      "engines": {
+        "node": ">=8.5"
+      }
+    },
+    "node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base32-encode": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-data-view": "^1.1.0"
+      }
+    },
+    "node_modules/bplist-creator": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stream-buffers": "~2.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/ds-store": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
+      "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bplist-creator": "~0.0.3",
+        "macos-alias": "~0.2.5",
+        "tn1150": "^0.1.0"
+      }
+    },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fmix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
+      "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "imul": "^1.0.0"
+      }
+    },
+    "node_modules/fs-temp": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
+      "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "random-path": "^0.1.0"
+      }
+    },
+    "node_modules/fs-xattr": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
+      "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "!win32"
+      ],
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/imul": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
+      "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/macos-alias": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.12.tgz",
+      "integrity": "sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "nan": "^2.4.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmur-32": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
+      "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encode-utf8": "^1.0.3",
+        "fmix": "^0.1.0",
+        "imul": "^1.0.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "~0.5.0"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/random-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
+      "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base32-encode": "^0.1.0 || ^1.0.0",
+        "murmur-32": "^0.1.0 || ^0.2.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tn1150": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
+      "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unorm": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/to-data-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true,
+      "license": "MIT or GPL-2.0",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,6 +9,7 @@
     "tauri": "tauri"
   },
   "devDependencies": {
+    "appdmg": "^0.6.6",
     "@tauri-apps/cli": "^2.8.0"
   }
 }

--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -16,6 +16,7 @@ DMG_APP_ICON_X=170
 DMG_APP_ICON_Y=275
 DMG_APPLICATIONS_ICON_X=630
 DMG_APPLICATIONS_ICON_Y=275
+APPDMG_BIN="$ROOT_DIR/desktop/node_modules/.bin/appdmg"
 
 resolve_bundle_dir() {
   local universal_dir="$TARGET_DIR/universal-apple-darwin/release/bundle"
@@ -85,40 +86,46 @@ prepare_dmg_background() {
 rebuild_dmg_from_signed_app() {
   local app_path="$1"
   local dmg_path="$2"
-  local bundle_script
   local stage_dir
   local background_path
   local app_name
-
-  bundle_script="$BUNDLE_DIR/dmg/bundle_dmg.sh"
+  local spec_path
   app_name="$(basename "$app_path")"
 
   rm -f "$dmg_path"
 
-  if [[ -x "$bundle_script" && -f "$DMG_BACKGROUND_SOURCE" ]]; then
+  if [[ -x "$APPDMG_BIN" && -f "$DMG_BACKGROUND_SOURCE" ]]; then
     stage_dir="$(mktemp -d)"
     mkdir -p "$stage_dir/.background"
     background_path="$stage_dir/.background/dmg-bg.png"
+    spec_path="$stage_dir/appdmg.json"
     prepare_dmg_background "$DMG_BACKGROUND_SOURCE" "$background_path"
     cp -R "$app_path" "$stage_dir/$app_name"
 
-    "$bundle_script" \
-      --volname "$DMG_VOLUME_NAME" \
-      --background "$background_path" \
-      --window-pos "$DMG_WINDOW_POS_X" "$DMG_WINDOW_POS_Y" \
-      --window-size "$DMG_WINDOW_WIDTH" "$DMG_WINDOW_HEIGHT" \
-      --icon-size "$DMG_ICON_SIZE" \
-      --text-size "$DMG_TEXT_SIZE" \
-      --icon "$app_name" "$DMG_APP_ICON_X" "$DMG_APP_ICON_Y" \
-      --hide-extension "$app_name" \
-      --app-drop-link "$DMG_APPLICATIONS_ICON_X" "$DMG_APPLICATIONS_ICON_Y" \
-      "$dmg_path" \
-      "$stage_dir"
+    cat >"$spec_path" <<EOF
+{
+  "title": "$DMG_VOLUME_NAME",
+  "background": ".background/dmg-bg.png",
+  "icon-size": $DMG_ICON_SIZE,
+  "window": {
+    "position": { "x": $DMG_WINDOW_POS_X, "y": $DMG_WINDOW_POS_Y },
+    "size": { "width": $DMG_WINDOW_WIDTH, "height": $DMG_WINDOW_HEIGHT }
+  },
+  "format": "UDZO",
+  "contents": [
+    { "x": $DMG_APP_ICON_X, "y": $DMG_APP_ICON_Y, "type": "file", "path": "$app_name" },
+    { "x": $DMG_APPLICATIONS_ICON_X, "y": $DMG_APPLICATIONS_ICON_Y, "type": "link", "path": "/Applications" }
+  ]
+}
+EOF
+
+    "$APPDMG_BIN" "$spec_path" "$dmg_path"
 
     rm -rf "$stage_dir"
     return
   fi
 
+  echo "appdmg unavailable or background missing; falling back to simple DMG layout" >&2
   hdiutil create \
     -volname "$DMG_VOLUME_NAME" \
     -srcfolder "$app_path" \

--- a/scripts/test/notarize_macos_test.sh
+++ b/scripts/test/notarize_macos_test.sh
@@ -28,6 +28,7 @@ assert_not_contains() {
 make_repo() {
   local repo_dir="$1"
   mkdir -p "$repo_dir/scripts/desktop" \
+    "$repo_dir/desktop/node_modules/.bin" \
     "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos" \
     "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg" \
     "$repo_dir/assets"
@@ -136,19 +137,18 @@ EOF
   chmod +x "$bin_dir/xcrun"
 }
 
-make_fake_bundle_dmg_script() {
+make_fake_appdmg() {
   local repo_dir="$1"
-  local bundle_dir="${2:-$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg}"
-  mkdir -p "$bundle_dir"
-cat >"$bundle_dir/bundle_dmg.sh" <<'EOF'
+cat >"$repo_dir/desktop/node_modules/.bin/appdmg" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-printf 'bundle_dmg:%s\n' "$*" >>"$CALL_LOG"
-argc=$#
-eval "out=\${$((argc-1))}"
+printf 'appdmg:%s\n' "$*" >>"$CALL_LOG"
+spec="$1"
+out="$2"
+printf 'appdmg-spec:%s\n' "$(tr -d '\n' <"$spec")" >>"$CALL_LOG"
 : >"$out"
 EOF
-  chmod +x "$bundle_dir/bundle_dmg.sh"
+  chmod +x "$repo_dir/desktop/node_modules/.bin/appdmg"
 }
 
 tmp_dir="$(mktemp -d)"
@@ -183,6 +183,7 @@ bin_accept="$tmp_dir/bin-accept"
 log_accept="$tmp_dir/accept.log"
 make_repo "$repo_accept"
 make_fake_bin "$bin_accept"
+make_fake_appdmg "$repo_accept"
 
 (
   cd "$repo_accept"
@@ -197,7 +198,15 @@ make_fake_bin "$bin_accept"
 )
 
 assert_contains "$log_accept" "xcrun:notarytool submit"
-assert_contains "$log_accept" "hdiutil:create -volname AI Gate Installer -srcfolder $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app -ov -format UDZO -o $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
+assert_contains "$log_accept" "appdmg:"
+assert_contains "$log_accept" "\"title\": \"AI Gate Installer\""
+assert_contains "$log_accept" "\"background\": \".background/dmg-bg.png\""
+assert_contains "$log_accept" "\"icon-size\": 128"
+assert_contains "$log_accept" "\"width\": 800"
+assert_contains "$log_accept" "\"height\": 560"
+assert_contains "$log_accept" "\"x\": 170"
+assert_contains "$log_accept" "\"y\": 275"
+assert_contains "$log_accept" "\"path\": \"/Applications\""
 assert_contains "$log_accept" "codesign:--force --timestamp --sign Developer ID Application: Example Developer (TEAMID1234) $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 assert_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 assert_not_contains "$log_accept" "stapler:$repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
@@ -206,13 +215,14 @@ assert_contains "$log_accept" "codesign:--force --options runtime --timestamp --
 assert_contains "$log_accept" "codesign:--force --options runtime --timestamp --sign Developer ID Application: Example Developer (TEAMID1234) $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/Resources/bin/routerd-universal-apple-darwin"
 assert_contains "$log_accept" "codesign:--force --options runtime --timestamp --sign Developer ID Application: Example Developer (TEAMID1234) $repo_accept/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app"
 assert_not_contains "$log_accept" "codesign:--force --deep --options runtime --timestamp"
+assert_not_contains "$log_accept" "hdiutil:create"
 
 repo_bundle="$tmp_dir/repo-bundle"
 bin_bundle="$tmp_dir/bin-bundle"
 log_bundle="$tmp_dir/bundle.log"
 make_repo "$repo_bundle"
 make_fake_bin "$bin_bundle"
-make_fake_bundle_dmg_script "$repo_bundle"
+make_fake_appdmg "$repo_bundle"
 
 (
   cd "$repo_bundle"
@@ -226,11 +236,9 @@ make_fake_bundle_dmg_script "$repo_bundle"
   bash scripts/desktop/notarize_macos.sh
 )
 
-assert_contains "$log_bundle" "bundle_dmg:--volname AI Gate Installer --background"
-assert_contains "$log_bundle" "--window-pos 120 120 --window-size 800 560"
-assert_contains "$log_bundle" "--icon-size 128 --text-size 16"
-assert_contains "$log_bundle" "--icon AI Gate.app 170 275"
-assert_contains "$log_bundle" "--app-drop-link 630 275"
+assert_contains "$log_bundle" "appdmg:"
+assert_contains "$log_bundle" "\"x\": 630"
+assert_contains "$log_bundle" "\"path\": \"/Applications\""
 assert_not_contains "$log_bundle" "hdiutil:create"
 
 repo_native="$tmp_dir/repo-native"
@@ -243,7 +251,7 @@ rm -rf "$repo_native/desktop/src-tauri/target/universal-apple-darwin"
 mkdir -p "$repo_native/desktop/src-tauri/target/release/bundle/macos/AI Gate.app/Contents/MacOS"
 mkdir -p "$repo_native/desktop/src-tauri/target/release/bundle/macos/AI Gate.app/Contents/Resources/bin"
 mkdir -p "$repo_native/desktop/src-tauri/target/release/bundle/dmg"
-make_fake_bundle_dmg_script "$repo_native" "$repo_native/desktop/src-tauri/target/release/bundle/dmg"
+make_fake_appdmg "$repo_native"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$repo_native/desktop/src-tauri/target/release/bundle/macos/AI Gate.app/Contents/MacOS/aigate-desktop"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$repo_native/desktop/src-tauri/target/release/bundle/macos/AI Gate.app/Contents/Resources/bin/routerd-universal-apple-darwin"
 chmod +x \
@@ -258,9 +266,8 @@ chmod +x \
   bash scripts/desktop/notarize_macos.sh
 )
 
-assert_contains "$log_native" "bundle_dmg:--volname AI Gate Installer --background"
-assert_contains "$log_native" "--icon AI Gate.app 170 275"
-assert_contains "$log_native" "--app-drop-link 630 275"
+assert_contains "$log_native" "appdmg:"
+assert_contains "$log_native" "\"title\": \"AI Gate Installer\""
 assert_not_contains "$log_native" "No macOS app bundle found"
 
 repo_no_dmg="$tmp_dir/repo-no-dmg"
@@ -268,7 +275,7 @@ bin_no_dmg="$tmp_dir/bin-no-dmg"
 log_no_dmg="$tmp_dir/no-dmg.log"
 make_repo "$repo_no_dmg"
 make_fake_bin "$bin_no_dmg"
-make_fake_bundle_dmg_script "$repo_no_dmg"
+make_fake_appdmg "$repo_no_dmg"
 rm -f "$repo_no_dmg/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 
 (
@@ -278,7 +285,22 @@ rm -f "$repo_no_dmg/desktop/src-tauri/target/universal-apple-darwin/release/bund
   bash scripts/desktop/notarize_macos.sh
 )
 
-assert_contains "$log_no_dmg" "bundle_dmg:--volname AI Gate Installer --background"
+assert_contains "$log_no_dmg" "appdmg:"
 assert_contains "$log_no_dmg" "$repo_no_dmg/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 assert_not_contains "$log_no_dmg" "No dmg found, create zip for notarization"
+
+repo_fallback="$tmp_dir/repo-fallback"
+bin_fallback="$tmp_dir/bin-fallback"
+log_fallback="$tmp_dir/fallback.log"
+make_repo "$repo_fallback"
+make_fake_bin "$bin_fallback"
+
+(
+  cd "$repo_fallback"
+  CALL_LOG="$log_fallback" \
+  PATH="$bin_fallback:$PATH" \
+  bash scripts/desktop/notarize_macos.sh
+)
+
+assert_contains "$log_fallback" "hdiutil:create -volname AI Gate Installer -srcfolder $repo_fallback/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app -ov -format UDZO -o $repo_fallback/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/AI Gate.dmg"
 echo "PASS: notarize_macos_test"


### PR DESCRIPTION
## Summary
- replace transient bundle_dmg dependency with repo-managed appdmg generation
- keep the existing DMG background image and layout coordinates in a deterministic JSON spec
- extend packaging tests so CI catches fallback-to-plain-DMG regressions

## Verification
- bash scripts/test/notarize_macos_test.sh
- bash scripts/test/package_local_release_test.sh
- TARGET_DIR="/Users/gcssloop/WorkSpace/AIGC/codex-router/desktop/src-tauri/target/universal-apple-darwin" APPLE_SIGNING_IDENTITY='' APPLE_API_KEY_PATH='' APPLE_API_KEY_ID='' APPLE_API_ISSUER='' bash scripts/desktop/notarize_macos.sh