### PR TITLE
release: cut v1.2.7 for tooling repo UX + desktop link opener

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -204,6 +204,19 @@ type toolingRepoRequest struct {
 	Branch   string `json:"branch"`
 }
 
+type toolingRepoResolveRequest struct {
+	Input string `json:"input"`
+}
+
+type toolingRepoResolveResponse struct {
+	Platform       string   `json:"platform"`
+	Owner          string   `json:"owner"`
+	Name           string   `json:"name"`
+	RepoURL        string   `json:"repo_url"`
+	BranchOptions  []string `json:"branch_options"`
+	SelectedBranch string   `json:"selected_branch"`
+}
+
 type toolingRepoSearchResponse struct {
 	Items []repoSearchResult `json:"items"`
 }
@@ -251,6 +264,8 @@ func (h *ToolingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.listSkillRepos(w)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/repos":
 		h.addSkillRepo(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/repos/resolve":
+		h.resolveSkillRepo(w, r)
 	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/tooling/skills/repos/"):
 		h.updateSkillRepo(w, r)
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/tooling/skills/repos/"):
@@ -565,6 +580,32 @@ func (h *ToolingHandler) addSkillRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, next)
+}
+
+func (h *ToolingHandler) resolveSkillRepo(w http.ResponseWriter, r *http.Request) {
+	var req toolingRepoResolveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resolved, err := parseToolingRepoInput(req.Input)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	branches, selectedBranch, err := resolveSkillRepoBranches(resolved.Platform, resolved.Owner, resolved.Name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, toolingRepoResolveResponse{
+		Platform:       resolved.Platform,
+		Owner:          resolved.Owner,
+		Name:           resolved.Name,
+		RepoURL:        buildRepoURL(resolved.Platform, resolved.Owner, resolved.Name),
+		BranchOptions:  branches,
+		SelectedBranch: selectedBranch,
+	})
 }
 
 func (h *ToolingHandler) updateSkillRepo(w http.ResponseWriter, r *http.Request) {
@@ -1171,6 +1212,197 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func parseToolingRepoInput(input string) (skillRepoRecord, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return skillRepoRecord{}, errors.New("repo input is required")
+	}
+	if !strings.Contains(trimmed, "://") {
+		if strings.HasPrefix(strings.ToLower(trimmed), "github.com/") || strings.HasPrefix(strings.ToLower(trimmed), "gitlab.com/") {
+			trimmed = "https://" + trimmed
+		}
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return skillRepoRecord{}, fmt.Errorf("invalid repo url: %w", err)
+	}
+	host := strings.ToLower(strings.TrimPrefix(parsed.Hostname(), "www."))
+	var platform string
+	switch host {
+	case "github.com":
+		platform = "github"
+	case "gitlab.com":
+		platform = "gitlab"
+	default:
+		return skillRepoRecord{}, fmt.Errorf("unsupported repo host: %s", host)
+	}
+	segments := strings.FieldsFunc(strings.Trim(parsed.Path, "/"), func(r rune) bool {
+		return r == '/'
+	})
+	if len(segments) < 2 {
+		return skillRepoRecord{}, errors.New("repo url must include owner and name")
+	}
+	owner := strings.TrimSpace(segments[0])
+	name := strings.TrimSuffix(strings.TrimSpace(segments[1]), ".git")
+	if owner == "" || name == "" {
+		return skillRepoRecord{}, errors.New("repo url must include owner and name")
+	}
+	return normalizeSkillRepoRecord(skillRepoRecord{
+		Platform: platform,
+		Owner:    owner,
+		Name:     name,
+	}), nil
+}
+
+func resolveSkillRepoBranches(platform string, owner string, name string) ([]string, string, error) {
+	switch normalizeSkillRepoPlatform(platform) {
+	case "gitlab":
+		return resolveGitLabRepoBranches(owner, name)
+	default:
+		return resolveGitHubRepoBranches(owner, name)
+	}
+}
+
+func resolveGitHubRepoBranches(owner string, name string) ([]string, string, error) {
+	defaultBranch, err := fetchGitHubDefaultBranch(owner, name)
+	if err != nil {
+		return nil, "", err
+	}
+	req, err := newGitHubAPIRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/%s/branches", githubAPIBase(), url.PathEscape(owner), url.PathEscape(name)))
+	if err != nil {
+		return nil, "", err
+	}
+	params := req.URL.Query()
+	params.Set("per_page", "100")
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, "", describeGitHubHTTPError("branches", resp)
+	}
+	var payload []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, "", err
+	}
+	branches := make([]string, 0, len(payload))
+	for _, item := range payload {
+		if name := strings.TrimSpace(item.Name); name != "" {
+			branches = append(branches, name)
+		}
+	}
+	selected := selectPreferredBranch(branches, defaultBranch)
+	return uniqueStrings(branches), selected, nil
+}
+
+func fetchGitHubDefaultBranch(owner string, name string) (string, error) {
+	req, err := newGitHubAPIRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/%s", githubAPIBase(), url.PathEscape(owner), url.PathEscape(name)))
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", describeGitHubHTTPError("repo", resp)
+	}
+	var payload struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(payload.DefaultBranch), nil
+}
+
+func resolveGitLabRepoBranches(owner string, name string) ([]string, string, error) {
+	projectID := url.PathEscape(owner + "/" + name)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/projects/%s/repository/branches", gitlabAPIBase(), projectID), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	params := req.URL.Query()
+	params.Set("per_page", "100")
+	req.URL.RawQuery = params.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("gitlab branches failed: %s", resp.Status)
+	}
+	var payload []struct {
+		Name    string `json:"name"`
+		Default bool   `json:"default"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, "", err
+	}
+	branches := make([]string, 0, len(payload))
+	defaultBranch := ""
+	for _, item := range payload {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		branches = append(branches, name)
+		if item.Default && defaultBranch == "" {
+			defaultBranch = name
+		}
+	}
+	selected := selectPreferredBranch(branches, defaultBranch)
+	return uniqueStrings(branches), selected, nil
+}
+
+func selectPreferredBranch(branches []string, fallback string) string {
+	candidates := uniqueStrings(branches)
+	for _, preferred := range []string{"main", "master"} {
+		for _, branch := range candidates {
+			if strings.EqualFold(branch, preferred) {
+				return branch
+			}
+		}
+	}
+	fallback = strings.TrimSpace(fallback)
+	if fallback != "" {
+		for _, branch := range candidates {
+			if strings.EqualFold(branch, fallback) {
+				return branch
+			}
+		}
+		return fallback
+	}
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+	return "main"
+}
+
+func uniqueStrings(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
 }
 
 func buildSkillStats(skills []managedSkillRecord) skillStatsResponse {

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -352,6 +352,103 @@ func TestToolingHandlerDeletesSingleSkillCollectionEverywhere(t *testing.T) {
 	}
 }
 
+func TestToolingHandlerResolvesGitHubRepoAndPrefersMainBranch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	githubAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/openai/codex-superpowers":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"default_branch":"release"}`))
+		case "/repos/openai/codex-superpowers/branches":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"name":"release"},{"name":"main"},{"name":"develop"}]`))
+		default:
+			t.Fatalf("unexpected github path: %s", r.URL.Path)
+		}
+	}))
+	defer githubAPI.Close()
+	t.Setenv("AIGATE_GITHUB_API_BASE", githubAPI.URL)
+
+	handler := api.NewToolingHandler()
+
+	resp := doToolingRequest(
+		t,
+		handler,
+		http.MethodPost,
+		"/tooling/skills/repos/resolve",
+		bytes.NewBufferString(`{"input":"https://github.com/openai/codex-superpowers/tree/release"}`),
+		map[string]string{"Content-Type": "application/json"},
+		http.StatusOK,
+	)
+
+	var payload map[string]any
+	if err := json.Unmarshal(resp, &payload); err != nil {
+		t.Fatalf("unmarshal resolve response: %v", err)
+	}
+	if got := payload["platform"]; got != "github" {
+		t.Fatalf("platform = %v, want github", got)
+	}
+	if got := payload["owner"]; got != "openai" {
+		t.Fatalf("owner = %v, want openai", got)
+	}
+	if got := payload["name"]; got != "codex-superpowers" {
+		t.Fatalf("name = %v, want codex-superpowers", got)
+	}
+	if got := payload["repo_url"]; got != "https://github.com/openai/codex-superpowers" {
+		t.Fatalf("repo_url = %v, want github repo url", got)
+	}
+	if got := payload["selected_branch"]; got != "main" {
+		t.Fatalf("selected_branch = %v, want main", got)
+	}
+	options := payload["branch_options"].([]any)
+	if len(options) != 3 {
+		t.Fatalf("branch_options = %v, want 3 branches", payload["branch_options"])
+	}
+}
+
+func TestToolingHandlerResolvesGitLabRepoAndFallsBackToDefaultBranch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	gitlabAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.RequestURI(), "/projects/gitlab-org%2Fcodex-superpowers/repository/branches") {
+			t.Fatalf("unexpected gitlab request: %s", r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"release","default":true},{"name":"feature-demo","default":false}]`))
+	}))
+	defer gitlabAPI.Close()
+	t.Setenv("AIGATE_GITLAB_API_BASE", gitlabAPI.URL)
+
+	handler := api.NewToolingHandler()
+
+	resp := doToolingRequest(
+		t,
+		handler,
+		http.MethodPost,
+		"/tooling/skills/repos/resolve",
+		bytes.NewBufferString(`{"input":"gitlab.com/gitlab-org/codex-superpowers.git"}`),
+		map[string]string{"Content-Type": "application/json"},
+		http.StatusOK,
+	)
+
+	var payload map[string]any
+	if err := json.Unmarshal(resp, &payload); err != nil {
+		t.Fatalf("unmarshal resolve response: %v", err)
+	}
+	if got := payload["platform"]; got != "gitlab" {
+		t.Fatalf("platform = %v, want gitlab", got)
+	}
+	if got := payload["repo_url"]; got != "https://gitlab.com/gitlab-org/codex-superpowers" {
+		t.Fatalf("repo_url = %v, want gitlab repo url", got)
+	}
+	if got := payload["selected_branch"]; got != "release" {
+		t.Fatalf("selected_branch = %v, want release", got)
+	}
+}
+
 func TestToolingHandlerInstallAndApplyMcpServer(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -31,6 +31,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tokio",
@@ -93,6 +94,137 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -173,6 +305,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -374,6 +519,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -721,6 +875,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +933,27 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -914,6 +1116,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1326,6 +1541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1872,25 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2189,6 +2429,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2451,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "osakit"
@@ -2240,6 +2502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2529,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2415,6 +2689,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,6 +2748,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3386,6 +3685,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,6 +4087,28 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
 ]
 
 [[package]]
