### PR TITLE
build: avoid Finder cache for DMG background

### DIFF
--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -17,6 +17,15 @@ DMG_APP_ICON_Y=275
 DMG_APPLICATIONS_ICON_X=630
 DMG_APPLICATIONS_ICON_Y=275
 
+if [[ -f "$ROOT_DIR/scripts/desktop/release_version_helpers.sh" ]]; then
+  # shellcheck source=scripts/desktop/release_version_helpers.sh
+  source "$ROOT_DIR/scripts/desktop/release_version_helpers.sh"
+fi
+
+if declare -F resolve_release_version >/dev/null 2>&1 && release_version="$(resolve_release_version 2>/dev/null)"; then
+  DMG_VOLUME_NAME="$DMG_VOLUME_NAME ${release_version#v}"
+fi
+
 resolve_bundle_dir() {
   local universal_dir="$TARGET_DIR/universal-apple-darwin/release/bundle"
   local native_dir="$TARGET_DIR/release/bundle"

--- a/scripts/test/notarize_macos_test.sh
+++ b/scripts/test/notarize_macos_test.sh
@@ -33,6 +33,7 @@ make_repo() {
     "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg" \
     "$repo_dir/assets"
   cp "$SOURCE_SCRIPT" "$repo_dir/scripts/desktop/notarize_macos.sh"
+  cp "$ROOT_DIR/scripts/desktop/release_version_helpers.sh" "$repo_dir/scripts/desktop/release_version_helpers.sh"
   chmod +x "$repo_dir/scripts/desktop/notarize_macos.sh"
   mkdir -p "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/MacOS"
   mkdir -p "$repo_dir/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/AI Gate.app/Contents/Resources/bin"
@@ -190,6 +191,7 @@ make_fake_appdmg "$repo_accept"
   cd "$repo_accept"
   CALL_LOG="$log_accept" \
   PATH="$bin_accept:$PATH" \
+  RELEASE_VERSION="v1.2.3" \
   APPLE_SIGNING_IDENTITY="Developer ID Application: Example Developer (TEAMID1234)" \
   APPLE_API_KEY_PATH="$tmp_dir/AuthKey.p8" \
   APPLE_API_KEY_ID="ABC123DEFG" \
@@ -200,7 +202,7 @@ make_fake_appdmg "$repo_accept"
 
 assert_contains "$log_accept" "xcrun:notarytool submit"
 assert_contains "$log_accept" "appdmg:"
-assert_contains "$log_accept" "\"title\": \"AI Gate Installer\""
+assert_contains "$log_accept" "\"title\": \"AI Gate Installer 1.2.3\""
 assert_contains "$log_accept" "\"background\": \".background/dmg-bg.png\""
 assert_contains "$log_accept" "\"icon-size\": 128"
 assert_contains "$log_accept" "\"width\": 800"
@@ -229,6 +231,7 @@ make_fake_appdmg "$repo_bundle"
   cd "$repo_bundle"
   CALL_LOG="$log_bundle" \
   PATH="$bin_bundle:$PATH" \
+  RELEASE_VERSION="v1.2.3" \
   APPLE_SIGNING_IDENTITY="Developer ID Application: Example Developer (TEAMID1234)" \
   APPLE_API_KEY_PATH="$tmp_dir/AuthKey.p8" \
   APPLE_API_KEY_ID="ABC123DEFG" \
@@ -238,6 +241,7 @@ make_fake_appdmg "$repo_bundle"
 )
 
 assert_contains "$log_bundle" "appdmg:"
+assert_contains "$log_bundle" "\"title\": \"AI Gate Installer 1.2.3\""
 assert_contains "$log_bundle" "\"x\": 630"
 assert_contains "$log_bundle" "\"path\": \"/Applications\""
 assert_not_contains "$log_bundle" "hdiutil:create"


### PR DESCRIPTION
## Summary\n- version the DMG volume name with the release version\n- avoid Finder reusing a stale white-background window layout across releases\n- cover the versioned title in notarize script tests\n\n## Verification\n- bash scripts/test/notarize_macos_test.sh\n- bash scripts/test/package_local_release_test.sh\n- local Finder repro: fixed volume name reproduced white background; versioned volume name restored the background