### PR TITLE
feat(tooling): add default openai/skills repo and repo count refresh

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -234,7 +234,15 @@ type mcpConfigPayload struct {
 	Mcp        map[string]any `json:"mcp"`
 }
 
-var toolingDefaultRepos = []skillRepoRecord{}
+var toolingDefaultRepos = []skillRepoRecord{
+	{
+		Platform: "github",
+		Owner:    "openai",
+		Name:     "skills",
+		Branch:   "main",
+		Enabled:  true,
+	},
+}
 
 var toolingTemplates = []mcpTemplateRecord{
 	{ID: "fetch", Name: "mcp-server-fetch", Description: "Quick template: mcp-fetch", Type: "stdio", Command: "uvx", Args: []string{"mcp-server-fetch"}},
@@ -1050,6 +1058,7 @@ func (h *ToolingHandler) loadConfig(home string) toolingConfig {
 		for idx := range cfg.SkillRepos {
 			cfg.SkillRepos[idx] = normalizeSkillRepoRecord(cfg.SkillRepos[idx])
 		}
+		cfg.SkillRepos = mergeDefaultSkillRepos(cfg.SkillRepos)
 	}
 	return cfg
 }
@@ -1062,6 +1071,7 @@ func (h *ToolingHandler) saveConfig(home string, cfg toolingConfig) error {
 		for idx := range cfg.SkillRepos {
 			cfg.SkillRepos[idx] = normalizeSkillRepoRecord(cfg.SkillRepos[idx])
 		}
+		cfg.SkillRepos = mergeDefaultSkillRepos(cfg.SkillRepos)
 	}
 	raw, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -1212,6 +1222,33 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func mergeDefaultSkillRepos(repos []skillRepoRecord) []skillRepoRecord {
+	result := make([]skillRepoRecord, 0, len(repos)+len(toolingDefaultRepos))
+	result = append(result, repos...)
+	for _, defaultRepo := range toolingDefaultRepos {
+		exists := false
+		for _, repo := range result {
+			if skillRepoMatches(repo, defaultRepo.Platform, defaultRepo.Owner, defaultRepo.Name) {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			result = append(result, normalizeSkillRepoRecord(defaultRepo))
+		}
+	}
+	return result
+}
+
+func repoRecordKey(platform string, owner string, name string) string {
+	return fmt.Sprintf(
+		"%s:%s/%s",
+		normalizeSkillRepoPlatform(platform),
+		strings.ToLower(strings.TrimSpace(owner)),
+		strings.ToLower(strings.TrimSpace(name)),
+	)
 }
 
 func parseToolingRepoInput(input string) (skillRepoRecord, error) {
@@ -1711,6 +1748,11 @@ func (h *ToolingHandler) refreshSkillDiscovery(home string) ([]discoveredSkillRe
 	if err != nil {
 		return nil, "", err
 	}
+	if applyRepoSkillCounts(&cfg, items) {
+		if err := h.saveConfig(home, cfg); err != nil {
+			return nil, "", err
+		}
+	}
 	fetchedAt := timeNowUTC().Format(time.RFC3339)
 	cache := skillDiscoveryCache{
 		FetchedAt: fetchedAt,
@@ -1720,6 +1762,23 @@ func (h *ToolingHandler) refreshSkillDiscovery(home string) ([]discoveredSkillRe
 		return nil, "", err
 	}
 	return items, fetchedAt, nil
+}
+
+func applyRepoSkillCounts(cfg *toolingConfig, items []discoveredSkillRecord) bool {
+	repoSkillCounts := map[string]int{}
+	for _, item := range items {
+		repoSkillCounts[repoRecordKey(item.Platform, item.RepoOwner, item.RepoName)]++
+	}
+	changed := false
+	for idx := range cfg.SkillRepos {
+		key := repoRecordKey(cfg.SkillRepos[idx].Platform, cfg.SkillRepos[idx].Owner, cfg.SkillRepos[idx].Name)
+		nextCount := repoSkillCounts[key]
+		if cfg.SkillRepos[idx].SkillCount != nextCount {
+			cfg.SkillRepos[idx].SkillCount = nextCount
+			changed = true
+		}
+	}
+	return changed
 }
 
 func applyManagedSkills(home string, method string, apps []string) (int, error) {
@@ -2435,10 +2494,11 @@ func defaultRepoSearchResults() []repoSearchResult {
 	results := make([]repoSearchResult, 0, len(toolingDefaultRepos))
 	for _, repo := range toolingDefaultRepos {
 		results = append(results, repoSearchResult{
-			Owner:  repo.Owner,
-			Name:   repo.Name,
-			Branch: repo.Branch,
-			URL:    fmt.Sprintf("https://github.com/%s/%s", repo.Owner, repo.Name),
+			Platform: repo.Platform,
+			Owner:    repo.Owner,
+			Name:     repo.Name,
+			Branch:   repo.Branch,
+			URL:      buildRepoURL(repo.Platform, repo.Owner, repo.Name),
 		})
 	}
 	return results

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -449,6 +449,27 @@ func TestToolingHandlerResolvesGitLabRepoAndFallsBackToDefaultBranch(t *testing.
 	}
 }
 
+func TestToolingHandlerStateIncludesDefaultSkillRepo(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	handler := api.NewToolingHandler()
+	state := doToolingRequest(t, handler, http.MethodGet, "/tooling/state", nil, nil, http.StatusOK)
+
+	var payload map[string]any
+	if err := json.Unmarshal(state, &payload); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	repos, ok := payload["skill_repos"].([]any)
+	if !ok || len(repos) == 0 {
+		t.Fatalf("skill_repos = %v, want default repos", payload["skill_repos"])
+	}
+	repo := repos[0].(map[string]any)
+	if repo["platform"] != "github" || repo["owner"] != "openai" || repo["name"] != "skills" || repo["branch"] != "main" {
+		t.Fatalf("default repo = %v, want github/openai/skills@main", repo)
+	}
+}
+
 func TestToolingHandlerInstallAndApplyMcpServer(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -859,6 +880,9 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
+	defaultArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
+		"README.md": "# OpenAI Skills\n",
+	})
 	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
 		"skills/zulu/SKILL.md":  "# Zulu Skill\nA trailing skill.\n\nUNIQUE-ZULU-BODY\n",
 		"skills/alpha/SKILL.md": "---\ndescription: Alpha summary\n---\n# Alpha Skill\nDetailed alpha body that must not be cached.\n",
@@ -866,6 +890,9 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/openai/skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(defaultArchive)
 		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
 			w.Header().Set("Content-Type", "application/zip")
 			_, _ = w.Write(archive)
@@ -954,12 +981,32 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 	if strings.Contains(cacheRaw, "Detailed alpha body that must not be cached.") || strings.Contains(cacheRaw, "UNIQUE-ZULU-BODY") {
 		t.Fatalf("cache raw = %s, want index-only cache without full body content", cacheRaw)
 	}
+
+	cfg := readToolingConfig(t, home)
+	repos := cfg["skill_repos"].([]any)
+	var target map[string]any
+	for _, raw := range repos {
+		repo := raw.(map[string]any)
+		if repo["owner"] == "openai" && repo["name"] == "codex-skills" {
+			target = repo
+			break
+		}
+	}
+	if target == nil {
+		t.Fatalf("skill_repos = %v, want openai/codex-skills", cfg["skill_repos"])
+	}
+	if target["skill_count"] != float64(2) {
+		t.Fatalf("skill_count = %v, want 2", target["skill_count"])
+	}
 }
 
 func TestToolingHandlerDiscoverSkillsMarksInstalledUpdatesByHash(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
+	defaultArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
+		"README.md": "# OpenAI Skills\n",
+	})
 	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
 		"skills/alpha/SKILL.md":          "# Alpha Skill\nNew upstream summary.\n",
 		"skills/alpha/assets/config.txt": "v2\n",
@@ -968,6 +1015,9 @@ func TestToolingHandlerDiscoverSkillsMarksInstalledUpdatesByHash(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/openai/skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(defaultArchive)
 		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
 			w.Header().Set("Content-Type", "application/zip")
 			_, _ = w.Write(archive)
@@ -1073,8 +1123,11 @@ func TestToolingHandlerSkillRepoCRUDSupportsPlatformAwareRecords(t *testing.T) {
 	}
 
 	listed = doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/repos", nil, nil, http.StatusOK)
-	if !strings.Contains(string(listed), `"platform":"gitlab"`) || strings.Contains(string(listed), `"platform":"github"`) {
-		t.Fatalf("list response after update = %s, want only updated gitlab record", string(listed))
+	if !strings.Contains(string(listed), `"platform":"gitlab"`) || !strings.Contains(string(listed), `"name":"skills"`) {
+		t.Fatalf("list response after update = %s, want updated gitlab repo plus default skills repo", string(listed))
+	}
+	if strings.Contains(string(listed), `"name":"codex-skills","branch":"main"`) {
+		t.Fatalf("list response after update = %s, want original github codex-skills record removed", string(listed))
 	}
 
 	removed := doToolingRequest(t, handler, http.MethodDelete, "/tooling/skills/repos/gitlab/gitlab-org/codex-skills", nil, nil, http.StatusOK)
@@ -1083,8 +1136,8 @@ func TestToolingHandlerSkillRepoCRUDSupportsPlatformAwareRecords(t *testing.T) {
 	}
 
 	listed = doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/repos", nil, nil, http.StatusOK)
-	if strings.TrimSpace(string(listed)) != "[]" {
-		t.Fatalf("list response after delete = %s, want empty list", string(listed))
+	if !strings.Contains(string(listed), `"name":"skills"`) || strings.Contains(string(listed), `"name":"codex-skills"`) {
+		t.Fatalf("list response after delete = %s, want only default skills repo", string(listed))
 	}
 }
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.7"
+version = "1.2.8"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -517,7 +517,8 @@ describe("ToolingPage", () => {
       ),
     );
 
-    fireEvent.change(within(createDialog).getByLabelText("分支"), { target: { value: "develop" } });
+    fireEvent.mouseDown(within(createDialog).getByLabelText("分支"));
+    fireEvent.click((await screen.findAllByText("develop"))[0]);
     fireEvent.click(within(createDialog).getByRole("button", { name: "确认添加仓库" }));
 
     await waitFor(() => expect(api.addToolingRepo).toHaveBeenCalledWith("gitlab", "gitlab-org", "codex-superpowers", "develop"));
@@ -529,7 +530,8 @@ describe("ToolingPage", () => {
 
     const editDialog = (await screen.findAllByRole("dialog")).at(-1)!;
     expect(within(editDialog).getByDisplayValue("https://github.com/openai/codex-superpowers")).toBeDisabled();
-    fireEvent.change(within(editDialog).getByLabelText("分支"), { target: { value: "release" } });
+    fireEvent.mouseDown(within(editDialog).getByLabelText("分支"));
+    fireEvent.click((await screen.findAllByText("release")).at(-1)!);
     fireEvent.click(within(editDialog).getByRole("button", { name: "保存仓库" }));
 
     await waitFor(() =>

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -8,7 +8,7 @@ import {
   ReloadOutlined,
   SearchOutlined,
 } from "@ant-design/icons";
-import { Button, Card, Checkbox, Empty, Input, Modal, Space, Spin, Typography, message } from "antd";
+import { Button, Card, Checkbox, Empty, Input, Modal, Select, Space, Spin, Typography, message } from "antd";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -152,6 +152,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         }
         setDiscoveryResponse(sortDiscoveryResponse(response));
         setDiscoveryStatus(t("已更新"));
+        void reload({ background: true });
       })
       .catch((error) => {
         if (!active) {
@@ -316,6 +317,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
       const response = await refreshToolingDiscoveredSkills();
       setDiscoveryResponse(sortDiscoveryResponse(response));
       setDiscoveryStatus(t("已更新"));
+      await reload({ background: true });
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("刷新发现技能失败"));
     } finally {
@@ -673,8 +675,9 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         <div className="tooling-repo-editor-shell">
           <label className="tooling-repo-field">
             <span>{t("仓库链接")}</span>
-            <input
+            <Input
               aria-label={t("仓库链接")}
+              className="tooling-repo-editor-input"
               value={repoForm.input}
               disabled={repoEditorMode === "edit"}
               onChange={(event) => {
@@ -687,17 +690,13 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
 
           <label className="tooling-repo-field">
             <span>{t("分支")}</span>
-            <select
+            <Select
               aria-label={t("分支")}
+              className="tooling-repo-editor-select"
               value={repoForm.branch}
-              onChange={(event) => setRepoForm((current) => ({ ...current, branch: event.target.value }))}
-            >
-              {repoForm.branchOptions.map((branch) => (
-                <option key={branch} value={branch}>
-                  {branch}
-                </option>
-              ))}
-            </select>
+              options={repoForm.branchOptions.map((branch) => ({ label: branch, value: branch }))}
+              onChange={(branch) => setRepoForm((current) => ({ ...current, branch }))}
+            />
           </label>
 
           <div className="tooling-repo-editor-summary">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -838,15 +838,36 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   color: var(--text-secondary);
 }
 
-.tooling-repo-field input,
-.tooling-repo-field select {
+.tooling-repo-editor-input.ant-input,
+.tooling-repo-editor-select.ant-select {
   width: 100%;
-  min-height: 38px;
-  border-radius: 12px;
-  border: 1px solid var(--panel-border);
-  padding: 0 12px;
+}
+
+.tooling-repo-editor-input.ant-input {
+  min-height: 40px;
+  border-radius: 14px;
+  border-color: var(--panel-border);
   background: #ffffff;
   color: var(--text-primary);
+  box-shadow: none;
+  padding-inline: 14px;
+}
+
+.tooling-repo-editor-select.ant-select .ant-select-selector {
+  min-height: 40px !important;
+  border-radius: 14px !important;
+  border-color: var(--panel-border) !important;
+  background: #ffffff !important;
+  box-shadow: none !important;
+  padding: 4px 14px !important;
+  color: var(--text-primary);
+}
+
+.tooling-repo-editor-input.ant-input:focus,
+.tooling-repo-editor-input.ant-input-focused,
+.tooling-repo-editor-select.ant-select-focused .ant-select-selector {
+  border-color: #7aa2f8 !important;
+  box-shadow: 0 0 0 3px rgba(122, 162, 248, 0.2) !important;
 }
 
 .tooling-card {


### PR DESCRIPTION
## Summary
- add github/openai/skills@main as a default skill discovery repo and keep defaults merged into tooling config
- persist per-repo discovered skill_count during refresh and expose platform-aware default repo search metadata
- refresh tooling state after discovery updates so repo manager counters update silently
- align repo manager branch/link controls to Ant Design input/select style used by stats page

## Testing
- go test ./... (backend)
- npm test -- --run (frontend)
- npm run build (frontend)