@@ -4251,7 +4582,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4302,6 +4645,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5414,6 +5768,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5524,4 +5939,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
 ]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.6"
+version = "1.2.7"
 edition = "2021"
 
 [build-dependencies]
@@ -9,6 +9,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-process = "2"
+tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 once_cell = "1"
 serde = { version = "1", features = ["derive"] }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "main-capability",
   "description": "Main window capability for AI Gate desktop shell",
   "windows": ["main"],
-  "permissions": ["core:default", "process:default", "updater:default"]
+  "permissions": ["core:default", "process:default", "opener:default", "updater:default"]
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -393,6 +393,7 @@ fn main() {
     APP_EXITING.store(false, Ordering::SeqCst);
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             force_exit_app,

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-opener": "^2.5.3",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "antd": "^6.3.1",
@@ -2200,6 +2201,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
+      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-process": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -15,6 +15,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "antd": "^6.3.1",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../../lib/api", async () => {
     refreshToolingDiscoveredSkills: vi.fn(),
     installToolingDiscoveredSkill: vi.fn(),
     searchToolingRepos: vi.fn(),
+    resolveToolingRepo: vi.fn(),
     addToolingRepo: vi.fn(),
     updateToolingRepo: vi.fn(),
     removeToolingRepo: vi.fn(),
@@ -213,6 +214,26 @@ describe("ToolingPage", () => {
       skill_sync_method: "symlink",
     });
     vi.mocked(api.searchToolingRepos).mockResolvedValue({ items: [] });
+    vi.mocked((api as typeof api & { resolveToolingRepo: typeof vi.fn }).resolveToolingRepo).mockImplementation(async (input: string) => {
+      if (input.includes("gitlab.com")) {
+        return {
+          platform: "gitlab",
+          owner: "gitlab-org",
+          name: "codex-superpowers",
+          repo_url: "https://gitlab.com/gitlab-org/codex-superpowers",
+          branch_options: ["main", "master", "develop"],
+          selected_branch: "main",
+        };
+      }
+      return {
+        platform: "github",
+        owner: "openai",
+        name: "codex-superpowers",
+        repo_url: "https://github.com/openai/codex-superpowers",
+        branch_options: ["main", "release"],
+        selected_branch: "main",
+      };
+    });
     vi.mocked(api.addToolingRepo).mockResolvedValue({
       platform: "github",
       owner: "openai",
@@ -470,7 +491,8 @@ describe("ToolingPage", () => {
     expect(within(dialog).getByRole("button", { name: "已安装 Zulu Skill" })).toBeDisabled();
   });
 
-  it("manages repositories in a secondary modal with create, update, and delete actions", async () => {
+  it("manages repositories with a compact list, hover actions, and a tertiary add/edit modal", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
     render(<ToolingPage mode="skills" t={(text) => text} />);
 
     await screen.findByText("Skill 技能");
@@ -480,19 +502,35 @@ describe("ToolingPage", () => {
     fireEvent.click(within(discoverDialog).getByRole("button", { name: "仓库管理" }));
 
     const repoDialog = (await screen.findAllByRole("dialog")).at(-1)!;
-    fireEvent.change(within(repoDialog).getByLabelText("仓库平台"), { target: { value: "gitlab" } });
-    fireEvent.change(within(repoDialog).getByLabelText("仓库归属"), { target: { value: "gitlab-org" } });
-    fireEvent.change(within(repoDialog).getByLabelText("仓库名称"), { target: { value: "codex-superpowers" } });
-    fireEvent.change(within(repoDialog).getByLabelText("分支"), { target: { value: "develop" } });
+    expect(within(repoDialog).queryByLabelText("仓库平台")).not.toBeInTheDocument();
+    expect(within(repoDialog).getByText("openai/codex-superpowers")).toBeInTheDocument();
+    expect(within(repoDialog).getByText("12 skills · https://github.com/openai/codex-superpowers")).toBeInTheDocument();
+
     fireEvent.click(within(repoDialog).getByRole("button", { name: "添加仓库" }));
+
+    const createDialog = (await screen.findAllByRole("dialog")).at(-1)!;
+    fireEvent.change(within(createDialog).getByLabelText("仓库链接"), { target: { value: "https://gitlab.com/gitlab-org/codex-superpowers" } });
+
+    await waitFor(() =>
+      expect(vi.mocked((api as typeof api & { resolveToolingRepo: typeof vi.fn }).resolveToolingRepo)).toHaveBeenCalledWith(
+        "https://gitlab.com/gitlab-org/codex-superpowers",
+      ),
+    );
+
+    fireEvent.change(within(createDialog).getByLabelText("分支"), { target: { value: "develop" } });
+    fireEvent.click(within(createDialog).getByRole("button", { name: "确认添加仓库" }));
 
     await waitFor(() => expect(api.addToolingRepo).toHaveBeenCalledWith("gitlab", "gitlab-org", "codex-superpowers", "develop"));
 
+    fireEvent.click(within(repoDialog).getByRole("button", { name: "查看 openai/codex-superpowers" }));
+    expect(openSpy).toHaveBeenCalledWith("https://github.com/openai/codex-superpowers", "_blank", "noopener,noreferrer");
+
     fireEvent.click(within(repoDialog).getByRole("button", { name: "编辑 openai/codex-superpowers" }));
-    fireEvent.change(within(repoDialog).getByLabelText("仓库平台"), { target: { value: "gitlab" } });
-    fireEvent.change(within(repoDialog).getByLabelText("仓库归属"), { target: { value: "gitlab-org" } });
-    fireEvent.change(within(repoDialog).getByLabelText("分支"), { target: { value: "develop" } });
-    fireEvent.click(within(repoDialog).getByRole("button", { name: "保存仓库" }));
+
+    const editDialog = (await screen.findAllByRole("dialog")).at(-1)!;
+    expect(within(editDialog).getByDisplayValue("https://github.com/openai/codex-superpowers")).toBeDisabled();
+    fireEvent.change(within(editDialog).getByLabelText("分支"), { target: { value: "release" } });
+    fireEvent.click(within(editDialog).getByRole("button", { name: "保存仓库" }));
 
     await waitFor(() =>
       expect(vi.mocked((api as typeof api & { updateToolingRepo: typeof vi.fn }).updateToolingRepo)).toHaveBeenCalledWith(
@@ -500,17 +538,16 @@ describe("ToolingPage", () => {
         "openai",
         "codex-superpowers",
         {
-          platform: "gitlab",
-          owner: "gitlab-org",
+          platform: "github",
+          owner: "openai",
           name: "codex-superpowers",
-          branch: "develop",
+          branch: "release",
         },
       ),
     );
 
-    const refreshedRepoDialog = (await screen.findAllByRole("dialog")).at(-1)!;
-    await waitFor(() => expect(within(refreshedRepoDialog).getByRole("button", { name: "移除 openai/codex-superpowers" })).not.toBeDisabled());
-    fireEvent.click(within(refreshedRepoDialog).getByRole("button", { name: "移除 openai/codex-superpowers" }));
+    await waitFor(() => expect(within(repoDialog).getByRole("button", { name: "删除 openai/codex-superpowers" })).not.toBeDisabled());
+    fireEvent.click(within(repoDialog).getByRole("button", { name: "删除 openai/codex-superpowers" }));
     await waitFor(() => expect(api.removeToolingRepo).toHaveBeenCalledWith("github", "openai", "codex-superpowers"));
   });
 

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -9,7 +9,7 @@ import {
   SearchOutlined,
 } from "@ant-design/icons";
 import { Button, Card, Checkbox, Empty, Input, Modal, Space, Spin, Typography, message } from "antd";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   addToolingRepo,
@@ -22,17 +22,20 @@ import {
   importToolingSkills,
   installToolingDiscoveredSkill,
   removeToolingRepo,
+  resolveToolingRepo,
   refreshToolingDiscoveredSkills,
   updateToolingSkill,
   updateToolingRepo,
   type ToolingDiscoveredSkill,
   type ToolingMcpServer,
+  type ToolingResolvedRepo,
   type ToolingSkillRecord,
   type ToolingSkillRepo,
   type ToolingSkillDiscoveryResponse,
   type ToolingState,
 } from "../../lib/api";
 import sourceOpenAIIcon from "../../assets/providers/openai.png";
+import { openExternalUrl } from "../../lib/desktop-shell";
 
 type ToolingMode = "skills" | "mcp";
 
@@ -49,6 +52,17 @@ type ManagedClientDescriptor = {
 
 type ManagedClientStatus = ManagedClientDescriptor & {
   enabled: boolean;
+};
+
+type RepoEditorMode = "create" | "edit";
+
+type RepoEditorForm = {
+  input: string;
+  platform: "github" | "gitlab";
+  owner: string;
+  name: string;
+  branch: string;
+  branchOptions: string[];
 };
 
 const managedClients: ManagedClientDescriptor[] = [
@@ -73,18 +87,13 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   const [discoveryBusyId, setDiscoveryBusyId] = useState<string | null>(null);
   const [importBusy, setImportBusy] = useState(false);
   const [repoBusyKey, setRepoBusyKey] = useState<string | null>(null);
-  const [repoForm, setRepoForm] = useState<{
-    platform: "github" | "gitlab";
-    owner: string;
-    name: string;
-    branch: string;
-  }>({
-    platform: "github",
-    owner: "",
-    name: "",
-    branch: "main",
-  });
+  const [repoEditorOpen, setRepoEditorOpen] = useState(false);
+  const [repoEditorMode, setRepoEditorMode] = useState<RepoEditorMode>("create");
   const [repoEditing, setRepoEditing] = useState<ToolingSkillRepo | null>(null);
+  const [repoForm, setRepoForm] = useState<RepoEditorForm>(() => createEmptyRepoForm());
+  const [repoResolving, setRepoResolving] = useState(false);
+  const [repoResolveError, setRepoResolveError] = useState("");
+  const repoResolveRequestRef = useRef(0);
   const [skillBusyName, setSkillBusyName] = useState<string | null>(null);
   const [mcpBusyId, setMcpBusyId] = useState<string | null>(null);
 
@@ -339,7 +348,40 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   }
 
   function handleViewDiscoveredSkill(skill: ToolingDiscoveredSkill) {
-    window.open(skill.source_url, "_blank", "noopener,noreferrer");
+    void openExternalUrl(skill.source_url);
+  }
+
+  async function resolveRepoInput(input: string, options?: { initialBranch?: string }) {
+    const trimmed = input.trim();
+    setRepoResolveError("");
+    if (!trimmed) {
+      repoResolveRequestRef.current += 1;
+      setRepoResolving(false);
+      setRepoForm((current) => ({
+        ...createEmptyRepoForm(),
+        input: current.input,
+      }));
+      return;
+    }
+    const requestId = repoResolveRequestRef.current + 1;
+    repoResolveRequestRef.current = requestId;
+    setRepoResolving(true);
+    try {
+      const resolved = await resolveToolingRepo(trimmed);
+      if (repoResolveRequestRef.current !== requestId) {
+        return;
+      }
+      setRepoForm((current) => applyResolvedRepo(current, resolved, options?.initialBranch));
+    } catch (error) {
+      if (repoResolveRequestRef.current !== requestId) {
+        return;
+      }
+      setRepoResolveError(error instanceof Error ? error.message : t("仓库解析失败"));
+    } finally {
+      if (repoResolveRequestRef.current === requestId) {
+        setRepoResolving(false);
+      }
+    }
   }
 
   async function handleRepoAdd() {
@@ -361,14 +403,19 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   }
 
   async function handleRepoSave() {
-    if (!repoEditing) {
+    if (repoEditorMode === "create" || !repoEditing) {
       await handleRepoAdd();
       return;
     }
     const key = repoRecordKey(repoEditing.platform ?? "github", repoEditing.owner, repoEditing.name);
     setRepoBusyKey(key);
     try {
-      await updateToolingRepo(repoEditing.platform ?? "github", repoEditing.owner, repoEditing.name, repoForm);
+      await updateToolingRepo(repoEditing.platform ?? "github", repoEditing.owner, repoEditing.name, {
+        platform: repoForm.platform,
+        owner: repoForm.owner,
+        name: repoForm.name,
+        branch: repoForm.branch,
+      });
       void messageApi.success(t("仓库已更新"));
       resetRepoForm();
       await reload({ background: true });
@@ -382,24 +429,43 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     }
   }
 
-  function startRepoEdit(repo: ToolingSkillRepo) {
-    setRepoEditing(repo);
-    setRepoForm({
+  function openRepoCreate() {
+    setRepoEditorMode("create");
+    setRepoEditing(null);
+    setRepoResolveError("");
+    setRepoResolving(false);
+    setRepoForm(createEmptyRepoForm());
+    setRepoEditorOpen(true);
+  }
+
+  function openRepoEdit(repo: ToolingSkillRepo) {
+    const repoUrl = buildRepoURL(repo.platform ?? "github", repo.owner, repo.name);
+    const nextForm: RepoEditorForm = {
+      input: repoUrl,
       platform: repo.platform ?? "github",
       owner: repo.owner,
       name: repo.name,
       branch: repo.branch,
-    });
+      branchOptions: [repo.branch],
+    };
+    repoResolveRequestRef.current += 1;
+    setRepoEditorMode("edit");
+    setRepoEditing(repo);
+    setRepoResolveError("");
+    setRepoResolving(false);
+    setRepoForm(nextForm);
+    setRepoEditorOpen(true);
+    void resolveRepoInput(repoUrl, { initialBranch: repo.branch });
   }
 
   function resetRepoForm() {
+    repoResolveRequestRef.current += 1;
     setRepoEditing(null);
-    setRepoForm({
-      platform: "github",
-      owner: "",
-      name: "",
-      branch: "main",
-    });
+    setRepoEditorMode("create");
+    setRepoEditorOpen(false);
+    setRepoResolving(false);
+    setRepoResolveError("");
+    setRepoForm(createEmptyRepoForm());
   }
 
   async function handleRepoRemove(repo: ToolingSkillRepo) {
@@ -417,6 +483,10 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     } finally {
       setRepoBusyKey(null);
     }
+  }
+
+  function handleRepoView(repo: ToolingSkillRepo) {
+    void openExternalUrl(buildRepoURL(repo.platform ?? "github", repo.owner, repo.name));
   }
 
   if (loading || !state) {
@@ -567,67 +637,88 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         }}
         footer={null}
         destroyOnHidden
+        className="tooling-repo-manager-modal"
       >
         <div className="tooling-repo-manager-shell">
-          <div className="tooling-repo-form-grid">
-            <label className="tooling-repo-field">
-              <span>{t("仓库平台")}</span>
-              <select
-                aria-label={t("仓库平台")}
-                value={repoForm.platform}
-                onChange={(event) => setRepoForm((current) => ({ ...current, platform: event.target.value as "github" | "gitlab" }))}
-              >
-                <option value="github">GitHub</option>
-                <option value="gitlab">GitLab</option>
-              </select>
-            </label>
-            <label className="tooling-repo-field">
-              <span>{t("仓库归属")}</span>
-              <input
-                aria-label={t("仓库归属")}
-                value={repoForm.owner}
-                onChange={(event) => setRepoForm((current) => ({ ...current, owner: event.target.value }))}
-              />
-            </label>
-            <label className="tooling-repo-field">
-              <span>{t("仓库名称")}</span>
-              <input
-                aria-label={t("仓库名称")}
-                value={repoForm.name}
-                onChange={(event) => setRepoForm((current) => ({ ...current, name: event.target.value }))}
-              />
-            </label>
-            <label className="tooling-repo-field">
-              <span>{t("分支")}</span>
-              <input
-                aria-label={t("分支")}
-                value={repoForm.branch}
-                onChange={(event) => setRepoForm((current) => ({ ...current, branch: event.target.value }))}
-              />
-            </label>
-          </div>
-          <Space wrap size={10}>
-            <Button type="primary" onClick={() => void handleRepoSave()}>
-              {repoEditing ? t("保存仓库") : t("添加仓库")}
+          <div className="tooling-repo-manager-toolbar">
+            <Typography.Text type="secondary">{t("仅管理公开 GitHub / GitLab 仓库")}</Typography.Text>
+            <Button type="primary" icon={<PlusOutlined />} aria-label={t("添加仓库")} onClick={openRepoCreate}>
+              {t("添加仓库")}
             </Button>
-            {repoEditing ? (
-              <Button onClick={() => resetRepoForm()}>
-                {t("取消编辑")}
-              </Button>
-            ) : null}
-          </Space>
+          </div>
 
-          <div className="tooling-discovery-list">
+          <div className="tooling-discovery-list tooling-repo-manager-list">
             {skillRepos.length > 0 ? skillRepos.map((repo) => (
               <RepoManageRow
                 key={repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
                 repo={repo}
                 busy={repoBusyKey === repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
-                onEdit={() => startRepoEdit(repo)}
+                onView={() => handleRepoView(repo)}
+                onEdit={() => openRepoEdit(repo)}
                 onDelete={() => void handleRepoRemove(repo)}
               />
             )) : <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无已管理仓库")} />}
           </div>
+        </div>
+      </Modal>
+
+      <Modal
+        open={repoEditorOpen}
+        title={repoEditorMode === "edit" ? t("编辑仓库") : t("添加仓库")}
+        onCancel={() => resetRepoForm()}
+        footer={null}
+        destroyOnHidden
+        className="tooling-repo-editor-modal"
+      >
+        <div className="tooling-repo-editor-shell">
+          <label className="tooling-repo-field">
+            <span>{t("仓库链接")}</span>
+            <input
+              aria-label={t("仓库链接")}
+              value={repoForm.input}
+              disabled={repoEditorMode === "edit"}
+              onChange={(event) => {
+                const nextInput = event.target.value;
+                setRepoForm((current) => ({ ...current, input: nextInput }));
+                void resolveRepoInput(nextInput);
+              }}
+            />
+          </label>
+
+          <label className="tooling-repo-field">
+            <span>{t("分支")}</span>
+            <select
+              aria-label={t("分支")}
+              value={repoForm.branch}
+              onChange={(event) => setRepoForm((current) => ({ ...current, branch: event.target.value }))}
+            >
+              {repoForm.branchOptions.map((branch) => (
+                <option key={branch} value={branch}>
+                  {branch}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="tooling-repo-editor-summary">
+            {repoResolving ? <Typography.Text type="secondary">{t("正在解析仓库和分支…")}</Typography.Text> : null}
+            {!repoResolving && repoResolveError ? <Typography.Text type="danger">{repoResolveError}</Typography.Text> : null}
+            {!repoResolving && !repoResolveError && repoForm.owner && repoForm.name ? (
+              <Typography.Text type="secondary">{`${repoForm.platform.toUpperCase()} · ${repoForm.owner}/${repoForm.name}`}</Typography.Text>
+            ) : null}
+          </div>
+
+          <Space wrap size={10}>
+            <Button
+              type="primary"
+              loading={repoBusyKey === repoRecordKey(repoForm.platform, repoForm.owner, repoForm.name)}
+              disabled={repoResolving || !repoForm.owner || !repoForm.name || !repoForm.branch}
+              onClick={() => void handleRepoSave()}
+            >
+              {repoEditorMode === "edit" ? t("保存仓库") : t("确认添加仓库")}
+            </Button>
+            <Button onClick={() => resetRepoForm()}>{t("取消")}</Button>
+          </Space>
         </div>
       </Modal>
     </div>
@@ -669,6 +760,40 @@ function markDiscoveredSkillInstalled(
 
 function repoRecordKey(platform: string, owner: string, name: string): string {
   return `${platform}:${owner}/${name}`;
+}
+
+function createEmptyRepoForm(): RepoEditorForm {
+  return {
+    input: "",
+    platform: "github",
+    owner: "",
+    name: "",
+    branch: "main",
+    branchOptions: ["main"],
+  };
+}
+
+function applyResolvedRepo(current: RepoEditorForm, resolved: ToolingResolvedRepo, preferredBranch?: string): RepoEditorForm {
+  const branchOptions = resolved.branch_options.length > 0 ? resolved.branch_options : [resolved.selected_branch || preferredBranch || "main"];
+  const selectedBranch =
+    preferredBranch && branchOptions.includes(preferredBranch)
+      ? preferredBranch
+      : branchOptions.includes(resolved.selected_branch)
+        ? resolved.selected_branch
+        : branchOptions[0];
+  return {
+    ...current,
+    input: resolved.repo_url,
+    platform: resolved.platform,
+    owner: resolved.owner,
+    name: resolved.name,
+    branch: selectedBranch,
+    branchOptions,
+  };
+}
+
+function buildRepoURL(platform: string, owner: string, name: string): string {
+  return `${platform === "gitlab" ? "https://gitlab.com" : "https://github.com"}/${owner}/${name}`;
 }
 
 function DeleteMcpConfirmContent({
@@ -768,28 +893,34 @@ function DiscoveredSkillCard({
 function RepoManageRow({
   repo,
   busy,
+  onView,
   onEdit,
   onDelete,
 }: {
   repo: ToolingSkillRepo;
   busy?: boolean;
+  onView: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }) {
+  const repoUrl = buildRepoURL(repo.platform ?? "github", repo.owner, repo.name);
   return (
     <div className="tooling-repo-row">
       <div className="tooling-repo-main">
         <div className="tooling-repo-title">{`${repo.owner}/${repo.name}`}</div>
-        <div className="stats-subtitle">{`${(repo.platform ?? "github").toUpperCase()} · ${repo.branch} · ${repo.skill_count} skills`}</div>
+        <div className="stats-subtitle">{`${repo.skill_count} skills · ${repoUrl}`}</div>
       </div>
-      <Space size={8}>
-        <Button size="small" icon={<EditOutlined />} aria-label={`编辑 ${repo.owner}/${repo.name}`} onClick={onEdit}>
+      <div className="tooling-repo-actions">
+        <button type="button" className="tooling-repo-action-button" aria-label={`查看 ${repo.owner}/${repo.name}`} onClick={onView}>
+          查看
+        </button>
+        <button type="button" className="tooling-repo-action-button" aria-label={`编辑 ${repo.owner}/${repo.name}`} onClick={onEdit}>
           编辑
-        </Button>
-        <Button size="small" danger loading={busy} icon={<DeleteOutlined />} aria-label={`移除 ${repo.owner}/${repo.name}`} onClick={onDelete}>
-          移除
-        </Button>
-      </Space>
+        </button>
+        <button type="button" className="tooling-repo-action-button is-danger" aria-label={`删除 ${repo.owner}/${repo.name}`} disabled={busy} onClick={onDelete}>
+          删除
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -287,6 +287,15 @@ export type ToolingRepoSearchResult = {
   description?: string;
 };
 
+export type ToolingResolvedRepo = {
+  platform: "github" | "gitlab";
+  owner: string;
+  name: string;
+  repo_url: string;
+  branch_options: string[];
+  selected_branch: string;
+};
+
 export type ToolingDiscoveredSkill = {
   id: string;
   name: string;
@@ -1075,6 +1084,19 @@ export async function searchToolingRepos(query: string): Promise<{ items: Toolin
   const response = await fetch(apiPath(`/tooling/skills/repos/search?q=${encodeURIComponent(query)}`));
   if (!response.ok) {
     throw new Error("failed to search tooling repos");
+  }
+  return response.json();
+}
+
+export async function resolveToolingRepo(input: string): Promise<ToolingResolvedRepo> {
+  const response = await fetch(apiPath("/tooling/skills/repos/resolve"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ input }),
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to resolve tooling repo");
   }
   return response.json();
 }

--- a/frontend/src/lib/desktop-shell.ts
+++ b/frontend/src/lib/desktop-shell.ts
@@ -89,6 +89,19 @@ export async function writeDesktopClipboardText(text: string): Promise<void> {
   await invoke("write_clipboard_text", { text });
 }
 
+export async function openExternalUrl(url: string): Promise<void> {
+  if (isDesktopShell()) {
+    try {
+      const opener = await import("@tauri-apps/plugin-opener");
+      await opener.openUrl(url);
+      return;
+    } catch (error) {
+      console.warn("desktop openUrl failed, fallback to window.open", error);
+    }
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
 export async function subscribeDesktopBackendStateChanged(handler: () => void): Promise<() => void> {
   if (!isDesktopShell()) {
     return () => {};

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -795,6 +795,35 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   gap: 16px;
 }
 
+.tooling-repo-manager-modal .ant-modal-body {
+  max-height: min(72vh, 720px);
+  overflow: hidden;
+}
+
+.tooling-repo-manager-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tooling-repo-manager-list {
+  max-height: min(56vh, 560px);
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.tooling-repo-editor-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.tooling-repo-editor-summary {
+  min-height: 22px;
+}
+
 .tooling-repo-form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -933,14 +962,24 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  padding: 14px 16px;
-  border-radius: 14px;
-  background: var(--interactive-soft);
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: #ffffff;
   border: 1px solid var(--panel-border);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.04);
+  transition: border-color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
+}
+
+.tooling-repo-row:hover,
+.tooling-repo-row:focus-within {
+  transform: translateY(-1px);
+  border-color: rgba(62, 91, 232, 0.2);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
 }
 
 .tooling-repo-main {
   min-width: 0;
+  flex: 1;
 }
 
 .tooling-delete-confirm-content {
@@ -978,6 +1017,53 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   gap: 8px;
   font-weight: 600;
   color: var(--text-primary);
+}
+
+.tooling-repo-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(2px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.tooling-repo-row:hover .tooling-repo-actions,
+.tooling-repo-row:focus-within .tooling-repo-actions {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.tooling-repo-action-button {
+  appearance: none;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease, opacity 120ms ease;
+}
+
+.tooling-repo-action-button:hover {
+  color: #2448d8;
+  background: rgba(62, 91, 232, 0.06);
+}
+
+.tooling-repo-action-button.is-danger:hover {
+  color: #c2410c;
+  background: rgba(249, 115, 22, 0.08);
+}
+
+.tooling-repo-action-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .tooling-template-row {
@@ -1019,6 +1105,21 @@ html[data-theme-mode="dark"] .top-home-update-dot {
 
   .tooling-repo-form-grid {
     grid-template-columns: 1fr;
+  }
+
+  .tooling-repo-manager-toolbar {
+    align-items: stretch;
+  }
+
+  .tooling-repo-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .tooling-repo-actions {
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
## Summary\n- redesign skill discovery repo manager to compact list + hover actions + tertiary add/edit modal\n- add backend repo resolve endpoint for URL parsing and branch selection\n- route desktop external links via Tauri opener plugin to fix mac client link jumps\n- bump release metadata to 1.2.7\n\n## Verification\n- go test ./...\n- npm test -- --run\n- npm test -- --run src/features/tooling/ToolingPage.test.tsx\n- npm run build\n- cargo check