### PR TITLE
feat: add cached skill discovery flow

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,12 +10,14 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	toml "github.com/pelletier/go-toml/v2"
 )
@@ -38,6 +41,7 @@ type toolingConfig struct {
 }
 
 type skillRepoRecord struct {
+	Platform   string `json:"platform,omitempty"`
 	Owner      string `json:"owner"`
 	Name       string `json:"name"`
 	Branch     string `json:"branch"`
@@ -92,11 +96,38 @@ type managedSkillRecord struct {
 }
 
 type repoSearchResult struct {
+	Platform    string `json:"platform,omitempty"`
 	Owner       string `json:"owner"`
 	Name        string `json:"name"`
 	Branch      string `json:"branch"`
 	URL         string `json:"url"`
 	Description string `json:"description,omitempty"`
+}
+
+type discoveredSkillRecord struct {
+	ID            string          `json:"id"`
+	Name          string          `json:"name"`
+	Description   string          `json:"description,omitempty"`
+	Platform      string          `json:"platform"`
+	RepoOwner     string          `json:"repo_owner"`
+	RepoName      string          `json:"repo_name"`
+	Branch        string          `json:"branch"`
+	RepoURL       string          `json:"repo_url"`
+	SourcePath    string          `json:"source_path"`
+	SourceURL     string          `json:"source_url"`
+	ManagedName   string          `json:"managed_name"`
+	InstalledApps map[string]bool `json:"installed_apps"`
+}
+
+type skillDiscoveryCache struct {
+	FetchedAt string                 `json:"fetched_at"`
+	Items     []discoveredSkillRecord `json:"items"`
+}
+
+type toolingSkillDiscoverResponse struct {
+	Cached    bool                  `json:"cached"`
+	FetchedAt string                `json:"fetched_at,omitempty"`
+	Items     []discoveredSkillRecord `json:"items"`
 }
 
 type mcpTemplateRecord struct {
@@ -152,7 +183,13 @@ type toolingSkillUpdateRequest struct {
 	Enabled bool     `json:"enabled"`
 }
 
+type toolingDiscoveredSkillInstallRequest struct {
+	ID   string   `json:"id"`
+	Apps []string `json:"apps"`
+}
+
 type toolingRepoRequest struct {
+	Platform string `json:"platform"`
 	Owner  string `json:"owner"`
 	Name   string `json:"name"`
 	Branch string `json:"branch"`
@@ -191,18 +228,26 @@ func (h *ToolingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getState(w)
 	case r.Method == http.MethodPut && r.URL.Path == "/tooling/settings":
 		h.updateSettings(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/tooling/skills/discover":
+		h.getDiscoveredSkills(w)
+	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/discover/install":
+		h.installDiscoveredSkill(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/discover/refresh":
+		h.refreshDiscoveredSkills(w)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/import":
 		h.importSkills(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/apply":
 		h.applySkills(w, r)
-	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/tooling/skills/"):
-		h.updateSkill(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/tooling/skills/repos":
 		h.listSkillRepos(w)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/repos":
 		h.addSkillRepo(w, r)
+	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/tooling/skills/repos/"):
+		h.updateSkillRepo(w, r)
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/tooling/skills/repos/"):
 		h.removeSkillRepo(w, r)
+	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/tooling/skills/"):
+		h.updateSkill(w, r)
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/tooling/skills/"):
 		h.deleteSkill(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/tooling/skills/repos/search":
@@ -274,6 +319,72 @@ func (h *ToolingHandler) updateSettings(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"skill_sync_method": cfg.SkillSyncMethod})
+}
+
+func (h *ToolingHandler) getDiscoveredSkills(w http.ResponseWriter) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	cache, ok := loadSkillDiscoveryCache(home)
+	if ok {
+		writeJSON(w, http.StatusOK, toolingSkillDiscoverResponse{
+			Cached:    true,
+			FetchedAt: cache.FetchedAt,
+			Items:     cache.Items,
+		})
+		return
+	}
+	items, fetchedAt, err := h.refreshSkillDiscovery(home)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, toolingSkillDiscoverResponse{
+		Cached:    false,
+		FetchedAt: fetchedAt,
+		Items:     items,
+	})
+}
+
+func (h *ToolingHandler) refreshDiscoveredSkills(w http.ResponseWriter) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	items, fetchedAt, err := h.refreshSkillDiscovery(home)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, toolingSkillDiscoverResponse{
+		Cached:    false,
+		FetchedAt: fetchedAt,
+		Items:     items,
+	})
+}
+
+func (h *ToolingHandler) installDiscoveredSkill(w http.ResponseWriter, r *http.Request) {
+	var req toolingDiscoveredSkillInstallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	cfg := h.loadConfig(home)
+	method := normalizeSkillSyncMethod(cfg.SkillSyncMethod)
+	applied, err := installDiscoveredSkillCollection(home, req.ID, method, reqApps(req.Apps))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"applied": applied, "enabled": true, "skill_sync_method": method})
 }
 
 func (h *ToolingHandler) importSkills(w http.ResponseWriter, r *http.Request) {
@@ -421,13 +532,15 @@ func (h *ToolingHandler) addSkillRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cfg := h.loadConfig(home)
-	branch := strings.TrimSpace(req.Branch)
-	if branch == "" {
-		branch = "main"
-	}
-	next := skillRepoRecord{Owner: strings.TrimSpace(req.Owner), Name: strings.TrimSpace(req.Name), Branch: branch, Enabled: true}
+	next := normalizeSkillRepoRecord(skillRepoRecord{
+		Platform: req.Platform,
+		Owner:    strings.TrimSpace(req.Owner),
+		Name:     strings.TrimSpace(req.Name),
+		Branch:   strings.TrimSpace(req.Branch),
+		Enabled:  true,
+	})
 	for idx, repo := range cfg.SkillRepos {
-		if strings.EqualFold(repo.Owner, next.Owner) && strings.EqualFold(repo.Name, next.Name) {
+		if skillRepoMatches(repo, next.Platform, next.Owner, next.Name) {
 			cfg.SkillRepos[idx] = next
 			if err := h.saveConfig(home, cfg); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -445,15 +558,53 @@ func (h *ToolingHandler) addSkillRepo(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, next)
 }
 
-func (h *ToolingHandler) removeSkillRepo(w http.ResponseWriter, r *http.Request) {
-	trimmed := strings.TrimPrefix(r.URL.Path, "/tooling/skills/repos/")
-	parts := strings.Split(trimmed, "/")
-	if len(parts) < 2 {
-		http.Error(w, "invalid repo path", http.StatusBadRequest)
+func (h *ToolingHandler) updateSkillRepo(w http.ResponseWriter, r *http.Request) {
+	platform, owner, name, err := decodeToolingRepoPath(r.URL.Path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	owner := parts[0]
-	name := parts[1]
+	var req toolingRepoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	cfg := h.loadConfig(home)
+	next := normalizeSkillRepoRecord(skillRepoRecord{
+		Platform: firstNonEmpty(req.Platform, platform),
+		Owner:    firstNonEmpty(req.Owner, owner),
+		Name:     firstNonEmpty(req.Name, name),
+		Branch:   strings.TrimSpace(req.Branch),
+		Enabled:  true,
+	})
+	for idx, repo := range cfg.SkillRepos {
+		if !skillRepoMatches(repo, platform, owner, name) {
+			continue
+		}
+		next.SkillCount = repo.SkillCount
+		next.Enabled = repo.Enabled
+		cfg.SkillRepos[idx] = next
+		if err := h.saveConfig(home, cfg); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, next)
+		return
+	}
+	http.Error(w, "repo not found", http.StatusNotFound)
+}
+
+func (h *ToolingHandler) removeSkillRepo(w http.ResponseWriter, r *http.Request) {
+	platform, owner, name, err := decodeToolingRepoPath(r.URL.Path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -463,7 +614,7 @@ func (h *ToolingHandler) removeSkillRepo(w http.ResponseWriter, r *http.Request)
 	next := make([]skillRepoRecord, 0, len(cfg.SkillRepos))
 	removed := false
 	for _, repo := range cfg.SkillRepos {
-		if strings.EqualFold(repo.Owner, owner) && strings.EqualFold(repo.Name, name) {
+		if skillRepoMatches(repo, platform, owner, name) {
 			removed = true
 			continue
 		}
@@ -481,11 +632,21 @@ func (h *ToolingHandler) removeSkillRepo(w http.ResponseWriter, r *http.Request)
 
 func (h *ToolingHandler) searchSkillRepos(w http.ResponseWriter, r *http.Request) {
 	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	platform := normalizeSkillRepoPlatform(r.URL.Query().Get("platform"))
 	if query == "" {
 		writeJSON(w, http.StatusOK, toolingRepoSearchResponse{Items: defaultRepoSearchResults()})
 		return
 	}
-	items, err := searchGitHubRepos(query)
+	var (
+		items []repoSearchResult
+		err error
+	)
+	switch platform {
+	case "gitlab":
+		items, err = searchGitLabRepos(query)
+	default:
+		items, err = searchGitHubRepos(query)
+	}
 	if err != nil {
 		writeJSON(w, http.StatusOK, toolingRepoSearchResponse{Items: defaultRepoSearchResults()})
 		return
@@ -835,6 +996,10 @@ func (h *ToolingHandler) loadConfig(home string) toolingConfig {
 	cfg.SkillSyncMethod = normalizeSkillSyncMethod(cfg.SkillSyncMethod)
 	if len(cfg.SkillRepos) == 0 {
 		cfg.SkillRepos = append([]skillRepoRecord{}, toolingDefaultRepos...)
+	} else {
+		for idx := range cfg.SkillRepos {
+			cfg.SkillRepos[idx] = normalizeSkillRepoRecord(cfg.SkillRepos[idx])
+		}
 	}
 	return cfg
 }
@@ -843,6 +1008,10 @@ func (h *ToolingHandler) saveConfig(home string, cfg toolingConfig) error {
 	cfg.SkillSyncMethod = normalizeSkillSyncMethod(cfg.SkillSyncMethod)
 	if len(cfg.SkillRepos) == 0 {
 		cfg.SkillRepos = append([]skillRepoRecord{}, toolingDefaultRepos...)
+	} else {
+		for idx := range cfg.SkillRepos {
+			cfg.SkillRepos[idx] = normalizeSkillRepoRecord(cfg.SkillRepos[idx])
+		}
 	}
 	raw, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -905,6 +1074,47 @@ func normalizeSkillSyncMethod(method string) string {
 		return "copy"
 	default:
 		return "symlink"
+	}
+}
+
+func normalizeSkillRepoPlatform(platform string) string {
+	switch strings.ToLower(strings.TrimSpace(platform)) {
+	case "gitlab":
+		return "gitlab"
+	default:
+		return "github"
+	}
+}
+
+func normalizeSkillRepoRecord(repo skillRepoRecord) skillRepoRecord {
+	repo.Platform = normalizeSkillRepoPlatform(repo.Platform)
+	repo.Owner = strings.TrimSpace(repo.Owner)
+	repo.Name = strings.TrimSpace(repo.Name)
+	repo.Branch = strings.TrimSpace(repo.Branch)
+	if repo.Branch == "" {
+		repo.Branch = "main"
+	}
+	return repo
+}
+
+func skillRepoMatches(repo skillRepoRecord, platform, owner, name string) bool {
+	repo = normalizeSkillRepoRecord(repo)
+	platform = normalizeSkillRepoPlatform(platform)
+	return strings.EqualFold(repo.Platform, platform) &&
+		strings.EqualFold(repo.Owner, owner) &&
+		strings.EqualFold(repo.Name, name)
+}
+
+func decodeToolingRepoPath(path string) (platform string, owner string, name string, err error) {
+	trimmed := strings.TrimPrefix(path, "/tooling/skills/repos/")
+	parts := strings.Split(trimmed, "/")
+	switch len(parts) {
+	case 2:
+		return "github", parts[0], parts[1], nil
+	case 3:
+		return normalizeSkillRepoPlatform(parts[0]), parts[1], parts[2], nil
+	default:
+		return "", "", "", errors.New("invalid repo path")
 	}
 }
 
@@ -1007,6 +1217,10 @@ type skillMetadata struct {
 	SourceClient string `json:"source_client"`
 	SourceRepo   string `json:"source_repo"`
 	SourceKind   string `json:"source_kind"`
+	Platform     string `json:"platform,omitempty"`
+	Branch       string `json:"branch,omitempty"`
+	SourcePath   string `json:"source_path,omitempty"`
+	SourceURL    string `json:"source_url,omitempty"`
 }
 
 func readSkillMetadata(dir string) skillMetadata {
@@ -1243,6 +1457,27 @@ func pathWithinRoot(root string, path string) bool {
 		return false
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func (h *ToolingHandler) refreshSkillDiscovery(home string) ([]discoveredSkillRecord, string, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	cfg := h.loadConfig(home)
+	clients := toolingClientStates(home)
+	items, err := discoverSkillsFromRepos(home, cfg.SkillRepos, clients)
+	if err != nil {
+		return nil, "", err
+	}
+	fetchedAt := timeNowUTC().Format(time.RFC3339)
+	cache := skillDiscoveryCache{
+		FetchedAt: fetchedAt,
+		Items:     items,
+	}
+	if err := saveSkillDiscoveryCache(home, cache); err != nil {
+		return nil, "", err
+	}
+	return items, fetchedAt, nil
 }
 
 func applyManagedSkills(home string, method string, apps []string) (int, error) {
@@ -2005,7 +2240,7 @@ func (h *ToolingHandler) syncManagedCodexMcpServers(home string, cfg toolingConf
 }
 
 func searchGitHubRepos(query string) ([]repoSearchResult, error) {
-	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/search/repositories", nil)
+	req, err := http.NewRequest(http.MethodGet, githubAPIBase()+"/search/repositories", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2039,6 +2274,7 @@ func searchGitHubRepos(query string) ([]repoSearchResult, error) {
 			continue
 		}
 		results = append(results, repoSearchResult{
+			Platform:    "github",
 			Owner:       owner,
 			Name:        name,
 			Branch:      firstNonEmpty(item.DefaultBranch, "main"),
@@ -2047,4 +2283,558 @@ func searchGitHubRepos(query string) ([]repoSearchResult, error) {
 		})
 	}
 	return results, nil
+}
+
+func searchGitLabRepos(query string) ([]repoSearchResult, error) {
+	req, err := http.NewRequest(http.MethodGet, gitlabAPIBase()+"/projects", nil)
+	if err != nil {
+		return nil, err
+	}
+	params := req.URL.Query()
+	params.Set("search", query)
+	params.Set("per_page", "8")
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("gitlab search failed: %s", resp.Status)
+	}
+	var payload []struct {
+		PathWithNamespace string `json:"path_with_namespace"`
+		WebURL            string `json:"web_url"`
+		Description       string `json:"description"`
+		DefaultBranch     string `json:"default_branch"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	results := make([]repoSearchResult, 0, len(payload))
+	for _, item := range payload {
+		owner, name, found := strings.Cut(item.PathWithNamespace, "/")
+		if !found {
+			continue
+		}
+		results = append(results, repoSearchResult{
+			Platform:    "gitlab",
+			Owner:       owner,
+			Name:        name,
+			Branch:      firstNonEmpty(item.DefaultBranch, "main"),
+			URL:         item.WebURL,
+			Description: item.Description,
+		})
+	}
+	return results, nil
+}
+
+func githubAPIBase() string {
+	return strings.TrimRight(firstNonEmpty(os.Getenv("AIGATE_GITHUB_API_BASE"), "https://api.github.com"), "/")
+}
+
+func gitlabAPIBase() string {
+	return strings.TrimRight(firstNonEmpty(os.Getenv("AIGATE_GITLAB_API_BASE"), "https://gitlab.com/api/v4"), "/")
+}
+
+func loadSkillDiscoveryCache(home string) (skillDiscoveryCache, bool) {
+	path := skillDiscoveryCachePath(home)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return skillDiscoveryCache{}, false
+	}
+	var cache skillDiscoveryCache
+	if err := json.Unmarshal(raw, &cache); err != nil {
+		return skillDiscoveryCache{}, false
+	}
+	return cache, true
+}
+
+func saveSkillDiscoveryCache(home string, cache skillDiscoveryCache) error {
+	raw, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeAtomic(skillDiscoveryCachePath(home), append(raw, '\n'), 0o600)
+}
+
+func skillDiscoveryCachePath(home string) string {
+	return filepath.Join(aigateDataRoot(home), "tooling", "skill-discovery-cache.json")
+}
+
+func timeNowUTC() time.Time {
+	return time.Now().UTC()
+}
+
+func discoverSkillsFromRepos(home string, repos []skillRepoRecord, clients []toolingClientState) ([]discoveredSkillRecord, error) {
+	installed := discoveredInstalledAppsBySource(home, clients)
+	items := make([]discoveredSkillRecord, 0)
+	for _, repo := range repos {
+		repo = normalizeSkillRepoRecord(repo)
+		if !repo.Enabled {
+			continue
+		}
+		repoItems, err := discoverSkillsFromRepo(repo, installed)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, repoItems...)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
+	})
+	return items, nil
+}
+
+func discoveredInstalledAppsBySource(home string, clients []toolingClientState) map[string]map[string]bool {
+	installed := map[string]map[string]bool{}
+	for _, record := range scanManagedSkills(home, clients) {
+		meta := readSkillMetadata(record.ManagedPath)
+		key := discoveredSkillKey(meta.Platform, meta.SourceRepo, meta.Branch, meta.SourcePath)
+		if key == "" {
+			continue
+		}
+		apps := map[string]bool{}
+		for app, enabled := range record.InstalledApps {
+			apps[app] = enabled
+		}
+		installed[key] = apps
+	}
+	return installed
+}
+
+func discoverSkillsFromRepo(repo skillRepoRecord, installed map[string]map[string]bool) ([]discoveredSkillRecord, error) {
+	switch repo.Platform {
+	case "gitlab":
+		return discoverGitLabRepoSkills(repo, installed)
+	default:
+		return discoverGitHubRepoSkills(repo, installed)
+	}
+}
+
+func discoverGitHubRepoSkills(repo skillRepoRecord, installed map[string]map[string]bool) ([]discoveredSkillRecord, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/%s/git/trees/%s", githubAPIBase(), url.PathEscape(repo.Owner), url.PathEscape(repo.Name), url.PathEscape(repo.Branch)), nil)
+	if err != nil {
+		return nil, err
+	}
+	params := req.URL.Query()
+	params.Set("recursive", "1")
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("github tree failed: %s", resp.Status)
+	}
+	var payload struct {
+		Tree []struct {
+			Path string `json:"path"`
+			Type string `json:"type"`
+		} `json:"tree"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	items := make([]discoveredSkillRecord, 0)
+	for _, entry := range payload.Tree {
+		if entry.Type != "blob" || !strings.HasSuffix(entry.Path, "/SKILL.md") {
+			continue
+		}
+		raw, err := fetchGitHubFile(repo, entry.Path)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, buildDiscoveredSkillRecord(repo, entry.Path, raw, installed))
+	}
+	return items, nil
+}
+
+func fetchGitHubFile(repo skillRepoRecord, path string) (string, error) {
+	urlPath := fmt.Sprintf("%s/repos/%s/%s/contents/%s", githubAPIBase(), url.PathEscape(repo.Owner), url.PathEscape(repo.Name), encodeRepoPath(path))
+	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+	if err != nil {
+		return "", err
+	}
+	params := req.URL.Query()
+	params.Set("ref", repo.Branch)
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("github content failed: %s", resp.Status)
+	}
+	var payload struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	if payload.Encoding != "base64" {
+		return "", fmt.Errorf("unsupported github content encoding: %s", payload.Encoding)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(payload.Content, "\n", ""))
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}
+
+func discoverGitLabRepoSkills(repo skillRepoRecord, installed map[string]map[string]bool) ([]discoveredSkillRecord, error) {
+	projectID := url.PathEscape(repo.Owner + "/" + repo.Name)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/projects/%s/repository/tree", gitlabAPIBase(), projectID), nil)
+	if err != nil {
+		return nil, err
+	}
+	params := req.URL.Query()
+	params.Set("ref", repo.Branch)
+	params.Set("recursive", "true")
+	params.Set("per_page", "100")
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("gitlab tree failed: %s", resp.Status)
+	}
+	var payload []struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	items := make([]discoveredSkillRecord, 0)
+	for _, entry := range payload {
+		if entry.Type != "blob" || !strings.HasSuffix(entry.Path, "/SKILL.md") {
+			continue
+		}
+		raw, err := fetchGitLabFile(repo, projectID, entry.Path)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, buildDiscoveredSkillRecord(repo, entry.Path, raw, installed))
+	}
+	return items, nil
+}
+
+func fetchGitLabFile(repo skillRepoRecord, projectID string, path string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/projects/%s/repository/files/%s/raw", gitlabAPIBase(), projectID, url.PathEscape(path)), nil)
+	if err != nil {
+		return "", err
+	}
+	params := req.URL.Query()
+	params.Set("ref", repo.Branch)
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("gitlab raw failed: %s", resp.Status)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func buildDiscoveredSkillRecord(repo skillRepoRecord, skillFilePath string, body string, installed map[string]map[string]bool) discoveredSkillRecord {
+	sourcePath := path.Dir(skillFilePath)
+	if sourcePath == "." {
+		sourcePath = ""
+	}
+	name, description := parseDiscoveredSkillBody(body, sourcePath)
+	key := discoveredSkillKey(repo.Platform, repo.Owner+"/"+repo.Name, repo.Branch, sourcePath)
+	record := discoveredSkillRecord{
+		ID:            key,
+		Name:          name,
+		Description:   description,
+		Platform:      repo.Platform,
+		RepoOwner:     repo.Owner,
+		RepoName:      repo.Name,
+		Branch:        repo.Branch,
+		RepoURL:       buildRepoURL(repo.Platform, repo.Owner, repo.Name),
+		SourcePath:    sourcePath,
+		SourceURL:     buildRepoTreeURL(repo.Platform, repo.Owner, repo.Name, repo.Branch, sourcePath),
+		ManagedName:   buildDiscoveredManagedName(repo, sourcePath),
+		InstalledApps: map[string]bool{},
+	}
+	if apps, ok := installed[key]; ok {
+		for app, enabled := range apps {
+			record.InstalledApps[app] = enabled
+		}
+	}
+	return record
+}
+
+func buildRepoURL(platform string, owner string, name string) string {
+	switch normalizeSkillRepoPlatform(platform) {
+	case "gitlab":
+		return fmt.Sprintf("https://gitlab.com/%s/%s", owner, name)
+	default:
+		return fmt.Sprintf("https://github.com/%s/%s", owner, name)
+	}
+}
+
+func buildRepoTreeURL(platform string, owner string, name string, branch string, sourcePath string) string {
+	base := buildRepoURL(platform, owner, name)
+	sourcePath = strings.Trim(sourcePath, "/")
+	switch normalizeSkillRepoPlatform(platform) {
+	case "gitlab":
+		if sourcePath == "" {
+			return fmt.Sprintf("%s/-/tree/%s", base, branch)
+		}
+		return fmt.Sprintf("%s/-/tree/%s/%s", base, branch, sourcePath)
+	default:
+		if sourcePath == "" {
+			return fmt.Sprintf("%s/tree/%s", base, branch)
+		}
+		return fmt.Sprintf("%s/tree/%s/%s", base, branch, sourcePath)
+	}
+}
+
+func buildDiscoveredManagedName(repo skillRepoRecord, sourcePath string) string {
+	base := filepath.Base(strings.Trim(sourcePath, "/"))
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		base = repo.Name
+	}
+	name := strings.ToLower(repo.Name + "-" + base)
+	replacer := strings.NewReplacer("/", "-", "\\", "-", "_", "-", " ", "-", ".", "-")
+	name = replacer.Replace(name)
+	for strings.Contains(name, "--") {
+		name = strings.ReplaceAll(name, "--", "-")
+	}
+	return strings.Trim(name, "-")
+}
+
+func parseDiscoveredSkillBody(body string, sourcePath string) (string, string) {
+	name := ""
+	description := ""
+	lines := strings.Split(body, "\n")
+	inFrontmatter := false
+	frontmatterSeen := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" && !frontmatterSeen {
+			inFrontmatter = true
+			frontmatterSeen = true
+			continue
+		}
+		if trimmed == "---" && inFrontmatter {
+			inFrontmatter = false
+			continue
+		}
+		if inFrontmatter {
+			switch {
+			case strings.HasPrefix(trimmed, "name:") && name == "":
+				name = strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "name:")), `"'`)
+			case strings.HasPrefix(trimmed, "title:") && name == "":
+				name = strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "title:")), `"'`)
+			case strings.HasPrefix(trimmed, "description:") && description == "":
+				description = strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "description:")), `"'`)
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") && name == "" {
+			name = strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
+			continue
+		}
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") && description == "" {
+			description = trimmed
+		}
+	}
+	if name == "" {
+		name = filepath.Base(strings.Trim(sourcePath, "/"))
+		if name == "." || name == "" {
+			name = "Skill"
+		}
+	}
+	return name, description
+}
+
+func discoveredSkillKey(platform string, sourceRepo string, branch string, sourcePath string) string {
+	if strings.TrimSpace(sourceRepo) == "" {
+		return ""
+	}
+	return strings.ToLower(strings.Join([]string{
+		normalizeSkillRepoPlatform(platform),
+		strings.TrimSpace(sourceRepo),
+		firstNonEmpty(branch, "main"),
+		strings.Trim(strings.TrimSpace(sourcePath), "/"),
+	}, ":"))
+}
+
+func encodeRepoPath(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	for idx, part := range parts {
+		parts[idx] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func installDiscoveredSkillCollection(home string, id string, method string, apps []string) (int, error) {
+	platform, repoFullName, branch, sourcePath, err := parseDiscoveredSkillID(id)
+	if err != nil {
+		return 0, err
+	}
+	owner, name, found := strings.Cut(repoFullName, "/")
+	if !found {
+		return 0, fmt.Errorf("invalid discovered skill repo: %s", repoFullName)
+	}
+	repo := normalizeSkillRepoRecord(skillRepoRecord{
+		Platform: platform,
+		Owner:    owner,
+		Name:     name,
+		Branch:   branch,
+		Enabled:  true,
+	})
+	managedName := buildDiscoveredManagedName(repo, sourcePath)
+	targetDir := filepath.Join(managedSkillsRoot(home), managedName)
+	if !pathExists(targetDir) {
+		files, err := fetchDiscoveredSkillFiles(repo, sourcePath)
+		if err != nil {
+			return 0, err
+		}
+		if len(files) == 0 {
+			return 0, fmt.Errorf("no files found for discovered skill: %s", id)
+		}
+		for relativePath, raw := range files {
+			fullPath := filepath.Join(targetDir, filepath.FromSlash(relativePath))
+			if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+				return 0, err
+			}
+			if err := os.WriteFile(fullPath, []byte(raw), 0o644); err != nil {
+				return 0, err
+			}
+		}
+		if err := writeSkillMetadata(targetDir, skillMetadata{
+			Name:       managedName,
+			SourceRepo: repoFullName,
+			SourceKind: "discovered",
+			Platform:   repo.Platform,
+			Branch:     repo.Branch,
+			SourcePath: sourcePath,
+			SourceURL:  buildRepoTreeURL(repo.Platform, repo.Owner, repo.Name, repo.Branch, sourcePath),
+		}); err != nil {
+			return 0, err
+		}
+	}
+	return applyManagedSkillCollection(home, managedName, method, apps)
+}
+
+func parseDiscoveredSkillID(id string) (platform string, repoFullName string, branch string, sourcePath string, err error) {
+	parts := strings.SplitN(strings.TrimSpace(id), ":", 4)
+	if len(parts) != 4 {
+		return "", "", "", "", fmt.Errorf("invalid discovered skill id: %s", id)
+	}
+	return normalizeSkillRepoPlatform(parts[0]), parts[1], firstNonEmpty(parts[2], "main"), strings.Trim(parts[3], "/"), nil
+}
+
+func fetchDiscoveredSkillFiles(repo skillRepoRecord, sourcePath string) (map[string]string, error) {
+	switch repo.Platform {
+	case "gitlab":
+		return fetchGitLabSkillFiles(repo, sourcePath)
+	default:
+		return fetchGitHubSkillFiles(repo, sourcePath)
+	}
+}
+
+func fetchGitHubSkillFiles(repo skillRepoRecord, sourcePath string) (map[string]string, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/%s/git/trees/%s", githubAPIBase(), url.PathEscape(repo.Owner), url.PathEscape(repo.Name), url.PathEscape(repo.Branch)), nil)
+	if err != nil {
+		return nil, err
+	}
+	params := req.URL.Query()
+	params.Set("recursive", "1")
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("github tree failed: %s", resp.Status)
+	}
+	var payload struct {
+		Tree []struct {
+			Path string `json:"path"`
+			Type string `json:"type"`
+		} `json:"tree"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	files := map[string]string{}
+	prefix := strings.Trim(sourcePath, "/")
+	for _, entry := range payload.Tree {
+		if entry.Type != "blob" || !pathWithinDiscoveredSkill(prefix, entry.Path) {
+			continue
+		}
+		raw, err := fetchGitHubFile(repo, entry.Path)
+		if err != nil {
+			return nil, err
+		}
+		files[strings.TrimPrefix(strings.TrimPrefix(entry.Path, prefix), "/")] = raw
+	}
+	return files, nil
+}
+
+func fetchGitLabSkillFiles(repo skillRepoRecord, sourcePath string) (map[string]string, error) {
+	projectID := url.PathEscape(repo.Owner + "/" + repo.Name)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/projects/%s/repository/tree", gitlabAPIBase(), projectID), nil)
+	if err != nil {
+		return nil, err
+	}
+	params := req.URL.Query()
+	params.Set("ref", repo.Branch)
+	params.Set("recursive", "true")
+	params.Set("per_page", "100")
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("gitlab tree failed: %s", resp.Status)
+	}
+	var payload []struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	files := map[string]string{}
+	prefix := strings.Trim(sourcePath, "/")
+	for _, entry := range payload {
+		if entry.Type != "blob" || !pathWithinDiscoveredSkill(prefix, entry.Path) {
+			continue
+		}
+		raw, err := fetchGitLabFile(repo, projectID, entry.Path)
+		if err != nil {
+			return nil, err
+		}
+		files[strings.TrimPrefix(strings.TrimPrefix(entry.Path, prefix), "/")] = raw
+	}
+	return files, nil
+}
+
+func pathWithinDiscoveredSkill(prefix string, fullPath string) bool {
+	prefix = strings.Trim(prefix, "/")
+	fullPath = strings.Trim(fullPath, "/")
+	if prefix == "" {
+		return true
+	}
+	return fullPath == prefix || strings.HasPrefix(fullPath, prefix+"/")
 }

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -757,6 +758,219 @@ command = "uvx"
 	}
 }
 
+func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/git/trees/main":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"tree": []map[string]any{
+					{"path": "skills/zulu/SKILL.md", "type": "blob"},
+					{"path": "skills/alpha/SKILL.md", "type": "blob"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/contents/skills/zulu/SKILL.md":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"encoding": "base64",
+				"content":  base64.StdEncoding.EncodeToString([]byte("# Zulu Skill\nA trailing skill.\n\nUNIQUE-ZULU-BODY\n")),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/contents/skills/alpha/SKILL.md":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"encoding": "base64",
+				"content":  base64.StdEncoding.EncodeToString([]byte("---\ndescription: Alpha summary\n---\n# Alpha Skill\nDetailed alpha body that must not be cached.\n")),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("AIGATE_GITHUB_API_BASE", server.URL)
+
+	writeToolingConfig(t, home, map[string]any{
+		"skill_sync_method": "symlink",
+		"skill_repos": []map[string]any{
+			{
+				"platform": "github",
+				"owner":    "openai",
+				"name":     "codex-skills",
+				"branch":   "main",
+				"enabled":  true,
+			},
+		},
+		"mcp_servers": []any{},
+	})
+	writeSkillDiscoveryCache(t, home, map[string]any{
+		"fetched_at": "2026-04-08T10:00:00Z",
+		"items": []map[string]any{
+			{
+				"id":             "github:openai/codex-skills:skills/cached",
+				"name":           "Cached Skill",
+				"description":    "Cached summary",
+				"platform":       "github",
+				"repo_owner":     "openai",
+				"repo_name":      "codex-skills",
+				"branch":         "main",
+				"repo_url":       "https://github.com/openai/codex-skills",
+				"source_path":    "skills/cached",
+				"source_url":     "https://github.com/openai/codex-skills/tree/main/skills/cached",
+				"managed_name":   "cached-skill",
+				"installed_apps": map[string]bool{"codex": false},
+			},
+		},
+	})
+
+	handler := api.NewToolingHandler()
+
+	cached := doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/discover", nil, nil, http.StatusOK)
+	var cachedPayload map[string]any
+	if err := json.Unmarshal(cached, &cachedPayload); err != nil {
+		t.Fatalf("unmarshal cached discover payload: %v", err)
+	}
+	if cachedPayload["cached"] != true {
+		t.Fatalf("cached flag = %v, want true", cachedPayload["cached"])
+	}
+	items := cachedPayload["items"].([]any)
+	if len(items) != 1 || items[0].(map[string]any)["name"] != "Cached Skill" {
+		t.Fatalf("cached items = %v, want cached skill only", cachedPayload["items"])
+	}
+
+	refreshed := doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/refresh", bytes.NewBufferString(`{}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
+	var refreshedPayload map[string]any
+	if err := json.Unmarshal(refreshed, &refreshedPayload); err != nil {
+		t.Fatalf("unmarshal refreshed discover payload: %v", err)
+	}
+	if refreshedPayload["cached"] != false {
+		t.Fatalf("cached flag after refresh = %v, want false", refreshedPayload["cached"])
+	}
+	refreshedItems := refreshedPayload["items"].([]any)
+	if len(refreshedItems) != 2 {
+		t.Fatalf("refreshed items = %d, want 2", len(refreshedItems))
+	}
+	if refreshedItems[0].(map[string]any)["name"] != "Alpha Skill" || refreshedItems[1].(map[string]any)["name"] != "Zulu Skill" {
+		t.Fatalf("refreshed item order = %v, want alpha then zulu", refreshedPayload["items"])
+	}
+
+	cacheRaw := readSkillDiscoveryCacheRaw(t, home)
+	if !strings.Contains(cacheRaw, "Alpha Skill") {
+		t.Fatalf("cache raw = %s, want discovered names cached", cacheRaw)
+	}
+	if strings.Contains(cacheRaw, "Detailed alpha body that must not be cached.") || strings.Contains(cacheRaw, "UNIQUE-ZULU-BODY") {
+		t.Fatalf("cache raw = %s, want index-only cache without full body content", cacheRaw)
+	}
+}
+
+func TestToolingHandlerSkillRepoCRUDSupportsPlatformAwareRecords(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	handler := api.NewToolingHandler()
+
+	created := doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/repos", bytes.NewBufferString(`{
+		"platform":"github",
+		"owner":"openai",
+		"name":"codex-skills",
+		"branch":"main"
+	}`), map[string]string{"Content-Type": "application/json"}, http.StatusCreated)
+	if !strings.Contains(string(created), `"platform":"github"`) {
+		t.Fatalf("create response = %s, want github platform", string(created))
+	}
+
+	listed := doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/repos", nil, nil, http.StatusOK)
+	if !strings.Contains(string(listed), `"name":"codex-skills"`) {
+		t.Fatalf("list response = %s, want created repo", string(listed))
+	}
+
+	updated := doToolingRequest(t, handler, http.MethodPut, "/tooling/skills/repos/github/openai/codex-skills", bytes.NewBufferString(`{
+		"platform":"gitlab",
+		"owner":"gitlab-org",
+		"name":"codex-skills",
+		"branch":"develop"
+	}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
+	if !strings.Contains(string(updated), `"platform":"gitlab"`) || !strings.Contains(string(updated), `"branch":"develop"`) {
+		t.Fatalf("update response = %s, want gitlab/develop", string(updated))
+	}
+
+	listed = doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/repos", nil, nil, http.StatusOK)
+	if !strings.Contains(string(listed), `"platform":"gitlab"`) || strings.Contains(string(listed), `"platform":"github"`) {
+		t.Fatalf("list response after update = %s, want only updated gitlab record", string(listed))
+	}
+
+	removed := doToolingRequest(t, handler, http.MethodDelete, "/tooling/skills/repos/gitlab/gitlab-org/codex-skills", nil, nil, http.StatusOK)
+	if !strings.Contains(string(removed), `"removed":true`) {
+		t.Fatalf("delete response = %s, want removed true", string(removed))
+	}
+
+	listed = doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/repos", nil, nil, http.StatusOK)
+	if strings.TrimSpace(string(listed)) != "[]" {
+		t.Fatalf("list response after delete = %s, want empty list", string(listed))
+	}
+}
+
+func TestToolingHandlerCanInstallDiscoveredSkillIntoManagedAndCodexDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/git/trees/main":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"tree": []map[string]any{
+					{"path": "skills/alpha/SKILL.md", "type": "blob"},
+					{"path": "skills/alpha/assets/config.json", "type": "blob"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/contents/skills/alpha/SKILL.md":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"encoding": "base64",
+				"content":  base64.StdEncoding.EncodeToString([]byte("# Alpha Skill\nInstallable summary.\n")),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/contents/skills/alpha/assets/config.json":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"encoding": "base64",
+				"content":  base64.StdEncoding.EncodeToString([]byte("{\"ok\":true}\n")),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("AIGATE_GITHUB_API_BASE", server.URL)
+
+	handler := api.NewToolingHandler()
+
+	installed := doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/install", bytes.NewBufferString(`{
+		"id":"github:openai/codex-skills:main:skills/alpha",
+		"apps":["codex"]
+	}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
+	if !strings.Contains(string(installed), `"applied":1`) {
+		t.Fatalf("install response = %s, want applied 1", string(installed))
+	}
+
+	managedRoot := filepath.Join(home, ".aigate", "data", "tooling", "skills", "codex-skills-alpha")
+	if _, err := os.Stat(filepath.Join(managedRoot, "SKILL.md")); err != nil {
+		t.Fatalf("expected managed skill file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(managedRoot, "assets", "config.json")); err != nil {
+		t.Fatalf("expected managed nested file: %v", err)
+	}
+	metaRaw, err := os.ReadFile(filepath.Join(managedRoot, ".aigate-skill.json"))
+	if err != nil {
+		t.Fatalf("ReadFile metadata: %v", err)
+	}
+	var metaPayload map[string]any
+	if err := json.Unmarshal(metaRaw, &metaPayload); err != nil {
+		t.Fatalf("Unmarshal metadata: %v", err)
+	}
+	if metaPayload["platform"] != "github" || metaPayload["source_path"] != "skills/alpha" {
+		t.Fatalf("metadata = %s, want discovery source metadata", string(metaRaw))
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "codex-skills-alpha", "SKILL.md")); err != nil {
+		t.Fatalf("expected codex synced skill file: %v", err)
+	}
+}
+
 func doToolingRequest(t *testing.T, handler http.Handler, method, path string, body *bytes.Buffer, headers map[string]string, wantStatus int) []byte {
 	t.Helper()
 	var reader *bytes.Reader
@@ -814,4 +1028,29 @@ func readToolingConfig(t *testing.T, home string) map[string]any {
 		t.Fatalf("Unmarshal tooling config: %v", err)
 	}
 	return payload
+}
+
+func writeSkillDiscoveryCache(t *testing.T, home string, payload map[string]any) {
+	t.Helper()
+	path := filepath.Join(home, ".aigate", "data", "tooling", "skill-discovery-cache.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll discovery cache dir: %v", err)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal discovery cache: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile discovery cache: %v", err)
+	}
+}
+
+func readSkillDiscoveryCacheRaw(t *testing.T, home string) string {
+	t.Helper()
+	path := filepath.Join(home, ".aigate", "data", "tooling", "skill-discovery-cache.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile discovery cache: %v", err)
+	}
+	return string(raw)
 }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.1.37",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.1.37",
