### PR TITLE
Fix tooling release CI and cut v1.2.3

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -280,20 +280,29 @@ describe("ToolingPage", () => {
   });
 
   it("uses the managed collection directory when toggling and deleting skills", async () => {
-    vi.mocked(api.getToolingState).mockResolvedValue({
-      ...buildToolingState(),
-      installed_skills: [
-        {
-          name: "Superpowers Collection",
-          description: "包含 2 个技能",
-          directory: "/tmp/aigate/tooling/skills/superpowers",
-          source_client: "codex",
-          source_kind: "codex",
-          managed_path: "/tmp/aigate/tooling/skills/superpowers",
-          installed_apps: { codex: true },
-        },
-      ],
-    });
+    const managedCollection: api.ToolingSkillRecord = {
+      name: "Superpowers Collection",
+      description: "包含 2 个技能",
+      directory: "/tmp/aigate/tooling/skills/superpowers",
+      source_client: "codex",
+      source_kind: "codex",
+      managed_path: "/tmp/aigate/tooling/skills/superpowers",
+      installed_apps: { codex: true },
+    };
+    vi.mocked(api.getToolingState)
+      .mockResolvedValueOnce({
+        ...buildToolingState(),
+        installed_skills: [managedCollection],
+      })
+      .mockResolvedValue({
+        ...buildToolingState(),
+        installed_skills: [
+          {
+            ...managedCollection,
+            installed_apps: { codex: false },
+          },
+        ],
+      });
 
     const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementation((config) => {
       void config.onOk?.();
@@ -314,7 +323,10 @@ describe("ToolingPage", () => {
       }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "删除 Superpowers Collection" }));
+    await screen.findByRole("button", { name: "启用 Superpowers Collection 到 Codex" });
+    const deleteButton = screen.getByRole("button", { name: "删除 Superpowers Collection" });
+    await waitFor(() => expect(deleteButton).toBeEnabled());
+    fireEvent.click(deleteButton);
     await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
     await waitFor(() => expect(api.deleteToolingSkill).toHaveBeenCalledWith("superpowers"));
   });


### PR DESCRIPTION
## Summary
- stabilize the managed skill delete test by waiting for the post-toggle refresh state
- keep the managed collection title stable across the mocked reload in the regression test
- bump app versions to 1.2.3 for the replacement release

## Verification
- npm --prefix frontend test -- --run
- npm --prefix frontend run build
- go test ./...