### PR TITLE
fix(tooling): improve discovered skill discovery actions

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"archive/zip"
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -106,18 +106,26 @@ type repoSearchResult struct {
 }
 
 type discoveredSkillRecord struct {
-	ID            string          `json:"id"`
-	Name          string          `json:"name"`
-	Description   string          `json:"description,omitempty"`
-	Platform      string          `json:"platform"`
-	RepoOwner     string          `json:"repo_owner"`
-	RepoName      string          `json:"repo_name"`
-	Branch        string          `json:"branch"`
-	RepoURL       string          `json:"repo_url"`
-	SourcePath    string          `json:"source_path"`
-	SourceURL     string          `json:"source_url"`
-	ManagedName   string          `json:"managed_name"`
-	InstalledApps map[string]bool `json:"installed_apps"`
+	ID              string          `json:"id"`
+	Name            string          `json:"name"`
+	Description     string          `json:"description,omitempty"`
+	Platform        string          `json:"platform"`
+	RepoOwner       string          `json:"repo_owner"`
+	RepoName        string          `json:"repo_name"`
+	Branch          string          `json:"branch"`
+	RepoURL         string          `json:"repo_url"`
+	SourcePath      string          `json:"source_path"`
+	SourceURL       string          `json:"source_url"`
+	ManagedName     string          `json:"managed_name"`
+	ContentHash     string          `json:"content_hash,omitempty"`
+	InstalledHash   string          `json:"installed_hash,omitempty"`
+	InstalledApps   map[string]bool `json:"installed_apps"`
+	UpdateAvailable bool            `json:"update_available"`
+}
+
+type discoveredInstallState struct {
+	Apps map[string]bool
+	Hash string
 }
 
 type skillDiscoveryCache struct {
@@ -1222,6 +1230,7 @@ type skillMetadata struct {
 	Branch       string `json:"branch,omitempty"`
 	SourcePath   string `json:"source_path,omitempty"`
 	SourceURL    string `json:"source_url,omitempty"`
+	UpstreamHash string `json:"upstream_hash,omitempty"`
 }
 
 func readSkillMetadata(dir string) skillMetadata {
@@ -2455,8 +2464,8 @@ func discoverSkillsFromRepos(home string, repos []skillRepoRecord, clients []too
 	return items, nil
 }
 
-func discoveredInstalledAppsBySource(home string, clients []toolingClientState) map[string]map[string]bool {
-	installed := map[string]map[string]bool{}
+func discoveredInstalledAppsBySource(home string, clients []toolingClientState) map[string]discoveredInstallState {
+	installed := map[string]discoveredInstallState{}
 	for _, record := range scanManagedSkills(home, clients) {
 		meta := readSkillMetadata(record.ManagedPath)
 		key := discoveredSkillKey(meta.Platform, meta.SourceRepo, meta.Branch, meta.SourcePath)
@@ -2467,12 +2476,19 @@ func discoveredInstalledAppsBySource(home string, clients []toolingClientState) 
 		for app, enabled := range record.InstalledApps {
 			apps[app] = enabled
 		}
-		installed[key] = apps
+		hash := strings.TrimSpace(meta.UpstreamHash)
+		if hash == "" {
+			hash = hashSkillDirectory(record.ManagedPath)
+		}
+		installed[key] = discoveredInstallState{
+			Apps: apps,
+			Hash: hash,
+		}
 	}
 	return installed
 }
 
-func discoverSkillsFromRepo(repo skillRepoRecord, installed map[string]map[string]bool) ([]discoveredSkillRecord, error) {
+func discoverSkillsFromRepo(repo skillRepoRecord, installed map[string]discoveredInstallState) ([]discoveredSkillRecord, error) {
 	switch repo.Platform {
 	case "gitlab":
 		return discoverGitLabRepoSkills(repo, installed)
@@ -2481,21 +2497,22 @@ func discoverSkillsFromRepo(repo skillRepoRecord, installed map[string]map[strin
 	}
 }
 
-func discoverGitHubRepoSkills(repo skillRepoRecord, installed map[string]map[string]bool) ([]discoveredSkillRecord, error) {
+func discoverGitHubRepoSkills(repo skillRepoRecord, installed map[string]discoveredInstallState) ([]discoveredSkillRecord, error) {
 	files, err := fetchGitHubArchiveFiles(repo, func(filePath string) bool {
-		return strings.HasSuffix(filePath, "/SKILL.md")
+		return true
 	})
 	if err != nil {
 		return nil, err
 	}
-	paths := make([]string, 0, len(files))
-	for filePath := range files {
-		paths = append(paths, filePath)
+	skillFiles := groupDiscoveredSkillFiles(files)
+	paths := make([]string, 0, len(skillFiles))
+	for sourcePath := range skillFiles {
+		paths = append(paths, sourcePath)
 	}
 	sort.Strings(paths)
 	items := make([]discoveredSkillRecord, 0)
-	for _, filePath := range paths {
-		items = append(items, buildDiscoveredSkillRecord(repo, filePath, files[filePath], installed))
+	for _, sourcePath := range paths {
+		items = append(items, buildDiscoveredSkillRecord(repo, sourcePath, skillFiles[sourcePath], installed))
 	}
 	return items, nil
 }
@@ -2556,7 +2573,7 @@ func trimGitHubArchivePath(filePath string) string {
 	return strings.Trim(relativePath, "/")
 }
 
-func discoverGitLabRepoSkills(repo skillRepoRecord, installed map[string]map[string]bool) ([]discoveredSkillRecord, error) {
+func discoverGitLabRepoSkills(repo skillRepoRecord, installed map[string]discoveredInstallState) ([]discoveredSkillRecord, error) {
 	projectID := url.PathEscape(repo.Owner + "/" + repo.Name)
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/projects/%s/repository/tree", gitlabAPIBase(), projectID), nil)
 	if err != nil {
@@ -2582,16 +2599,18 @@ func discoverGitLabRepoSkills(repo skillRepoRecord, installed map[string]map[str
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return nil, err
 	}
+	skillFiles, err := fetchGitLabSkillDiscoveryFiles(repo, projectID, payload)
+	if err != nil {
+		return nil, err
+	}
 	items := make([]discoveredSkillRecord, 0)
-	for _, entry := range payload {
-		if entry.Type != "blob" || !strings.HasSuffix(entry.Path, "/SKILL.md") {
-			continue
-		}
-		raw, err := fetchGitLabFile(repo, projectID, entry.Path)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, buildDiscoveredSkillRecord(repo, entry.Path, raw, installed))
+	paths := make([]string, 0, len(skillFiles))
+	for sourcePath := range skillFiles {
+		paths = append(paths, sourcePath)
+	}
+	sort.Strings(paths)
+	for _, sourcePath := range paths {
+		items = append(items, buildDiscoveredSkillRecord(repo, sourcePath, skillFiles[sourcePath], installed))
 	}
 	return items, nil
 }
@@ -2619,29 +2638,177 @@ func fetchGitLabFile(repo skillRepoRecord, projectID string, path string) (strin
 	return string(raw), nil
 }
 
-func buildDiscoveredSkillRecord(repo skillRepoRecord, skillFilePath string, body string, installed map[string]map[string]bool) discoveredSkillRecord {
-	sourcePath := path.Dir(skillFilePath)
-	if sourcePath == "." {
-		sourcePath = ""
+func fetchGitLabSkillDiscoveryFiles(repo skillRepoRecord, projectID string, payload []struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+}) (map[string]map[string]string, error) {
+	roots := collectDiscoveredSkillRootsFromTree(payload)
+	files := map[string]map[string]string{}
+	for _, root := range roots {
+		files[root] = map[string]string{}
 	}
+	for _, entry := range payload {
+		if entry.Type != "blob" {
+			continue
+		}
+		root, ok := matchDiscoveredSkillRoot(roots, entry.Path)
+		if !ok {
+			continue
+		}
+		raw, err := fetchGitLabFile(repo, projectID, entry.Path)
+		if err != nil {
+			return nil, err
+		}
+		files[root][strings.TrimPrefix(strings.TrimPrefix(entry.Path, root), "/")] = raw
+	}
+	for root, entries := range files {
+		if _, ok := entries["SKILL.md"]; ok {
+			continue
+		}
+		delete(files, root)
+	}
+	return files, nil
+}
+
+func collectDiscoveredSkillRootsFromTree(payload []struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+}) []string {
+	roots := make([]string, 0)
+	for _, entry := range payload {
+		if entry.Type != "blob" || !strings.HasSuffix(entry.Path, "/SKILL.md") {
+			continue
+		}
+		root := strings.Trim(strings.TrimSuffix(entry.Path, "/SKILL.md"), "/")
+		roots = append(roots, root)
+	}
+	sort.Slice(roots, func(i, j int) bool {
+		if len(roots[i]) == len(roots[j]) {
+			return roots[i] < roots[j]
+		}
+		return len(roots[i]) > len(roots[j])
+	})
+	return roots
+}
+
+func groupDiscoveredSkillFiles(files map[string]string) map[string]map[string]string {
+	roots := make([]string, 0)
+	for filePath := range files {
+		if !strings.HasSuffix(filePath, "/SKILL.md") {
+			continue
+		}
+		root := strings.Trim(strings.TrimSuffix(filePath, "/SKILL.md"), "/")
+		roots = append(roots, root)
+	}
+	sort.Slice(roots, func(i, j int) bool {
+		if len(roots[i]) == len(roots[j]) {
+			return roots[i] < roots[j]
+		}
+		return len(roots[i]) > len(roots[j])
+	})
+	grouped := map[string]map[string]string{}
+	for _, root := range roots {
+		grouped[root] = map[string]string{}
+	}
+	for filePath, raw := range files {
+		root, ok := matchDiscoveredSkillRoot(roots, filePath)
+		if !ok {
+			continue
+		}
+		grouped[root][strings.TrimPrefix(strings.TrimPrefix(filePath, root), "/")] = raw
+	}
+	for root, entries := range grouped {
+		if _, ok := entries["SKILL.md"]; ok {
+			continue
+		}
+		delete(grouped, root)
+	}
+	return grouped
+}
+
+func matchDiscoveredSkillRoot(roots []string, filePath string) (string, bool) {
+	for _, root := range roots {
+		if pathWithinDiscoveredSkill(root, filePath) {
+			return root, true
+		}
+	}
+	return "", false
+}
+
+func hashSkillFiles(files map[string]string) string {
+	if len(files) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(files))
+	for key := range files {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	digest := sha256.New()
+	for _, key := range keys {
+		_, _ = digest.Write([]byte(key))
+		_, _ = digest.Write([]byte{0})
+		_, _ = digest.Write([]byte(files[key]))
+		_, _ = digest.Write([]byte{0})
+	}
+	return fmt.Sprintf("%x", digest.Sum(nil))
+}
+
+func hashSkillDirectory(root string) string {
+	files := map[string]string{}
+	_ = filepath.WalkDir(root, func(current string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if current != root && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, current)
+		if err != nil {
+			return err
+		}
+		if rel == ".aigate-skill.json" {
+			return nil
+		}
+		raw, err := os.ReadFile(current)
+		if err != nil {
+			return err
+		}
+		files[filepath.ToSlash(rel)] = string(raw)
+		return nil
+	})
+	return hashSkillFiles(files)
+}
+
+func buildDiscoveredSkillRecord(repo skillRepoRecord, sourcePath string, files map[string]string, installed map[string]discoveredInstallState) discoveredSkillRecord {
+	sourcePath = strings.Trim(sourcePath, "/")
+	body := files["SKILL.md"]
 	name, description := parseDiscoveredSkillBody(body, sourcePath)
 	key := discoveredSkillKey(repo.Platform, repo.Owner+"/"+repo.Name, repo.Branch, sourcePath)
+	contentHash := hashSkillFiles(files)
 	record := discoveredSkillRecord{
-		ID:            key,
-		Name:          name,
-		Description:   description,
-		Platform:      repo.Platform,
-		RepoOwner:     repo.Owner,
-		RepoName:      repo.Name,
-		Branch:        repo.Branch,
-		RepoURL:       buildRepoURL(repo.Platform, repo.Owner, repo.Name),
-		SourcePath:    sourcePath,
-		SourceURL:     buildRepoTreeURL(repo.Platform, repo.Owner, repo.Name, repo.Branch, sourcePath),
-		ManagedName:   buildDiscoveredManagedName(repo, sourcePath),
-		InstalledApps: map[string]bool{},
+		ID:              key,
+		Name:            name,
+		Description:     description,
+		Platform:        repo.Platform,
+		RepoOwner:       repo.Owner,
+		RepoName:        repo.Name,
+		Branch:          repo.Branch,
+		RepoURL:         buildRepoURL(repo.Platform, repo.Owner, repo.Name),
+		SourcePath:      sourcePath,
+		SourceURL:       buildRepoTreeURL(repo.Platform, repo.Owner, repo.Name, repo.Branch, sourcePath),
+		ManagedName:     buildDiscoveredManagedName(repo, sourcePath),
+		ContentHash:     contentHash,
+		InstalledApps:   map[string]bool{},
+		UpdateAvailable: false,
 	}
-	if apps, ok := installed[key]; ok {
-		for app, enabled := range apps {
+	if state, ok := installed[key]; ok {
+		record.InstalledHash = state.Hash
+		record.UpdateAvailable = state.Hash != "" && contentHash != "" && state.Hash != contentHash
+		for app, enabled := range state.Apps {
 			record.InstalledApps[app] = enabled
 		}
 	}
@@ -2771,34 +2938,36 @@ func installDiscoveredSkillCollection(home string, id string, method string, app
 	})
 	managedName := buildDiscoveredManagedName(repo, sourcePath)
 	targetDir := filepath.Join(managedSkillsRoot(home), managedName)
-	if !pathExists(targetDir) {
-		files, err := fetchDiscoveredSkillFiles(repo, sourcePath)
-		if err != nil {
+	files, err := fetchDiscoveredSkillFiles(repo, sourcePath)
+	if err != nil {
+		return 0, err
+	}
+	if len(files) == 0 {
+		return 0, fmt.Errorf("no files found for discovered skill: %s", id)
+	}
+	if err := os.RemoveAll(targetDir); err != nil {
+		return 0, err
+	}
+	for relativePath, raw := range files {
+		fullPath := filepath.Join(targetDir, filepath.FromSlash(relativePath))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 			return 0, err
 		}
-		if len(files) == 0 {
-			return 0, fmt.Errorf("no files found for discovered skill: %s", id)
-		}
-		for relativePath, raw := range files {
-			fullPath := filepath.Join(targetDir, filepath.FromSlash(relativePath))
-			if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
-				return 0, err
-			}
-			if err := os.WriteFile(fullPath, []byte(raw), 0o644); err != nil {
-				return 0, err
-			}
-		}
-		if err := writeSkillMetadata(targetDir, skillMetadata{
-			Name:       managedName,
-			SourceRepo: repoFullName,
-			SourceKind: "discovered",
-			Platform:   repo.Platform,
-			Branch:     repo.Branch,
-			SourcePath: sourcePath,
-			SourceURL:  buildRepoTreeURL(repo.Platform, repo.Owner, repo.Name, repo.Branch, sourcePath),
-		}); err != nil {
+		if err := os.WriteFile(fullPath, []byte(raw), 0o644); err != nil {
 			return 0, err
 		}
+	}
+	if err := writeSkillMetadata(targetDir, skillMetadata{
+		Name:         managedName,
+		SourceRepo:   repoFullName,
+		SourceKind:   "discovered",
+		Platform:     repo.Platform,
+		Branch:       repo.Branch,
+		SourcePath:   sourcePath,
+		SourceURL:    buildRepoTreeURL(repo.Platform, repo.Owner, repo.Name, repo.Branch, sourcePath),
+		UpstreamHash: hashSkillFiles(files),
+	}); err != nil {
+		return 0, err
 	}
 	return applyManagedSkillCollection(home, managedName, method, apps)
 }

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -798,18 +798,20 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 		"fetched_at": "2026-04-08T10:00:00Z",
 		"items": []map[string]any{
 			{
-				"id":             "github:openai/codex-skills:skills/cached",
-				"name":           "Cached Skill",
-				"description":    "Cached summary",
-				"platform":       "github",
-				"repo_owner":     "openai",
-				"repo_name":      "codex-skills",
-				"branch":         "main",
-				"repo_url":       "https://github.com/openai/codex-skills",
-				"source_path":    "skills/cached",
-				"source_url":     "https://github.com/openai/codex-skills/tree/main/skills/cached",
-				"managed_name":   "cached-skill",
-				"installed_apps": map[string]bool{"codex": false},
+				"id":               "github:openai/codex-skills:skills/cached",
+				"name":             "Cached Skill",
+				"description":      "Cached summary",
+				"platform":         "github",
+				"repo_owner":       "openai",
+				"repo_name":        "codex-skills",
+				"branch":           "main",
+				"repo_url":         "https://github.com/openai/codex-skills",
+				"source_path":      "skills/cached",
+				"source_url":       "https://github.com/openai/codex-skills/tree/main/skills/cached",
+				"managed_name":     "cached-skill",
+				"content_hash":     "cached-hash",
+				"installed_apps":   map[string]bool{"codex": false},
+				"update_available": false,
 			},
 		},
 	})
@@ -844,6 +846,9 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 	if refreshedItems[0].(map[string]any)["name"] != "Alpha Skill" || refreshedItems[1].(map[string]any)["name"] != "Zulu Skill" {
 		t.Fatalf("refreshed item order = %v, want alpha then zulu", refreshedPayload["items"])
 	}
+	if strings.TrimSpace(refreshedItems[0].(map[string]any)["content_hash"].(string)) == "" {
+		t.Fatalf("refreshed item content_hash = %v, want non-empty hash", refreshedItems[0].(map[string]any)["content_hash"])
+	}
 
 	cacheRaw := readSkillDiscoveryCacheRaw(t, home)
 	if !strings.Contains(cacheRaw, "Alpha Skill") {
@@ -851,6 +856,91 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 	}
 	if strings.Contains(cacheRaw, "Detailed alpha body that must not be cached.") || strings.Contains(cacheRaw, "UNIQUE-ZULU-BODY") {
 		t.Fatalf("cache raw = %s, want index-only cache without full body content", cacheRaw)
+	}
+}
+
+func TestToolingHandlerDiscoverSkillsMarksInstalledUpdatesByHash(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
+		"skills/alpha/SKILL.md":          "# Alpha Skill\nNew upstream summary.\n",
+		"skills/alpha/assets/config.txt": "v2\n",
+		"skills/zulu/SKILL.md":           "# Zulu Skill\nStable upstream summary.\n",
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("AIGATE_GITHUB_ARCHIVE_BASE", server.URL)
+
+	writeToolingConfig(t, home, map[string]any{
+		"skill_sync_method": "symlink",
+		"skill_repos": []map[string]any{
+			{
+				"platform": "github",
+				"owner":    "openai",
+				"name":     "codex-skills",
+				"branch":   "main",
+				"enabled":  true,
+			},
+		},
+		"mcp_servers": []any{},
+	})
+
+	managedRoot := filepath.Join(home, ".aigate", "data", "tooling", "skills", "codex-skills-alpha")
+	if err := os.MkdirAll(filepath.Join(managedRoot, "assets"), 0o755); err != nil {
+		t.Fatalf("MkdirAll managed assets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(managedRoot, "SKILL.md"), []byte("# Alpha Skill\nOld local summary.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile managed SKILL: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(managedRoot, "assets", "config.txt"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile managed asset: %v", err)
+	}
+	if err := writeSkillMetadataForTest(managedRoot, map[string]any{
+		"name":        "codex-skills-alpha",
+		"source_repo": "openai/codex-skills",
+		"source_kind": "discovered",
+		"platform":    "github",
+		"branch":      "main",
+		"source_path": "skills/alpha",
+		"source_url":  "https://github.com/openai/codex-skills/tree/main/skills/alpha",
+	}); err != nil {
+		t.Fatalf("writeSkillMetadata: %v", err)
+	}
+	codexRoot := filepath.Join(home, ".codex", "skills", "codex-skills-alpha")
+	if err := copyDirForTest(managedRoot, codexRoot); err != nil {
+		t.Fatalf("copyDir codex skill: %v", err)
+	}
+
+	handler := api.NewToolingHandler()
+	refreshed := doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/refresh", bytes.NewBufferString(`{}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
+
+	var payload map[string]any
+	if err := json.Unmarshal(refreshed, &payload); err != nil {
+		t.Fatalf("unmarshal refreshed discover payload: %v", err)
+	}
+	items := payload["items"].([]any)
+	alpha := items[0].(map[string]any)
+	if alpha["name"] != "Alpha Skill" {
+		t.Fatalf("first item = %v, want Alpha Skill", alpha["name"])
+	}
+	if alpha["installed_apps"].(map[string]any)["codex"] != true {
+		t.Fatalf("installed_apps = %v, want codex true", alpha["installed_apps"])
+	}
+	if alpha["update_available"] != true {
+		t.Fatalf("update_available = %v, want true", alpha["update_available"])
+	}
+	if alpha["installed_hash"] == alpha["content_hash"] {
+		t.Fatalf("installed_hash = %v, content_hash = %v, want differing hashes", alpha["installed_hash"], alpha["content_hash"])
 	}
 }
 
@@ -966,6 +1056,70 @@ func TestToolingHandlerCanInstallDiscoveredSkillIntoManagedAndCodexDirs(t *testi
 	}
 }
 
+func TestToolingHandlerInstallDiscoveredSkillUpdatesExistingManagedFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
+		"skills/alpha/SKILL.md":          "# Alpha Skill\nUpdated summary.\n",
+		"skills/alpha/assets/config.txt": "v2\n",
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("AIGATE_GITHUB_ARCHIVE_BASE", server.URL)
+
+	managedRoot := filepath.Join(home, ".aigate", "data", "tooling", "skills", "codex-skills-alpha")
+	if err := os.MkdirAll(filepath.Join(managedRoot, "assets"), 0o755); err != nil {
+		t.Fatalf("MkdirAll managed assets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(managedRoot, "SKILL.md"), []byte("# Alpha Skill\nOld summary.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile managed SKILL: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(managedRoot, "stale.txt"), []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile stale file: %v", err)
+	}
+	if err := writeSkillMetadataForTest(managedRoot, map[string]any{
+		"name":        "codex-skills-alpha",
+		"source_repo": "openai/codex-skills",
+		"source_kind": "discovered",
+		"platform":    "github",
+		"branch":      "main",
+		"source_path": "skills/alpha",
+		"source_url":  "https://github.com/openai/codex-skills/tree/main/skills/alpha",
+	}); err != nil {
+		t.Fatalf("writeSkillMetadata: %v", err)
+	}
+
+	handler := api.NewToolingHandler()
+	doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/install", bytes.NewBufferString(`{
+		"id":"github:openai/codex-skills:main:skills/alpha",
+		"apps":["codex"]
+	}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
+
+	raw, err := os.ReadFile(filepath.Join(managedRoot, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("ReadFile updated SKILL: %v", err)
+	}
+	if !strings.Contains(string(raw), "Updated summary.") {
+		t.Fatalf("updated SKILL = %s, want updated summary", string(raw))
+	}
+	if _, err := os.Stat(filepath.Join(managedRoot, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale file should be removed on update, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "codex-skills-alpha", "assets", "config.txt")); err != nil {
+		t.Fatalf("expected synced updated asset in codex dir: %v", err)
+	}
+}
+
 func makeGitHubArchiveZip(t *testing.T, root string, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -1013,6 +1167,44 @@ func seedSkill(t *testing.T, dir, body string) {
 	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
 		t.Fatalf("WriteFile skill: %v", err)
 	}
+}
+
+func copyDirForTest(source string, target string) error {
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		return err
+	}
+	return filepath.WalkDir(source, func(current string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(source, current)
+		if err != nil {
+			return err
+		}
+		dst := filepath.Join(target, rel)
+		if d.IsDir() {
+			if rel == "." {
+				return nil
+			}
+			return os.MkdirAll(dst, 0o755)
+		}
+		raw, err := os.ReadFile(current)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(dst, raw, 0o644)
+	})
+}
+
+func writeSkillMetadataForTest(dir string, payload map[string]any) error {
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, ".aigate-skill.json"), append(raw, '\n'), 0o600)
 }
 
 func writeToolingConfig(t *testing.T, home string, payload map[string]any) {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -148,7 +148,9 @@ function buildDiscoveredSkillResponse(overrides?: Partial<api.ToolingSkillDiscov
         source_path: "skills/zulu",
         source_url: "https://github.com/openai/codex-skills/tree/main/skills/zulu",
         managed_name: "codex-skills-zulu",
+        content_hash: "hash-zulu-v1",
         installed_apps: { codex: false },
+        update_available: false,
       },
       {
         id: "github:openai/codex-skills:main:skills/alpha",
@@ -162,7 +164,9 @@ function buildDiscoveredSkillResponse(overrides?: Partial<api.ToolingSkillDiscov
         source_path: "skills/alpha",
         source_url: "https://github.com/openai/codex-skills/tree/main/skills/alpha",
         managed_name: "codex-skills-alpha",
+        content_hash: "hash-alpha-v1",
         installed_apps: { codex: false },
+        update_available: false,
       },
     ],
     ...overrides,
@@ -367,6 +371,27 @@ describe("ToolingPage", () => {
 
   it("supports manual refresh, viewing source repo, and installing a discovered skill", async () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    vi.mocked((api as typeof api & { getToolingState: typeof vi.fn }).getToolingState)
+      .mockResolvedValueOnce(buildToolingState())
+      .mockImplementation(() => new Promise(() => {}));
+    vi.mocked((api as typeof api & { refreshToolingDiscoveredSkills: typeof vi.fn }).refreshToolingDiscoveredSkills)
+      .mockResolvedValueOnce(
+        buildDiscoveredSkillResponse({
+          cached: false,
+          fetched_at: "2026-04-08T10:01:00Z",
+          items: [
+            {
+              ...buildDiscoveredSkillResponse().items[1],
+              description: "Latest alpha summary",
+            },
+            {
+              ...buildDiscoveredSkillResponse().items[0],
+              description: "Latest zulu summary",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() => new Promise(() => {}));
 
     render(<ToolingPage mode="skills" t={(text) => text} />);
 
@@ -381,7 +406,10 @@ describe("ToolingPage", () => {
     );
 
     fireEvent.click(within(dialog).getByRole("button", { name: "查看 Alpha Skill 的仓库页面" }));
-    expect(openSpy).toHaveBeenCalledWith("https://github.com/openai/codex-skills", "_blank", "noopener,noreferrer");
+    expect(openSpy).toHaveBeenCalledWith("https://github.com/openai/codex-skills/tree/main/skills/alpha", "_blank", "noopener,noreferrer");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "打开 Alpha Skill 的源目录" }));
+    expect(openSpy).toHaveBeenCalledWith("https://github.com/openai/codex-skills/tree/main/skills/alpha", "_blank", "noopener,noreferrer");
 
     fireEvent.click(within(dialog).getByRole("button", { name: "安装 Alpha Skill" }));
     await waitFor(() =>
@@ -390,6 +418,56 @@ describe("ToolingPage", () => {
         apps: ["codex"],
       }),
     );
+    await waitFor(() =>
+      expect(within(dialog).getByRole("button", { name: "已安装 Alpha Skill" })).toBeDisabled(),
+    );
+  });
+
+  it("distinguishes install states in discovered skill cards", async () => {
+    vi.mocked((api as typeof api & { getToolingDiscoveredSkills: typeof vi.fn }).getToolingDiscoveredSkills).mockResolvedValue(
+      buildDiscoveredSkillResponse({
+        items: [
+          {
+            ...buildDiscoveredSkillResponse().items[1],
+            installed_apps: { codex: true },
+            update_available: true,
+          },
+          {
+            ...buildDiscoveredSkillResponse().items[0],
+            installed_apps: { codex: true },
+            update_available: false,
+          },
+        ],
+      }),
+    );
+    vi.mocked((api as typeof api & { refreshToolingDiscoveredSkills: typeof vi.fn }).refreshToolingDiscoveredSkills).mockResolvedValue(
+      buildDiscoveredSkillResponse({
+        cached: false,
+        items: [
+          {
+            ...buildDiscoveredSkillResponse().items[1],
+            installed_apps: { codex: true },
+            update_available: true,
+          },
+          {
+            ...buildDiscoveredSkillResponse().items[0],
+            installed_apps: { codex: true },
+            update_available: false,
+          },
+        ],
+      }),
+    );
+
+    render(<ToolingPage mode="skills" t={(text) => text} />);
+
+    await screen.findByText("Skill 技能");
+    fireEvent.click(screen.getByRole("button", { name: /发现技能/ }));
+
+    const dialog = await screen.findByRole("dialog", { name: "发现技能" });
+    expect(within(dialog).getByText("可更新")).toBeInTheDocument();
+    expect(within(dialog).getAllByText("已安装").length).toBeGreaterThan(0);
+    expect(within(dialog).getByRole("button", { name: "更新 Alpha Skill" })).toBeEnabled();
+    expect(within(dialog).getByRole("button", { name: "已安装 Zulu Skill" })).toBeDisabled();
   });
 
   it("manages repositories in a secondary modal with create, update, and delete actions", async () => {

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -318,11 +318,19 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     setDiscoveryBusyId(skill.id);
     try {
       await installToolingDiscoveredSkill({ id: skill.id, apps: ["codex"] });
-      void messageApi.success(t("安装成功"));
-      await reload({ background: true });
-      const response = await refreshToolingDiscoveredSkills();
-      setDiscoveryResponse(sortDiscoveryResponse(response));
-      setDiscoveryStatus(t("已更新"));
+      const nextAction = skill.update_available ? t("已更新") : t("安装成功");
+      setDiscoveryResponse((current) => markDiscoveredSkillInstalled(current, skill.id));
+      setDiscoveryStatus(skill.update_available ? t("已更新") : t("已安装"));
+      void messageApi.success(nextAction);
+      void reload({ background: true });
+      void refreshToolingDiscoveredSkills()
+        .then((response) => {
+          setDiscoveryResponse(sortDiscoveryResponse(response));
+          setDiscoveryStatus(t("已更新"));
+        })
+        .catch((error) => {
+          void messageApi.error(error instanceof Error ? error.message : t("刷新发现技能失败"));
+        });
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("安装失败"));
     } finally {
@@ -331,7 +339,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   }
 
   function handleViewDiscoveredSkill(skill: ToolingDiscoveredSkill) {
-    window.open(skill.repo_url, "_blank", "noopener,noreferrer");
+    window.open(skill.source_url, "_blank", "noopener,noreferrer");
   }
 
   async function handleRepoAdd() {
@@ -538,6 +546,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
                   key={skill.id}
                   skill={skill}
                   busy={discoveryBusyId === skill.id}
+                  t={t}
                   onView={() => handleViewDiscoveredSkill(skill)}
                   onInstall={() => void handleDiscoveredSkillInstall(skill)}
                 />
@@ -632,6 +641,32 @@ function sortDiscoveryResponse(response: ToolingSkillDiscoveryResponse): Tooling
   };
 }
 
+function markDiscoveredSkillInstalled(
+  response: ToolingSkillDiscoveryResponse | null,
+  id: string,
+): ToolingSkillDiscoveryResponse | null {
+  if (!response) {
+    return response;
+  }
+  return {
+    ...response,
+    items: response.items.map((item) => {
+      if (item.id !== id) {
+        return item;
+      }
+      return {
+        ...item,
+        installed_apps: {
+          ...item.installed_apps,
+          codex: true,
+        },
+        installed_hash: item.content_hash,
+        update_available: false,
+      };
+    }),
+  };
+}
+
 function repoRecordKey(platform: string, owner: string, name: string): string {
   return `${platform}:${owner}/${name}`;
 }
@@ -684,31 +719,46 @@ function DeleteMcpConfirmContent({
 function DiscoveredSkillCard({
   skill,
   busy,
+  t,
   onView,
   onInstall,
 }: {
   skill: ToolingDiscoveredSkill;
   busy?: boolean;
+  t: (text: string) => string;
   onView: () => void;
   onInstall: () => void;
 }) {
   const installed = Boolean(skill.installed_apps?.codex);
+  const updateAvailable = installed && Boolean(skill.update_available);
+  const actionLabel = updateAvailable ? t("更新") : installed ? t("已安装") : t("安装");
+  const statusLabel = updateAvailable ? t("可更新") : installed ? t("已安装") : t("未安装");
   return (
     <div className="tooling-discovered-card">
       <div className="tooling-discovered-card-main">
         <div className="tooling-discovered-card-meta">
           <span className="tooling-discovered-platform">{skill.platform.toUpperCase()}</span>
           <span className="tooling-discovered-repo">{`${skill.repo_owner}/${skill.repo_name}`}</span>
+          <span className={`tooling-status-pill ${updateAvailable ? "is-update" : installed ? "is-enabled" : "is-disabled"}`}>{statusLabel}</span>
         </div>
-        <div className="tooling-item-title" data-testid="tooling-discovered-skill-title">{skill.name}</div>
+        <button type="button" className="tooling-discovered-title-button" data-testid="tooling-discovered-skill-title" aria-label={`打开 ${skill.name} 的源目录`} onClick={onView}>
+          {skill.name}
+        </button>
         {skill.description ? <div className="tooling-item-description is-default">{skill.description}</div> : null}
       </div>
       <div className="tooling-discovered-card-actions">
         <Button icon={<LinkOutlined />} aria-label={`查看 ${skill.name} 的仓库页面`} onClick={onView}>
-          查看
+          {t("查看")}
         </Button>
-        <Button type="primary" icon={<PlusOutlined />} loading={busy} disabled={installed} aria-label={`安装 ${skill.name}`} onClick={onInstall}>
-          {installed ? "已安装" : "安装"}
+        <Button
+          type="primary"
+          icon={updateAvailable ? <ReloadOutlined /> : <PlusOutlined />}
+          loading={busy}
+          disabled={installed && !updateAvailable}
+          aria-label={`${actionLabel} ${skill.name}`}
+          onClick={onInstall}
+        >
+          {actionLabel}
         </Button>
       </div>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -299,7 +299,10 @@ export type ToolingDiscoveredSkill = {
   source_path: string;
   source_url: string;
   managed_name: string;
+  content_hash?: string;
+  installed_hash?: string;
   installed_apps: Record<string, boolean>;
+  update_available?: boolean;
 };
 
 export type ToolingSkillDiscoveryResponse = {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -571,6 +571,12 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   opacity: 0.55;
 }
 
+.tooling-status-pill.is-update {
+  color: #9a3412;
+  border-color: rgba(249, 115, 22, 0.24);
+  background: rgba(249, 115, 22, 0.1);
+}
+
 .tooling-item-primary-action,
 .tooling-item-icon-action {
   appearance: none;
@@ -764,6 +770,23 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.tooling-discovered-title-button {
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.35;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tooling-discovered-title-button:hover {
+  color: #2f49c8;
 }
 
 .tooling-repo-manager-shell {


### PR DESCRIPTION
## Summary\n- fix discovered skill view links so both the title and view button open the skill source directory\n- settle install state immediately and surface install/update states in discovery cards\n- compare discovered skill content hashes with installed hashes to surface available updates\n\n## Verification\n- go test ./...\n- npm test -- --run\n- npm run build\n- cargo test