+      "version": "1.2.2",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.1.37",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.1.37"
+version = "1.2.2"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.1.37"
+version = "1.2.2"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.1.37",
+  "version": "1.2.2",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.1.37",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.1.37",
+      "version": "1.2.2",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.1.37",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -13,8 +13,12 @@ vi.mock("../../lib/api", async () => {
     importToolingSkills: vi.fn(),
     updateToolingSkill: vi.fn(),
     deleteToolingSkill: vi.fn(),
+    getToolingDiscoveredSkills: vi.fn(),
+    refreshToolingDiscoveredSkills: vi.fn(),
+    installToolingDiscoveredSkill: vi.fn(),
     searchToolingRepos: vi.fn(),
     addToolingRepo: vi.fn(),
+    updateToolingRepo: vi.fn(),
     removeToolingRepo: vi.fn(),
     importToolingMcpServers: vi.fn(),
     applyToolingMcpServer: vi.fn(),
@@ -44,6 +48,7 @@ function buildToolingState(): api.ToolingState {
     },
     skill_repos: [
       {
+        platform: "github",
         owner: "openai",
         name: "codex-superpowers",
         branch: "main",
@@ -126,6 +131,44 @@ function buildToolingState(): api.ToolingState {
   };
 }
 
+function buildDiscoveredSkillResponse(overrides?: Partial<api.ToolingSkillDiscoveryResponse>): api.ToolingSkillDiscoveryResponse {
+  return {
+    cached: true,
+    fetched_at: "2026-04-08T10:00:00Z",
+    items: [
+      {
+        id: "github:openai/codex-skills:main:skills/zulu",
+        name: "Zulu Skill",
+        description: "Cached zulu summary",
+        platform: "github",
+        repo_owner: "openai",
+        repo_name: "codex-skills",
+        branch: "main",
+        repo_url: "https://github.com/openai/codex-skills",
+        source_path: "skills/zulu",
+        source_url: "https://github.com/openai/codex-skills/tree/main/skills/zulu",
+        managed_name: "codex-skills-zulu",
+        installed_apps: { codex: false },
+      },
+      {
+        id: "github:openai/codex-skills:main:skills/alpha",
+        name: "Alpha Skill",
+        description: "Cached alpha summary",
+        platform: "github",
+        repo_owner: "openai",
+        repo_name: "codex-skills",
+        branch: "main",
+        repo_url: "https://github.com/openai/codex-skills",
+        source_path: "skills/alpha",
+        source_url: "https://github.com/openai/codex-skills/tree/main/skills/alpha",
+        managed_name: "codex-skills-alpha",
+        installed_apps: { codex: false },
+      },
+    ],
+    ...overrides,
+  };
+}
+
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -143,11 +186,42 @@ describe("ToolingPage", () => {
     vi.mocked(api.importToolingSkills).mockResolvedValue({ imported: 1 });
     vi.mocked(api.updateToolingSkill).mockResolvedValue({ applied: 1, enabled: true, skill_sync_method: "symlink" });
     vi.mocked(api.deleteToolingSkill).mockResolvedValue();
+    vi.mocked((api as typeof api & { getToolingDiscoveredSkills: typeof vi.fn }).getToolingDiscoveredSkills).mockResolvedValue(buildDiscoveredSkillResponse());
+    vi.mocked((api as typeof api & { refreshToolingDiscoveredSkills: typeof vi.fn }).refreshToolingDiscoveredSkills).mockResolvedValue(
+      buildDiscoveredSkillResponse({
+        cached: false,
+        fetched_at: "2026-04-08T10:01:00Z",
+        items: [
+          {
+            ...buildDiscoveredSkillResponse().items[1],
+            description: "Latest alpha summary",
+          },
+          {
+            ...buildDiscoveredSkillResponse().items[0],
+            description: "Latest zulu summary",
+          },
+        ],
+      }),
+    );
+    vi.mocked((api as typeof api & { installToolingDiscoveredSkill: typeof vi.fn }).installToolingDiscoveredSkill).mockResolvedValue({
+      applied: 1,
+      enabled: true,
+      skill_sync_method: "symlink",
+    });
     vi.mocked(api.searchToolingRepos).mockResolvedValue({ items: [] });
     vi.mocked(api.addToolingRepo).mockResolvedValue({
+      platform: "github",
       owner: "openai",
       name: "codex-superpowers",
       branch: "main",
+      enabled: true,
+      skill_count: 12,
+    });
+    vi.mocked((api as typeof api & { updateToolingRepo: typeof vi.fn }).updateToolingRepo).mockResolvedValue({
+      platform: "gitlab",
+      owner: "gitlab-org",
+      name: "codex-superpowers",
+      branch: "develop",
       enabled: true,
       skill_count: 12,
     });
@@ -245,16 +319,109 @@ describe("ToolingPage", () => {
     await waitFor(() => expect(api.deleteToolingSkill).toHaveBeenCalledWith("superpowers"));
   });
 
-  it("shows skills discovery in a modal", async () => {
+  it("shows full-screen skills discovery with cached list by default and silently refreshes it", async () => {
+    const refreshDeferred = createDeferred<api.ToolingSkillDiscoveryResponse>();
+    vi.mocked((api as typeof api & { refreshToolingDiscoveredSkills: typeof vi.fn }).refreshToolingDiscoveredSkills).mockImplementationOnce(() => refreshDeferred.promise);
+
     render(<ToolingPage mode="skills" t={(text) => text} />);
 
     await screen.findByText("Skill 技能");
     fireEvent.click(screen.getByRole("button", { name: /发现技能/ }));
 
     const dialog = await screen.findByRole("dialog", { name: "发现技能" });
-    expect(within(dialog).getByText("仓库搜索")).toBeInTheDocument();
-    expect(within(dialog).getByText("仓库管理")).toBeInTheDocument();
-    expect(within(dialog).getByText("openai/codex-superpowers")).toBeInTheDocument();
+    expect(within(dialog).getByPlaceholderText("搜索发现的技能")).toBeInTheDocument();
+    expect(within(dialog).getByText("使用缓存")).toBeInTheDocument();
+    const skillTitles = within(dialog).getAllByTestId("tooling-discovered-skill-title").map((node) => node.textContent);
+    expect(skillTitles).toEqual(["Alpha Skill", "Zulu Skill"]);
+
+    refreshDeferred.resolve(buildDiscoveredSkillResponse({
+      cached: false,
+      fetched_at: "2026-04-08T10:05:00Z",
+      items: [
+        {
+          ...buildDiscoveredSkillResponse().items[1],
+          description: "Latest alpha summary",
+        },
+        {
+          ...buildDiscoveredSkillResponse().items[0],
+          description: "Latest zulu summary",
+        },
+      ],
+    }));
+
+    expect(await within(dialog).findByText("Latest alpha summary")).toBeInTheDocument();
+    expect(within(dialog).getByText("已更新")).toBeInTheDocument();
+  });
+
+  it("supports manual refresh, viewing source repo, and installing a discovered skill", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<ToolingPage mode="skills" t={(text) => text} />);
+
+    await screen.findByText("Skill 技能");
+    fireEvent.click(screen.getByRole("button", { name: /发现技能/ }));
+
+    const dialog = await screen.findByRole("dialog", { name: "发现技能" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "刷新技能索引" }));
+
+    await waitFor(() =>
+      expect(vi.mocked((api as typeof api & { refreshToolingDiscoveredSkills: typeof vi.fn }).refreshToolingDiscoveredSkills)).toHaveBeenCalled(),
+    );
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "查看 Alpha Skill 的仓库页面" }));
+    expect(openSpy).toHaveBeenCalledWith("https://github.com/openai/codex-skills", "_blank", "noopener,noreferrer");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "安装 Alpha Skill" }));
+    await waitFor(() =>
+      expect(vi.mocked((api as typeof api & { installToolingDiscoveredSkill: typeof vi.fn }).installToolingDiscoveredSkill)).toHaveBeenCalledWith({
+        id: "github:openai/codex-skills:main:skills/alpha",
+        apps: ["codex"],
+      }),
+    );
+  });
+
+  it("manages repositories in a secondary modal with create, update, and delete actions", async () => {
+    render(<ToolingPage mode="skills" t={(text) => text} />);
+
+    await screen.findByText("Skill 技能");
+    fireEvent.click(screen.getByRole("button", { name: /发现技能/ }));
+
+    const discoverDialog = await screen.findByRole("dialog", { name: "发现技能" });
+    fireEvent.click(within(discoverDialog).getByRole("button", { name: "仓库管理" }));
+
+    const repoDialog = (await screen.findAllByRole("dialog")).at(-1)!;
+    fireEvent.change(within(repoDialog).getByLabelText("仓库平台"), { target: { value: "gitlab" } });
+    fireEvent.change(within(repoDialog).getByLabelText("仓库归属"), { target: { value: "gitlab-org" } });
+    fireEvent.change(within(repoDialog).getByLabelText("仓库名称"), { target: { value: "codex-superpowers" } });
+    fireEvent.change(within(repoDialog).getByLabelText("分支"), { target: { value: "develop" } });
+    fireEvent.click(within(repoDialog).getByRole("button", { name: "添加仓库" }));
+
+    await waitFor(() => expect(api.addToolingRepo).toHaveBeenCalledWith("gitlab", "gitlab-org", "codex-superpowers", "develop"));
+
+    fireEvent.click(within(repoDialog).getByRole("button", { name: "编辑 openai/codex-superpowers" }));
+    fireEvent.change(within(repoDialog).getByLabelText("仓库平台"), { target: { value: "gitlab" } });
+    fireEvent.change(within(repoDialog).getByLabelText("仓库归属"), { target: { value: "gitlab-org" } });
+    fireEvent.change(within(repoDialog).getByLabelText("分支"), { target: { value: "develop" } });
+    fireEvent.click(within(repoDialog).getByRole("button", { name: "保存仓库" }));
+
+    await waitFor(() =>
+      expect(vi.mocked((api as typeof api & { updateToolingRepo: typeof vi.fn }).updateToolingRepo)).toHaveBeenCalledWith(
+        "github",
+        "openai",
+        "codex-superpowers",
+        {
+          platform: "gitlab",
+          owner: "gitlab-org",
+          name: "codex-superpowers",
+          branch: "develop",
+        },
+      ),
+    );
+
+    const refreshedRepoDialog = (await screen.findAllByRole("dialog")).at(-1)!;
+    await waitFor(() => expect(within(refreshedRepoDialog).getByRole("button", { name: "移除 openai/codex-superpowers" })).not.toBeDisabled());
+    fireEvent.click(within(refreshedRepoDialog).getByRole("button", { name: "移除 openai/codex-superpowers" }));
+    await waitFor(() => expect(api.removeToolingRepo).toHaveBeenCalledWith("github", "openai", "codex-superpowers"));
   });
 
   it("renders the minimal mcp management layout and toggles codex sync", async () => {

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -2,7 +2,10 @@ import {
   CheckCircleOutlined,
   CloudDownloadOutlined,
   DeleteOutlined,
+  EditOutlined,
+  LinkOutlined,
   PlusOutlined,
+  ReloadOutlined,
   SearchOutlined,
 } from "@ant-design/icons";
 import { Button, Card, Checkbox, Empty, Input, Modal, Space, Spin, Typography, message } from "antd";
@@ -13,15 +16,20 @@ import {
   applyToolingMcpServer,
   deleteToolingMcpServer,
   deleteToolingSkill,
+  getToolingDiscoveredSkills,
   getToolingState,
   importToolingMcpServers,
   importToolingSkills,
+  installToolingDiscoveredSkill,
   removeToolingRepo,
-  searchToolingRepos,
+  refreshToolingDiscoveredSkills,
   updateToolingSkill,
+  updateToolingRepo,
+  type ToolingDiscoveredSkill,
   type ToolingMcpServer,
-  type ToolingRepoSearchResult,
   type ToolingSkillRecord,
+  type ToolingSkillRepo,
+  type ToolingSkillDiscoveryResponse,
   type ToolingState,
 } from "../../lib/api";
 import sourceOpenAIIcon from "../../assets/providers/openai.png";
@@ -31,10 +39,6 @@ type ToolingMode = "skills" | "mcp";
 type ToolingPageProps = {
   mode: ToolingMode;
   t: (text: string) => string;
-};
-
-type RepoSearchRow = ToolingRepoSearchResult & {
-  key: string;
 };
 
 type ManagedClientDescriptor = {
@@ -60,11 +64,27 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   const [loading, setLoading] = useState(true);
   const [state, setState] = useState<ToolingState | null>(null);
   const [skillDiscoverOpen, setSkillDiscoverOpen] = useState(false);
-  const [repoQuery, setRepoQuery] = useState("");
-  const [repoSearchLoading, setRepoSearchLoading] = useState(false);
-  const [repoSearchResults, setRepoSearchResults] = useState<RepoSearchRow[]>([]);
+  const [repoManagerOpen, setRepoManagerOpen] = useState(false);
+  const [discoveryQuery, setDiscoveryQuery] = useState("");
+  const [discoveryResponse, setDiscoveryResponse] = useState<ToolingSkillDiscoveryResponse | null>(null);
+  const [discoveryLoading, setDiscoveryLoading] = useState(false);
+  const [discoveryRefreshing, setDiscoveryRefreshing] = useState(false);
+  const [discoveryStatus, setDiscoveryStatus] = useState("");
+  const [discoveryBusyId, setDiscoveryBusyId] = useState<string | null>(null);
   const [importBusy, setImportBusy] = useState(false);
   const [repoBusyKey, setRepoBusyKey] = useState<string | null>(null);
+  const [repoForm, setRepoForm] = useState<{
+    platform: "github" | "gitlab";
+    owner: string;
+    name: string;
+    branch: string;
+  }>({
+    platform: "github",
+    owner: "",
+    name: "",
+    branch: "main",
+  });
+  const [repoEditing, setRepoEditing] = useState<ToolingSkillRepo | null>(null);
   const [skillBusyName, setSkillBusyName] = useState<string | null>(null);
   const [mcpBusyId, setMcpBusyId] = useState<string | null>(null);
 
@@ -89,14 +109,78 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     void reload();
   }, []);
 
+  useEffect(() => {
+    if (!skillDiscoverOpen || mode !== "skills") {
+      return;
+    }
+    let active = true;
+    setDiscoveryLoading(true);
+    void getToolingDiscoveredSkills()
+      .then((response) => {
+        if (!active) {
+          return;
+        }
+        setDiscoveryResponse(sortDiscoveryResponse(response));
+        setDiscoveryStatus(response.cached ? t("使用缓存") : t("最新索引"));
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+        void messageApi.error(error instanceof Error ? error.message : t("加载发现技能失败"));
+      })
+      .finally(() => {
+        if (active) {
+          setDiscoveryLoading(false);
+        }
+      });
+
+    setDiscoveryRefreshing(true);
+    void refreshToolingDiscoveredSkills()
+      .then((response) => {
+        if (!active) {
+          return;
+        }
+        setDiscoveryResponse(sortDiscoveryResponse(response));
+        setDiscoveryStatus(t("已更新"));
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+        if (!discoveryResponse) {
+          void messageApi.error(error instanceof Error ? error.message : t("刷新发现技能失败"));
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setDiscoveryRefreshing(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [skillDiscoverOpen, mode]);
+
   const skillCount = state?.skill_stats.by_source.codex ?? 0;
   const mcpCount = state?.mcp_servers.length ?? 0;
-  const repoRows = repoSearchResults.length > 0
-    ? repoSearchResults
-    : (state?.repo_search_results ?? []).map((item) => ({ ...item, key: `${item.owner}/${item.name}` }));
-
   const skills = useMemo(() => state?.installed_skills ?? [], [state?.installed_skills]);
+  const skillRepos = useMemo(
+    () => [...(state?.skill_repos ?? [])].sort((a, b) => `${a.platform ?? "github"}:${a.owner}/${a.name}`.localeCompare(`${b.platform ?? "github"}:${b.owner}/${b.name}`)),
+    [state?.skill_repos],
+  );
   const mcpServers = useMemo(() => state?.mcp_servers ?? [], [state?.mcp_servers]);
+  const discoveredSkills = useMemo(() => {
+    const items = [...(discoveryResponse?.items ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+    const query = discoveryQuery.trim().toLowerCase();
+    if (!query) {
+      return items;
+    }
+    return items.filter((item) =>
+      [item.name, item.description ?? "", item.repo_owner, item.repo_name, item.source_path].join(" ").toLowerCase().includes(query),
+    );
+  }, [discoveryQuery, discoveryResponse?.items]);
 
   async function handleImportSkills() {
     setImportBusy(true);
@@ -217,30 +301,50 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     });
   }
 
-  async function handleRepoSearch() {
-    const query = repoQuery.trim();
-    if (!query) {
-      setRepoSearchResults([]);
-      return;
-    }
-    setRepoSearchLoading(true);
+  async function handleDiscoveryRefresh() {
+    setDiscoveryLoading(true);
     try {
-      const result = await searchToolingRepos(query);
-      setRepoSearchResults(result.items.map((item) => ({ ...item, key: `${item.owner}/${item.name}` })));
+      const response = await refreshToolingDiscoveredSkills();
+      setDiscoveryResponse(sortDiscoveryResponse(response));
+      setDiscoveryStatus(t("已更新"));
     } catch (error) {
-      void messageApi.error(error instanceof Error ? error.message : t("搜索失败"));
+      void messageApi.error(error instanceof Error ? error.message : t("刷新发现技能失败"));
     } finally {
-      setRepoSearchLoading(false);
+      setDiscoveryLoading(false);
     }
   }
 
-  async function handleRepoAdd(owner: string, name: string, branch = "main") {
-    const key = `${owner}/${name}`;
+  async function handleDiscoveredSkillInstall(skill: ToolingDiscoveredSkill) {
+    setDiscoveryBusyId(skill.id);
+    try {
+      await installToolingDiscoveredSkill({ id: skill.id, apps: ["codex"] });
+      void messageApi.success(t("安装成功"));
+      await reload({ background: true });
+      const response = await refreshToolingDiscoveredSkills();
+      setDiscoveryResponse(sortDiscoveryResponse(response));
+      setDiscoveryStatus(t("已更新"));
+    } catch (error) {
+      void messageApi.error(error instanceof Error ? error.message : t("安装失败"));
+    } finally {
+      setDiscoveryBusyId(null);
+    }
+  }
+
+  function handleViewDiscoveredSkill(skill: ToolingDiscoveredSkill) {
+    window.open(skill.repo_url, "_blank", "noopener,noreferrer");
+  }
+
+  async function handleRepoAdd() {
+    const key = repoRecordKey(repoForm.platform, repoForm.owner, repoForm.name);
     setRepoBusyKey(key);
     try {
-      await addToolingRepo(owner, name, branch);
+      await addToolingRepo(repoForm.platform, repoForm.owner, repoForm.name, repoForm.branch);
       void messageApi.success(t("仓库已添加"));
+      resetRepoForm();
       await reload({ background: true });
+      const response = await refreshToolingDiscoveredSkills();
+      setDiscoveryResponse(sortDiscoveryResponse(response));
+      setDiscoveryStatus(t("已更新"));
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("添加失败"));
     } finally {
@@ -248,13 +352,58 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     }
   }
 
-  async function handleRepoRemove(owner: string, name: string) {
-    const key = `${owner}/${name}`;
+  async function handleRepoSave() {
+    if (!repoEditing) {
+      await handleRepoAdd();
+      return;
+    }
+    const key = repoRecordKey(repoEditing.platform ?? "github", repoEditing.owner, repoEditing.name);
     setRepoBusyKey(key);
     try {
-      await removeToolingRepo(owner, name);
+      await updateToolingRepo(repoEditing.platform ?? "github", repoEditing.owner, repoEditing.name, repoForm);
+      void messageApi.success(t("仓库已更新"));
+      resetRepoForm();
+      await reload({ background: true });
+      const response = await refreshToolingDiscoveredSkills();
+      setDiscoveryResponse(sortDiscoveryResponse(response));
+      setDiscoveryStatus(t("已更新"));
+    } catch (error) {
+      void messageApi.error(error instanceof Error ? error.message : t("更新失败"));
+    } finally {
+      setRepoBusyKey(null);
+    }
+  }
+
+  function startRepoEdit(repo: ToolingSkillRepo) {
+    setRepoEditing(repo);
+    setRepoForm({
+      platform: repo.platform ?? "github",
+      owner: repo.owner,
+      name: repo.name,
+      branch: repo.branch,
+    });
+  }
+
+  function resetRepoForm() {
+    setRepoEditing(null);
+    setRepoForm({
+      platform: "github",
+      owner: "",
+      name: "",
+      branch: "main",
+    });
+  }
+
+  async function handleRepoRemove(repo: ToolingSkillRepo) {
+    const key = repoRecordKey(repo.platform ?? "github", repo.owner, repo.name);
+    setRepoBusyKey(key);
+    try {
+      await removeToolingRepo(repo.platform ?? "github", repo.owner, repo.name);
       void messageApi.success(t("仓库已删除"));
       await reload({ background: true });
+      const response = await refreshToolingDiscoveredSkills();
+      setDiscoveryResponse(sortDiscoveryResponse(response));
+      setDiscoveryStatus(t("已更新"));
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("删除失败"));
     } finally {
@@ -354,52 +503,137 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         title={t("发现技能")}
         onCancel={() => setSkillDiscoverOpen(false)}
         footer={null}
-        centered
+        width="100vw"
+        style={{ top: 0, paddingBottom: 0 }}
+        className="tooling-discovery-modal"
         destroyOnHidden
       >
-        <Space orientation="vertical" size={16} style={{ width: "100%" }}>
-          <div>
-            <div className="tooling-modal-section-title">{t("仓库搜索")}</div>
-            <Space.Compact className="tooling-search-bar">
-              <Input value={repoQuery} onChange={(event) => setRepoQuery(event.target.value)} placeholder={t("输入仓库关键词")} />
-              <Button icon={<SearchOutlined />} loading={repoSearchLoading} onClick={() => void handleRepoSearch()}>
-                {t("搜索")}
+        <div className="tooling-discovery-shell">
+          <div className="tooling-discovery-toolbar">
+            <Input
+              value={discoveryQuery}
+              onChange={(event) => setDiscoveryQuery(event.target.value)}
+              placeholder={t("搜索发现的技能")}
+              className="tooling-discovery-search"
+            />
+            <Space wrap size={10}>
+              <Typography.Text type="secondary">{discoveryStatus || (discoveryRefreshing ? t("正在更新") : "")}</Typography.Text>
+              <Button icon={<ReloadOutlined />} loading={discoveryLoading} aria-label={t("刷新技能索引")} onClick={() => void handleDiscoveryRefresh()}>
+                {t("刷新")}
               </Button>
-            </Space.Compact>
-            <div className="tooling-discovery-list">
-              {repoRows.length > 0 ? repoRows.map((repo) => (
-                <DiscoveryRow
-                  key={repo.key}
-                  title={`${repo.owner}/${repo.name}`}
-                  description={repo.description || repo.branch}
-                  actionLabel={t("添加")}
-                  actionBusy={repoBusyKey === `${repo.owner}/${repo.name}`}
-                  onAction={() => void handleRepoAdd(repo.owner, repo.name, repo.branch)}
-                />
-              )) : <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无搜索结果")} />}
-            </div>
+              <Button aria-label={t("仓库管理")} onClick={() => setRepoManagerOpen(true)}>
+                {t("仓库管理")}
+              </Button>
+            </Space>
           </div>
 
-          <div>
-            <div className="tooling-modal-section-title">{t("仓库管理")}</div>
-            <div className="tooling-discovery-list">
-              {state.skill_repos.length > 0 ? state.skill_repos.map((repo) => (
-                <DiscoveryRow
-                  key={`${repo.owner}/${repo.name}`}
-                  title={`${repo.owner}/${repo.name}`}
-                  description={`${repo.branch} · ${repo.skill_count} skills`}
-                  actionLabel={t("移除")}
-                  danger
-                  actionBusy={repoBusyKey === `${repo.owner}/${repo.name}`}
-                  onAction={() => void handleRepoRemove(repo.owner, repo.name)}
+          <div className="tooling-discovery-list tooling-discovery-grid">
+            {discoveryLoading && !discoveryResponse ? (
+              <div className="tooling-discovery-loading">
+                <Spin size="large" />
+              </div>
+            ) : discoveredSkills.length > 0 ? (
+              discoveredSkills.map((skill) => (
+                <DiscoveredSkillCard
+                  key={skill.id}
+                  skill={skill}
+                  busy={discoveryBusyId === skill.id}
+                  onView={() => handleViewDiscoveredSkill(skill)}
+                  onInstall={() => void handleDiscoveredSkillInstall(skill)}
                 />
-              )) : <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无已管理仓库")} />}
-            </div>
+              ))
+            ) : (
+              <Empty description={t("暂无发现技能")} />
+            )}
           </div>
-        </Space>
+        </div>
+      </Modal>
+
+      <Modal
+        open={repoManagerOpen}
+        title={t("仓库管理")}
+        onCancel={() => {
+          setRepoManagerOpen(false);
+          resetRepoForm();
+        }}
+        footer={null}
+        destroyOnHidden
+      >
+        <div className="tooling-repo-manager-shell">
+          <div className="tooling-repo-form-grid">
+            <label className="tooling-repo-field">
+              <span>{t("仓库平台")}</span>
+              <select
+                aria-label={t("仓库平台")}
+                value={repoForm.platform}
+                onChange={(event) => setRepoForm((current) => ({ ...current, platform: event.target.value as "github" | "gitlab" }))}
+              >
+                <option value="github">GitHub</option>
+                <option value="gitlab">GitLab</option>
+              </select>
+            </label>
+            <label className="tooling-repo-field">
+              <span>{t("仓库归属")}</span>
+              <input
+                aria-label={t("仓库归属")}
+                value={repoForm.owner}
+                onChange={(event) => setRepoForm((current) => ({ ...current, owner: event.target.value }))}
+              />
+            </label>
+            <label className="tooling-repo-field">
+              <span>{t("仓库名称")}</span>
+              <input
+                aria-label={t("仓库名称")}
+                value={repoForm.name}
+                onChange={(event) => setRepoForm((current) => ({ ...current, name: event.target.value }))}
+              />
+            </label>
+            <label className="tooling-repo-field">
+              <span>{t("分支")}</span>
+              <input
+                aria-label={t("分支")}
+                value={repoForm.branch}
+                onChange={(event) => setRepoForm((current) => ({ ...current, branch: event.target.value }))}
+              />
+            </label>
+          </div>
+          <Space wrap size={10}>
+            <Button type="primary" onClick={() => void handleRepoSave()}>
+              {repoEditing ? t("保存仓库") : t("添加仓库")}
+            </Button>
+            {repoEditing ? (
+              <Button onClick={() => resetRepoForm()}>
+                {t("取消编辑")}
+              </Button>
+            ) : null}
+          </Space>
+
+          <div className="tooling-discovery-list">
+            {skillRepos.length > 0 ? skillRepos.map((repo) => (
+              <RepoManageRow
+                key={repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
+                repo={repo}
+                busy={repoBusyKey === repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
+                onEdit={() => startRepoEdit(repo)}
+                onDelete={() => void handleRepoRemove(repo)}
+              />
+            )) : <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无已管理仓库")} />}
+          </div>
+        </div>
       </Modal>
     </div>
   );
+}
+
+function sortDiscoveryResponse(response: ToolingSkillDiscoveryResponse): ToolingSkillDiscoveryResponse {
+  return {
+    ...response,
+    items: [...response.items].sort((left, right) => left.name.localeCompare(right.name)),
+  };
+}
+
+function repoRecordKey(platform: string, owner: string, name: string): string {
+  return `${platform}:${owner}/${name}`;
 }
 
 function DeleteMcpConfirmContent({
@@ -444,6 +678,69 @@ function DeleteMcpConfirmContent({
         </div>
       ) : null}
     </Space>
+  );
+}
+
+function DiscoveredSkillCard({
+  skill,
+  busy,
+  onView,
+  onInstall,
+}: {
+  skill: ToolingDiscoveredSkill;
+  busy?: boolean;
+  onView: () => void;
+  onInstall: () => void;
+}) {
+  const installed = Boolean(skill.installed_apps?.codex);
+  return (
+    <div className="tooling-discovered-card">
+      <div className="tooling-discovered-card-main">
+        <div className="tooling-discovered-card-meta">
+          <span className="tooling-discovered-platform">{skill.platform.toUpperCase()}</span>
+          <span className="tooling-discovered-repo">{`${skill.repo_owner}/${skill.repo_name}`}</span>
+        </div>
+        <div className="tooling-item-title" data-testid="tooling-discovered-skill-title">{skill.name}</div>
+        {skill.description ? <div className="tooling-item-description is-default">{skill.description}</div> : null}
+      </div>
+      <div className="tooling-discovered-card-actions">
+        <Button icon={<LinkOutlined />} aria-label={`查看 ${skill.name} 的仓库页面`} onClick={onView}>
+          查看
+        </Button>
+        <Button type="primary" icon={<PlusOutlined />} loading={busy} disabled={installed} aria-label={`安装 ${skill.name}`} onClick={onInstall}>
+          {installed ? "已安装" : "安装"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function RepoManageRow({
+  repo,
+  busy,
+  onEdit,
+  onDelete,
+}: {
+  repo: ToolingSkillRepo;
+  busy?: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="tooling-repo-row">
+      <div className="tooling-repo-main">
+        <div className="tooling-repo-title">{`${repo.owner}/${repo.name}`}</div>
+        <div className="stats-subtitle">{`${(repo.platform ?? "github").toUpperCase()} · ${repo.branch} · ${repo.skill_count} skills`}</div>
+      </div>
+      <Space size={8}>
+        <Button size="small" icon={<EditOutlined />} aria-label={`编辑 ${repo.owner}/${repo.name}`} onClick={onEdit}>
+          编辑
+        </Button>
+        <Button size="small" danger loading={busy} icon={<DeleteOutlined />} aria-label={`移除 ${repo.owner}/${repo.name}`} onClick={onDelete}>
+          移除
+        </Button>
+      </Space>
+    </div>
   );
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -270,6 +270,7 @@ export type ToolingSkillStats = {
 };
 
 export type ToolingSkillRepo = {
+  platform?: "github" | "gitlab";
   owner: string;
   name: string;
   branch: string;
@@ -278,11 +279,33 @@ export type ToolingSkillRepo = {
 };
 
 export type ToolingRepoSearchResult = {
+  platform?: "github" | "gitlab";
   owner: string;
   name: string;
   branch: string;
   url: string;
   description?: string;
+};
+
+export type ToolingDiscoveredSkill = {
+  id: string;
+  name: string;
+  description?: string;
+  platform: "github" | "gitlab";
+  repo_owner: string;
+  repo_name: string;
+  branch: string;
+  repo_url: string;
+  source_path: string;
+  source_url: string;
+  managed_name: string;
+  installed_apps: Record<string, boolean>;
+};
+
+export type ToolingSkillDiscoveryResponse = {
+  cached: boolean;
+  fetched_at?: string;
+  items: ToolingDiscoveredSkill[];
 };
 
 export type ToolingSkillRecord = {
@@ -989,11 +1012,21 @@ export async function listToolingRepos(): Promise<ToolingSkillRepo[]> {
   return response.json();
 }
 
-export async function addToolingRepo(owner: string, name: string, branch = "main"): Promise<ToolingSkillRepo> {
+export async function addToolingRepo(
+  platformOrOwner: "github" | "gitlab" | string,
+  ownerOrName: string,
+  nameOrBranch = "main",
+  maybeBranch?: string,
+): Promise<ToolingSkillRepo> {
+  const usesExplicitPlatform = platformOrOwner === "github" || platformOrOwner === "gitlab";
+  const platform = usesExplicitPlatform ? platformOrOwner : "github";
+  const owner = usesExplicitPlatform ? ownerOrName : platformOrOwner;
+  const name = usesExplicitPlatform ? nameOrBranch : ownerOrName;
+  const branch = usesExplicitPlatform ? (maybeBranch ?? "main") : (nameOrBranch || "main");
   const response = await fetch(apiPath("/tooling/skills/repos"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ owner, name, branch }),
+    body: JSON.stringify({ platform, owner, name, branch }),
   });
   if (!response.ok) {
     const details = await response.text();
@@ -1002,8 +1035,31 @@ export async function addToolingRepo(owner: string, name: string, branch = "main
   return response.json();
 }
 
-export async function removeToolingRepo(owner: string, name: string): Promise<void> {
-  const response = await fetch(apiPath(`/tooling/skills/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`), {
+export async function updateToolingRepo(
+  currentPlatform: "github" | "gitlab",
+  currentOwner: string,
+  currentName: string,
+  payload: {
+    platform: "github" | "gitlab";
+    owner: string;
+    name: string;
+    branch: string;
+  },
+): Promise<ToolingSkillRepo> {
+  const response = await fetch(apiPath(`/tooling/skills/repos/${encodeURIComponent(currentPlatform)}/${encodeURIComponent(currentOwner)}/${encodeURIComponent(currentName)}`), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to update tooling repo");
+  }
+  return response.json();
+}
+
+export async function removeToolingRepo(platform: "github" | "gitlab", owner: string, name: string): Promise<void> {
+  const response = await fetch(apiPath(`/tooling/skills/repos/${encodeURIComponent(platform)}/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`), {
     method: "DELETE",
   });
   if (!response.ok) {
@@ -1016,6 +1072,44 @@ export async function searchToolingRepos(query: string): Promise<{ items: Toolin
   const response = await fetch(apiPath(`/tooling/skills/repos/search?q=${encodeURIComponent(query)}`));
   if (!response.ok) {
     throw new Error("failed to search tooling repos");
+  }
+  return response.json();
+}
+
+export async function getToolingDiscoveredSkills(): Promise<ToolingSkillDiscoveryResponse> {
+  const response = await fetch(apiPath("/tooling/skills/discover"));
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to load discovered skills");
+  }
+  return response.json();
+}
+
+export async function refreshToolingDiscoveredSkills(): Promise<ToolingSkillDiscoveryResponse> {
+  const response = await fetch(apiPath("/tooling/skills/discover/refresh"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to refresh discovered skills");
+  }
+  return response.json();
+}
+
+export async function installToolingDiscoveredSkill(payload: {
+  id: string;
+  apps?: string[];
+}): Promise<{ applied: number; enabled: boolean; skill_sync_method?: "symlink" | "copy" }> {
+  const response = await fetch(apiPath("/tooling/skills/discover/install"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to install discovered skill");
   }
   return response.json();
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -671,6 +671,132 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   gap: 10px;
 }
 
+.tooling-discovery-modal .ant-modal-content {
+  min-height: 100vh;
+  border-radius: 0;
+  padding: 20px 24px 24px;
+}
+
+.tooling-discovery-modal .ant-modal-body {
+  height: calc(100vh - 92px);
+}
+
+.tooling-discovery-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  height: 100%;
+}
+
+.tooling-discovery-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.tooling-discovery-search {
+  max-width: 420px;
+}
+
+.tooling-discovery-grid {
+  flex: 1;
+  overflow: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 12px;
+  align-content: start;
+}
+
+.tooling-discovery-loading {
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tooling-discovered-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid var(--panel-border);
+  background: #ffffff;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.04);
+}
+
+.tooling-discovered-card-main {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.tooling-discovered-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tooling-discovered-platform {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: rgba(62, 91, 232, 0.08);
+  color: #2f49c8;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.tooling-discovered-repo {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.tooling-discovered-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.tooling-repo-manager-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.tooling-repo-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.tooling-repo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.tooling-repo-field input,
+.tooling-repo-field select {
+  width: 100%;
+  min-height: 38px;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  padding: 0 12px;
+  background: #ffffff;
+  color: var(--text-primary);
+}
+
 .tooling-card {
   border-radius: 18px;
   border: 1px solid var(--panel-border);
@@ -856,6 +982,21 @@ html[data-theme-mode="dark"] .top-home-update-dot {
 .tooling-template-main {
   min-width: 0;
   text-align: left;
+}
+
+@media (max-width: 840px) {
+  .tooling-discovery-toolbar {
+    align-items: stretch;
+  }
+
+  .tooling-discovery-search {
+    max-width: none;
+    width: 100%;
+  }
+
+  .tooling-repo-form-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .tooling-template-title {


### PR DESCRIPTION
## Summary
- add a full-screen skill discovery flow with cached index loading, silent background refresh, and manual refresh
- support discovered skill install plus repository-page viewing and secondary repo management for public GitHub/GitLab repos
- bump release metadata to v1.2.2

## Verification
- go test ./...
- npm test -- --run
- npm run build