### PR TITLE
fix(tooling): avoid github api rate-limit on skill discovery

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -1,8 +1,8 @@
 package api
 
 import (
+	"archive/zip"
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -120,13 +121,13 @@ type discoveredSkillRecord struct {
 }
 
 type skillDiscoveryCache struct {
-	FetchedAt string                 `json:"fetched_at"`
+	FetchedAt string                  `json:"fetched_at"`
 	Items     []discoveredSkillRecord `json:"items"`
 }
 
 type toolingSkillDiscoverResponse struct {
-	Cached    bool                  `json:"cached"`
-	FetchedAt string                `json:"fetched_at,omitempty"`
+	Cached    bool                    `json:"cached"`
+	FetchedAt string                  `json:"fetched_at,omitempty"`
 	Items     []discoveredSkillRecord `json:"items"`
 }
 
@@ -190,9 +191,9 @@ type toolingDiscoveredSkillInstallRequest struct {
 
 type toolingRepoRequest struct {
 	Platform string `json:"platform"`
-	Owner  string `json:"owner"`
-	Name   string `json:"name"`
-	Branch string `json:"branch"`
+	Owner    string `json:"owner"`
+	Name     string `json:"name"`
+	Branch   string `json:"branch"`
 }
 
 type toolingRepoSearchResponse struct {
@@ -639,7 +640,7 @@ func (h *ToolingHandler) searchSkillRepos(w http.ResponseWriter, r *http.Request
 	}
 	var (
 		items []repoSearchResult
-		err error
+		err   error
 	)
 	switch platform {
 	case "gitlab":
@@ -2240,7 +2241,7 @@ func (h *ToolingHandler) syncManagedCodexMcpServers(home string, cfg toolingConf
 }
 
 func searchGitHubRepos(query string) ([]repoSearchResult, error) {
-	req, err := http.NewRequest(http.MethodGet, githubAPIBase()+"/search/repositories", nil)
+	req, err := newGitHubAPIRequest(http.MethodGet, githubAPIBase()+"/search/repositories")
 	if err != nil {
 		return nil, err
 	}
@@ -2254,7 +2255,7 @@ func searchGitHubRepos(query string) ([]repoSearchResult, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("github search failed: %s", resp.Status)
+		return nil, describeGitHubHTTPError("search", resp)
 	}
 	var payload struct {
 		Items []struct {
@@ -2333,8 +2334,76 @@ func githubAPIBase() string {
 	return strings.TrimRight(firstNonEmpty(os.Getenv("AIGATE_GITHUB_API_BASE"), "https://api.github.com"), "/")
 }
 
+func githubArchiveBase() string {
+	return strings.TrimRight(firstNonEmpty(os.Getenv("AIGATE_GITHUB_ARCHIVE_BASE"), "https://github.com"), "/")
+}
+
 func gitlabAPIBase() string {
 	return strings.TrimRight(firstNonEmpty(os.Getenv("AIGATE_GITLAB_API_BASE"), "https://gitlab.com/api/v4"), "/")
+}
+
+func githubAuthToken() string {
+	return strings.TrimSpace(firstNonEmpty(
+		os.Getenv("AIGATE_GITHUB_TOKEN"),
+		os.Getenv("GITHUB_TOKEN"),
+		os.Getenv("GH_TOKEN"),
+		os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN"),
+	))
+}
+
+func newGitHubAPIRequest(method string, targetURL string) (*http.Request, error) {
+	req, err := http.NewRequest(method, targetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "ai-gate")
+	if token := githubAuthToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req, nil
+}
+
+func newGitHubArchiveRequest(repo skillRepoRecord) (*http.Request, error) {
+	archiveURL := fmt.Sprintf("%s/%s/%s/archive/refs/heads/%s.zip", githubArchiveBase(), url.PathEscape(repo.Owner), url.PathEscape(repo.Name), url.PathEscape(repo.Branch))
+	req, err := http.NewRequest(http.MethodGet, archiveURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "ai-gate")
+	return req, nil
+}
+
+func describeGitHubHTTPError(kind string, resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	bodyText := strings.TrimSpace(string(body))
+	message := bodyText
+	if strings.HasPrefix(bodyText, "{") {
+		var payload struct {
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(body, &payload) == nil && strings.TrimSpace(payload.Message) != "" {
+			message = strings.TrimSpace(payload.Message)
+		}
+	}
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+		if resp.Header.Get("X-RateLimit-Remaining") == "0" || strings.Contains(strings.ToLower(message), "rate limit") {
+			resetHint := ""
+			if rawReset := strings.TrimSpace(resp.Header.Get("X-RateLimit-Reset")); rawReset != "" {
+				if ts, err := strconv.ParseInt(rawReset, 10, 64); err == nil {
+					resetHint = fmt.Sprintf("，预计 %s 重置", time.Unix(ts, 0).UTC().Format(time.RFC3339))
+				}
+			}
+			if githubAuthToken() == "" {
+				return fmt.Errorf("github %s 触发匿名请求限流%s，请稍后重试或配置 GitHub Token", kind, resetHint)
+			}
+			return fmt.Errorf("github %s 触发请求限流%s，请稍后重试", kind, resetHint)
+		}
+	}
+	if message != "" && message != resp.Status {
+		return fmt.Errorf("github %s failed: %s (%s)", kind, resp.Status, message)
+	}
+	return fmt.Errorf("github %s failed: %s", kind, resp.Status)
 }
 
 func loadSkillDiscoveryCache(home string) (skillDiscoveryCache, bool) {
@@ -2413,76 +2482,78 @@ func discoverSkillsFromRepo(repo skillRepoRecord, installed map[string]map[strin
 }
 
 func discoverGitHubRepoSkills(repo skillRepoRecord, installed map[string]map[string]bool) ([]discoveredSkillRecord, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/%s/git/trees/%s", githubAPIBase(), url.PathEscape(repo.Owner), url.PathEscape(repo.Name), url.PathEscape(repo.Branch)), nil)
+	files, err := fetchGitHubArchiveFiles(repo, func(filePath string) bool {
+		return strings.HasSuffix(filePath, "/SKILL.md")
+	})
 	if err != nil {
 		return nil, err
 	}
-	params := req.URL.Query()
-	params.Set("recursive", "1")
-	req.URL.RawQuery = params.Encode()
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
+	paths := make([]string, 0, len(files))
+	for filePath := range files {
+		paths = append(paths, filePath)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("github tree failed: %s", resp.Status)
-	}
-	var payload struct {
-		Tree []struct {
-			Path string `json:"path"`
-			Type string `json:"type"`
-		} `json:"tree"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return nil, err
-	}
+	sort.Strings(paths)
 	items := make([]discoveredSkillRecord, 0)
-	for _, entry := range payload.Tree {
-		if entry.Type != "blob" || !strings.HasSuffix(entry.Path, "/SKILL.md") {
-			continue
-		}
-		raw, err := fetchGitHubFile(repo, entry.Path)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, buildDiscoveredSkillRecord(repo, entry.Path, raw, installed))
+	for _, filePath := range paths {
+		items = append(items, buildDiscoveredSkillRecord(repo, filePath, files[filePath], installed))
 	}
 	return items, nil
 }
 
-func fetchGitHubFile(repo skillRepoRecord, path string) (string, error) {
-	urlPath := fmt.Sprintf("%s/repos/%s/%s/contents/%s", githubAPIBase(), url.PathEscape(repo.Owner), url.PathEscape(repo.Name), encodeRepoPath(path))
-	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+func fetchGitHubArchiveFiles(repo skillRepoRecord, match func(string) bool) (map[string]string, error) {
+	req, err := newGitHubArchiveRequest(repo)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	params := req.URL.Query()
-	params.Set("ref", repo.Branch)
-	req.URL.RawQuery = params.Encode()
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
-		return "", fmt.Errorf("github content failed: %s", resp.Status)
+		return nil, describeGitHubHTTPError("archive", resp)
 	}
-	var payload struct {
-		Content  string `json:"content"`
-		Encoding string `json:"encoding"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", err
-	}
-	if payload.Encoding != "base64" {
-		return "", fmt.Errorf("unsupported github content encoding: %s", payload.Encoding)
-	}
-	decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(payload.Content, "\n", ""))
+	archive, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return string(decoded), nil
+	reader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, err
+	}
+	files := map[string]string{}
+	for _, file := range reader.File {
+		relativePath := trimGitHubArchivePath(file.Name)
+		if relativePath == "" || file.FileInfo().IsDir() || !match(relativePath) {
+			continue
+		}
+		handle, err := file.Open()
+		if err != nil {
+			return nil, err
+		}
+		raw, readErr := io.ReadAll(handle)
+		closeErr := handle.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+		files[relativePath] = string(raw)
+	}
+	return files, nil
+}
+
+func trimGitHubArchivePath(filePath string) string {
+	filePath = strings.Trim(filePath, "/")
+	if filePath == "" {
+		return ""
+	}
+	_, relativePath, found := strings.Cut(filePath, "/")
+	if !found {
+		return ""
+	}
+	return strings.Trim(relativePath, "/")
 }
 
 func discoverGitLabRepoSkills(repo skillRepoRecord, installed map[string]map[string]bool) ([]discoveredSkillRecord, error) {
@@ -2750,43 +2821,18 @@ func fetchDiscoveredSkillFiles(repo skillRepoRecord, sourcePath string) (map[str
 }
 
 func fetchGitHubSkillFiles(repo skillRepoRecord, sourcePath string) (map[string]string, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/%s/git/trees/%s", githubAPIBase(), url.PathEscape(repo.Owner), url.PathEscape(repo.Name), url.PathEscape(repo.Branch)), nil)
-	if err != nil {
-		return nil, err
-	}
-	params := req.URL.Query()
-	params.Set("recursive", "1")
-	req.URL.RawQuery = params.Encode()
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("github tree failed: %s", resp.Status)
-	}
-	var payload struct {
-		Tree []struct {
-			Path string `json:"path"`
-			Type string `json:"type"`
-		} `json:"tree"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return nil, err
-	}
-	files := map[string]string{}
 	prefix := strings.Trim(sourcePath, "/")
-	for _, entry := range payload.Tree {
-		if entry.Type != "blob" || !pathWithinDiscoveredSkill(prefix, entry.Path) {
-			continue
-		}
-		raw, err := fetchGitHubFile(repo, entry.Path)
-		if err != nil {
-			return nil, err
-		}
-		files[strings.TrimPrefix(strings.TrimPrefix(entry.Path, prefix), "/")] = raw
+	files, err := fetchGitHubArchiveFiles(repo, func(filePath string) bool {
+		return pathWithinDiscoveredSkill(prefix, filePath)
+	})
+	if err != nil {
+		return nil, err
 	}
-	return files, nil
+	result := map[string]string{}
+	for filePath, raw := range files {
+		result[strings.TrimPrefix(strings.TrimPrefix(filePath, prefix), "/")] = raw
+	}
+	return result, nil
 }
 
 func fetchGitLabSkillFiles(repo skillRepoRecord, sourcePath string) (map[string]string, error) {

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -1,8 +1,8 @@
 package api_test
 
 import (
+	"archive/zip"
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -762,31 +762,24 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
+	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
+		"skills/zulu/SKILL.md":  "# Zulu Skill\nA trailing skill.\n\nUNIQUE-ZULU-BODY\n",
+		"skills/alpha/SKILL.md": "---\ndescription: Alpha summary\n---\n# Alpha Skill\nDetailed alpha body that must not be cached.\n",
+	})
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/git/trees/main":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"tree": []map[string]any{
-					{"path": "skills/zulu/SKILL.md", "type": "blob"},
-					{"path": "skills/alpha/SKILL.md", "type": "blob"},
-				},
-			})
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/contents/skills/zulu/SKILL.md":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"encoding": "base64",
-				"content":  base64.StdEncoding.EncodeToString([]byte("# Zulu Skill\nA trailing skill.\n\nUNIQUE-ZULU-BODY\n")),
-			})
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/contents/skills/alpha/SKILL.md":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"encoding": "base64",
-				"content":  base64.StdEncoding.EncodeToString([]byte("---\ndescription: Alpha summary\n---\n# Alpha Skill\nDetailed alpha body that must not be cached.\n")),
-			})
+		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(archive)
+		case strings.Contains(r.URL.Path, "/git/trees/"), strings.Contains(r.URL.Path, "/contents/"):
+			http.Error(w, "legacy github api path should not be used", http.StatusForbidden)
 		default:
 			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
-	t.Setenv("AIGATE_GITHUB_API_BASE", server.URL)
+	t.Setenv("AIGATE_GITHUB_ARCHIVE_BASE", server.URL)
 
 	writeToolingConfig(t, home, map[string]any{
 		"skill_sync_method": "symlink",
@@ -912,31 +905,27 @@ func TestToolingHandlerCanInstallDiscoveredSkillIntoManagedAndCodexDirs(t *testi
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
+	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
+		"skills/alpha/SKILL.md":           "# Alpha Skill\nInstallable summary.\n",
+		"skills/alpha/assets/config.json": "{\"ok\":true}\n",
+		"skills/alpha/assets/readme.txt":  "hello\n",
+		"skills/ignore-other/SKILL.md":    "# Ignore Other\nnot selected\n",
+		"skills/ignore-other/extra.txt":   "ignore\n",
+	})
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/git/trees/main":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"tree": []map[string]any{
-					{"path": "skills/alpha/SKILL.md", "type": "blob"},
-					{"path": "skills/alpha/assets/config.json", "type": "blob"},
-				},
-			})
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/contents/skills/alpha/SKILL.md":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"encoding": "base64",
-				"content":  base64.StdEncoding.EncodeToString([]byte("# Alpha Skill\nInstallable summary.\n")),
-			})
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills/contents/skills/alpha/assets/config.json":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"encoding": "base64",
-				"content":  base64.StdEncoding.EncodeToString([]byte("{\"ok\":true}\n")),
-			})
+		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(archive)
+		case strings.Contains(r.URL.Path, "/git/trees/"), strings.Contains(r.URL.Path, "/contents/"):
+			http.Error(w, "legacy github api path should not be used", http.StatusForbidden)
 		default:
 			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
-	t.Setenv("AIGATE_GITHUB_API_BASE", server.URL)
+	t.Setenv("AIGATE_GITHUB_ARCHIVE_BASE", server.URL)
 
 	handler := api.NewToolingHandler()
 
@@ -955,6 +944,12 @@ func TestToolingHandlerCanInstallDiscoveredSkillIntoManagedAndCodexDirs(t *testi
 	if _, err := os.Stat(filepath.Join(managedRoot, "assets", "config.json")); err != nil {
 		t.Fatalf("expected managed nested file: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(managedRoot, "assets", "readme.txt")); err != nil {
+		t.Fatalf("expected managed text asset: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".aigate", "data", "tooling", "skills", "codex-skills-ignore-other")); !os.IsNotExist(err) {
+		t.Fatalf("expected unrelated skill not installed, stat err = %v", err)
+	}
 	metaRaw, err := os.ReadFile(filepath.Join(managedRoot, ".aigate-skill.json"))
 	if err != nil {
 		t.Fatalf("ReadFile metadata: %v", err)
@@ -969,6 +964,25 @@ func TestToolingHandlerCanInstallDiscoveredSkillIntoManagedAndCodexDirs(t *testi
 	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "codex-skills-alpha", "SKILL.md")); err != nil {
 		t.Fatalf("expected codex synced skill file: %v", err)
 	}
+}
+
+func makeGitHubArchiveZip(t *testing.T, root string, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for relativePath, raw := range files {
+		entry, err := zw.Create(root + "/" + strings.TrimLeft(relativePath, "/"))
+		if err != nil {
+			t.Fatalf("Create zip entry %s: %v", relativePath, err)
+		}
+		if _, err := entry.Write([]byte(raw)); err != nil {
+			t.Fatalf("Write zip entry %s: %v", relativePath, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Close zip writer: %v", err)
+	}
+	return buf.Bytes()
 }
 
 func doToolingRequest(t *testing.T, handler http.Handler, method, path string, body *bytes.Buffer, headers map[string]string, wantStatus int) []byte {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- switch GitHub skill discovery and install from tree/contents API calls to branch archive downloads
- add optional GitHub token support plus clearer GitHub rate-limit errors for API-backed calls
- bump release version to v1.2.5

## Verification
- go test ./... (backend)
- npm test -- --run (frontend)
- npm run build (frontend)
- cargo test (desktop/src-tauri)