### PR TITLE
feat(tooling): add repo ranking, drag sort, and daily discovery refresh

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -28,7 +28,10 @@ const toolingConfigFilename = "tooling.json"
 var toolingSupportedApps = []string{"codex"}
 
 type ToolingHandler struct {
-	mu sync.Mutex
+	mu                  sync.Mutex
+	autoRefreshMu       sync.Mutex
+	autoRefreshInFlight bool
+	autoRefreshLastTry  time.Time
 }
 
 func NewToolingHandler() *ToolingHandler {
@@ -86,14 +89,15 @@ type skillStatsResponse struct {
 }
 
 type managedSkillRecord struct {
-	Name          string          `json:"name"`
-	Description   string          `json:"description,omitempty"`
-	Directory     string          `json:"directory"`
-	SourceClient  string          `json:"source_client,omitempty"`
-	SourceRepo    string          `json:"source_repo,omitempty"`
-	SourceKind    string          `json:"source_kind"`
-	ManagedPath   string          `json:"managed_path"`
-	InstalledApps map[string]bool `json:"installed_apps"`
+	Name            string          `json:"name"`
+	Description     string          `json:"description,omitempty"`
+	Directory       string          `json:"directory"`
+	SourceClient    string          `json:"source_client,omitempty"`
+	SourceRepo      string          `json:"source_repo,omitempty"`
+	SourceKind      string          `json:"source_kind"`
+	ManagedPath     string          `json:"managed_path"`
+	InstalledApps   map[string]bool `json:"installed_apps"`
+	UpdateAvailable bool            `json:"update_available"`
 }
 
 type repoSearchResult struct {
@@ -204,6 +208,16 @@ type toolingRepoRequest struct {
 	Branch   string `json:"branch"`
 }
 
+type toolingRepoOrderItem struct {
+	Platform string `json:"platform"`
+	Owner    string `json:"owner"`
+	Name     string `json:"name"`
+}
+
+type toolingRepoOrderRequest struct {
+	Items []toolingRepoOrderItem `json:"items"`
+}
+
 type toolingRepoResolveRequest struct {
 	Input string `json:"input"`
 }
@@ -242,6 +256,20 @@ var toolingDefaultRepos = []skillRepoRecord{
 		Branch:   "main",
 		Enabled:  true,
 	},
+	{
+		Platform: "github",
+		Owner:    "anthropics",
+		Name:     "skills",
+		Branch:   "main",
+		Enabled:  true,
+	},
+	{
+		Platform: "github",
+		Owner:    "ComposioHQ",
+		Name:     "awesome-claude-skills",
+		Branch:   "master",
+		Enabled:  true,
+	},
 }
 
 var toolingTemplates = []mcpTemplateRecord{
@@ -274,6 +302,8 @@ func (h *ToolingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.addSkillRepo(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/repos/resolve":
 		h.resolveSkillRepo(w, r)
+	case r.Method == http.MethodPut && r.URL.Path == "/tooling/skills/repos/order":
+		h.reorderSkillRepos(w, r)
 	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/tooling/skills/repos/"):
 		h.updateSkillRepo(w, r)
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/tooling/skills/repos/"):
@@ -314,9 +344,12 @@ func (h *ToolingHandler) getState(w http.ResponseWriter) {
 	cfg, _ = h.syncManagedCodexMcpServers(home, cfg)
 	clients := toolingClientStates(home)
 	skills := scanManagedSkills(home, clients)
+	cache, _ := loadSkillDiscoveryCache(home)
+	applySkillUpdateFlags(skills, cache.Items)
 	repoResults := defaultRepoSearchResults()
 	discoveredServers := discoverMcpServers(home)
 	servers := h.buildMcpViews(home, cfg)
+	h.maybeScheduleDailySkillDiscoveryRefresh(home, cache.FetchedAt)
 
 	writeJSON(w, http.StatusOK, toolingStateResponse{
 		SkillSyncMethod:      normalizeSkillSyncMethod(cfg.SkillSyncMethod),
@@ -329,6 +362,32 @@ func (h *ToolingHandler) getState(w http.ResponseWriter) {
 		McpTemplates:         toolingTemplates,
 		McpServers:           servers,
 	})
+}
+
+func (h *ToolingHandler) maybeScheduleDailySkillDiscoveryRefresh(home string, fetchedAt string) {
+	parsedFetchedAt, _ := time.Parse(time.RFC3339, strings.TrimSpace(fetchedAt))
+	if !parsedFetchedAt.IsZero() && timeNowUTC().Sub(parsedFetchedAt) < 24*time.Hour {
+		return
+	}
+	h.autoRefreshMu.Lock()
+	defer h.autoRefreshMu.Unlock()
+	now := timeNowUTC()
+	if h.autoRefreshInFlight {
+		return
+	}
+	if !h.autoRefreshLastTry.IsZero() && now.Sub(h.autoRefreshLastTry) < 5*time.Minute {
+		return
+	}
+	h.autoRefreshInFlight = true
+	h.autoRefreshLastTry = now
+	go func() {
+		defer func() {
+			h.autoRefreshMu.Lock()
+			h.autoRefreshInFlight = false
+			h.autoRefreshMu.Unlock()
+		}()
+		_, _, _ = h.refreshSkillDiscovery(home)
+	}()
 }
 
 func (h *ToolingHandler) updateSettings(w http.ResponseWriter, r *http.Request) {
@@ -655,6 +714,53 @@ func (h *ToolingHandler) updateSkillRepo(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	http.Error(w, "repo not found", http.StatusNotFound)
+}
+
+func (h *ToolingHandler) reorderSkillRepos(w http.ResponseWriter, r *http.Request) {
+	var req toolingRepoOrderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	cfg := h.loadConfig(home)
+	byKey := make(map[string]skillRepoRecord, len(cfg.SkillRepos))
+	orderedKeys := make([]string, 0, len(cfg.SkillRepos))
+	for _, repo := range cfg.SkillRepos {
+		key := repoRecordKey(repo.Platform, repo.Owner, repo.Name)
+		byKey[key] = repo
+		orderedKeys = append(orderedKeys, key)
+	}
+	seen := map[string]bool{}
+	reordered := make([]skillRepoRecord, 0, len(cfg.SkillRepos))
+	for _, item := range req.Items {
+		key := repoRecordKey(item.Platform, item.Owner, item.Name)
+		if seen[key] {
+			continue
+		}
+		repo, ok := byKey[key]
+		if !ok {
+			continue
+		}
+		reordered = append(reordered, repo)
+		seen[key] = true
+	}
+	for _, key := range orderedKeys {
+		if seen[key] {
+			continue
+		}
+		reordered = append(reordered, byKey[key])
+	}
+	cfg.SkillRepos = reordered
+	if err := h.saveConfig(home, cfg); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, cfg.SkillRepos)
 }
 
 func (h *ToolingHandler) removeSkillRepo(w http.ResponseWriter, r *http.Request) {
@@ -1464,14 +1570,15 @@ func scanManagedSkills(home string, clients []toolingClientState) []managedSkill
 	for _, entry := range records {
 		meta := readSkillMetadata(entry.FullPath)
 		record := managedSkillRecord{
-			Name:          firstNonEmpty(meta.Name, entry.RelativePath),
-			Description:   describeSkillCollection(entry.FullPath),
-			Directory:     entry.FullPath,
-			SourceClient:  meta.SourceClient,
-			SourceRepo:    meta.SourceRepo,
-			SourceKind:    firstNonEmpty(meta.SourceKind, "manual"),
-			ManagedPath:   entry.FullPath,
-			InstalledApps: map[string]bool{},
+			Name:            firstNonEmpty(meta.Name, entry.RelativePath),
+			Description:     describeSkillCollection(entry.FullPath),
+			Directory:       entry.FullPath,
+			SourceClient:    meta.SourceClient,
+			SourceRepo:      meta.SourceRepo,
+			SourceKind:      firstNonEmpty(meta.SourceKind, "manual"),
+			ManagedPath:     entry.FullPath,
+			InstalledApps:   map[string]bool{},
+			UpdateAvailable: false,
 		}
 		for _, client := range clients {
 			if pathExists(filepath.Join(client.SkillsDir, filepath.FromSlash(entry.RelativePath))) {
@@ -1488,6 +1595,25 @@ func scanManagedSkills(home string, clients []toolingClientState) []managedSkill
 		return strings.ToLower(result[i].Name) < strings.ToLower(result[j].Name)
 	})
 	return result
+}
+
+func applySkillUpdateFlags(skills []managedSkillRecord, items []discoveredSkillRecord) {
+	if len(skills) == 0 || len(items) == 0 {
+		return
+	}
+	updates := map[string]bool{}
+	for _, item := range items {
+		if !item.UpdateAvailable {
+			continue
+		}
+		updates[strings.ToLower(strings.TrimSpace(item.ManagedName))] = true
+	}
+	for idx := range skills {
+		collectionName := strings.ToLower(strings.TrimSpace(filepath.Base(skills[idx].ManagedPath)))
+		if updates[collectionName] {
+			skills[idx].UpdateAvailable = true
+		}
+	}
 }
 
 type skillMetadata struct {

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -461,12 +461,23 @@ func TestToolingHandlerStateIncludesDefaultSkillRepo(t *testing.T) {
 		t.Fatalf("unmarshal state: %v", err)
 	}
 	repos, ok := payload["skill_repos"].([]any)
-	if !ok || len(repos) == 0 {
+	if !ok || len(repos) < 3 {
 		t.Fatalf("skill_repos = %v, want default repos", payload["skill_repos"])
 	}
-	repo := repos[0].(map[string]any)
-	if repo["platform"] != "github" || repo["owner"] != "openai" || repo["name"] != "skills" || repo["branch"] != "main" {
-		t.Fatalf("default repo = %v, want github/openai/skills@main", repo)
+	expected := []struct {
+		owner  string
+		name   string
+		branch string
+	}{
+		{owner: "openai", name: "skills", branch: "main"},
+		{owner: "anthropics", name: "skills", branch: "main"},
+		{owner: "ComposioHQ", name: "awesome-claude-skills", branch: "master"},
+	}
+	for idx, item := range expected {
+		repo := repos[idx].(map[string]any)
+		if repo["platform"] != "github" || repo["owner"] != item.owner || repo["name"] != item.name || repo["branch"] != item.branch {
+			t.Fatalf("default repo[%d] = %v, want github/%s/%s@%s", idx, repo, item.owner, item.name, item.branch)
+		}
 	}
 }
 
@@ -883,6 +894,12 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 	defaultArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
 		"README.md": "# OpenAI Skills\n",
 	})
+	anthropicsArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
+		"README.md": "# Anthropic Skills\n",
+	})
+	composioArchive := makeGitHubArchiveZip(t, "awesome-claude-skills-master", map[string]string{
+		"README.md": "# Awesome Claude Skills\n",
+	})
 	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
 		"skills/zulu/SKILL.md":  "# Zulu Skill\nA trailing skill.\n\nUNIQUE-ZULU-BODY\n",
 		"skills/alpha/SKILL.md": "---\ndescription: Alpha summary\n---\n# Alpha Skill\nDetailed alpha body that must not be cached.\n",
@@ -893,6 +910,12 @@ func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/openai/skills/archive/refs/heads/main.zip":
 			w.Header().Set("Content-Type", "application/zip")
 			_, _ = w.Write(defaultArchive)
+		case r.Method == http.MethodGet && r.URL.Path == "/anthropics/skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(anthropicsArchive)
+		case r.Method == http.MethodGet && r.URL.Path == "/ComposioHQ/awesome-claude-skills/archive/refs/heads/master.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(composioArchive)
 		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
 			w.Header().Set("Content-Type", "application/zip")
 			_, _ = w.Write(archive)
@@ -1007,6 +1030,12 @@ func TestToolingHandlerDiscoverSkillsMarksInstalledUpdatesByHash(t *testing.T) {
 	defaultArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
 		"README.md": "# OpenAI Skills\n",
 	})
+	anthropicsArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
+		"README.md": "# Anthropic Skills\n",
+	})
+	composioArchive := makeGitHubArchiveZip(t, "awesome-claude-skills-master", map[string]string{
+		"README.md": "# Awesome Claude Skills\n",
+	})
 	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
 		"skills/alpha/SKILL.md":          "# Alpha Skill\nNew upstream summary.\n",
 		"skills/alpha/assets/config.txt": "v2\n",
@@ -1018,6 +1047,12 @@ func TestToolingHandlerDiscoverSkillsMarksInstalledUpdatesByHash(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/openai/skills/archive/refs/heads/main.zip":
 			w.Header().Set("Content-Type", "application/zip")
 			_, _ = w.Write(defaultArchive)
+		case r.Method == http.MethodGet && r.URL.Path == "/anthropics/skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(anthropicsArchive)
+		case r.Method == http.MethodGet && r.URL.Path == "/ComposioHQ/awesome-claude-skills/archive/refs/heads/master.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(composioArchive)
 		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
 			w.Header().Set("Content-Type", "application/zip")
 			_, _ = w.Write(archive)
@@ -1136,8 +1171,46 @@ func TestToolingHandlerSkillRepoCRUDSupportsPlatformAwareRecords(t *testing.T) {
 	}
 
 	listed = doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/repos", nil, nil, http.StatusOK)
-	if !strings.Contains(string(listed), `"name":"skills"`) || strings.Contains(string(listed), `"name":"codex-skills"`) {
-		t.Fatalf("list response after delete = %s, want only default skills repo", string(listed))
+	if !strings.Contains(string(listed), `"owner":"openai","name":"skills"`) ||
+		!strings.Contains(string(listed), `"owner":"anthropics","name":"skills"`) ||
+		!strings.Contains(string(listed), `"owner":"ComposioHQ","name":"awesome-claude-skills"`) ||
+		strings.Contains(string(listed), `"name":"codex-skills"`) {
+		t.Fatalf("list response after delete = %s, want only default repos", string(listed))
+	}
+}
+
+func TestToolingHandlerReorderSkillReposPersistsOrder(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	handler := api.NewToolingHandler()
+
+	doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/repos", bytes.NewBufferString(`{
+		"platform":"github",
+		"owner":"z-org",
+		"name":"z-repo",
+		"branch":"main"
+	}`), map[string]string{"Content-Type": "application/json"}, http.StatusCreated)
+
+	doToolingRequest(t, handler, http.MethodPut, "/tooling/skills/repos/order", bytes.NewBufferString(`{
+		"items":[
+			{"platform":"github","owner":"z-org","name":"z-repo"},
+			{"platform":"github","owner":"openai","name":"skills"},
+			{"platform":"github","owner":"anthropics","name":"skills"},
+			{"platform":"github","owner":"ComposioHQ","name":"awesome-claude-skills"}
+		]
+	}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
+
+	listed := doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/repos", nil, nil, http.StatusOK)
+	var repos []map[string]any
+	if err := json.Unmarshal(listed, &repos); err != nil {
+		t.Fatalf("unmarshal repos: %v", err)
+	}
+	if len(repos) < 4 {
+		t.Fatalf("repos = %v, want at least 4", repos)
+	}
+	first := repos[0]
+	if first["owner"] != "z-org" || first["name"] != "z-repo" {
+		t.Fatalf("first repo = %v, want z-org/z-repo", first)
 	}
 }
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.8",
+  "version": "1.2.9",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.8"
+version = "1.2.9"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.8"
+version = "1.2.9"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.8",
+  "version": "1.2.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../../lib/api", async () => {
     addToolingRepo: vi.fn(),
     updateToolingRepo: vi.fn(),
     removeToolingRepo: vi.fn(),
+    reorderToolingRepos: vi.fn(),
     importToolingMcpServers: vi.fn(),
     applyToolingMcpServer: vi.fn(),
     installToolingMcpServer: vi.fn(),
@@ -251,6 +252,16 @@ describe("ToolingPage", () => {
       skill_count: 12,
     });
     vi.mocked(api.removeToolingRepo).mockResolvedValue();
+    vi.mocked((api as typeof api & { reorderToolingRepos: typeof vi.fn }).reorderToolingRepos).mockImplementation(async (items) => {
+      return items.map((item) => ({
+        platform: item.platform ?? "github",
+        owner: item.owner,
+        name: item.name,
+        branch: "main",
+        enabled: true,
+        skill_count: item.name === "codex-superpowers" ? 12 : 0,
+      }));
+    });
     vi.mocked(api.importToolingMcpServers).mockResolvedValue({ imported: 1 });
     vi.mocked(api.applyToolingMcpServer).mockResolvedValue();
     vi.mocked(api.installToolingMcpServer).mockResolvedValue(buildToolingState().mcp_servers[0]);
@@ -261,7 +272,7 @@ describe("ToolingPage", () => {
     render(<ToolingPage mode="skills" t={(text) => text} />);
 
     expect(await screen.findByText("Skill 技能")).toBeInTheDocument();
-    expect(screen.getByText("Codex 2")).toBeInTheDocument();
+    expect(screen.getByText("Codex 1")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /导入已有/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /发现技能/ })).toBeInTheDocument();
     expect(screen.getByText("superpowers")).toBeInTheDocument();

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -2,14 +2,14 @@ import {
   CheckCircleOutlined,
   CloudDownloadOutlined,
   DeleteOutlined,
-  EditOutlined,
+  DragOutlined,
   LinkOutlined,
   PlusOutlined,
   ReloadOutlined,
   SearchOutlined,
 } from "@ant-design/icons";
 import { Button, Card, Checkbox, Empty, Input, Modal, Select, Space, Spin, Typography, message } from "antd";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type DragEvent } from "react";
 
 import {
   addToolingRepo,
@@ -24,6 +24,7 @@ import {
   removeToolingRepo,
   resolveToolingRepo,
   refreshToolingDiscoveredSkills,
+  reorderToolingRepos,
   updateToolingSkill,
   updateToolingRepo,
   type ToolingDiscoveredSkill,
@@ -90,6 +91,8 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   const [repoEditorOpen, setRepoEditorOpen] = useState(false);
   const [repoEditorMode, setRepoEditorMode] = useState<RepoEditorMode>("create");
   const [repoEditing, setRepoEditing] = useState<ToolingSkillRepo | null>(null);
+  const [repoDragKey, setRepoDragKey] = useState<string | null>(null);
+  const [repoOrdering, setRepoOrdering] = useState(false);
   const [repoForm, setRepoForm] = useState<RepoEditorForm>(() => createEmptyRepoForm());
   const [repoResolving, setRepoResolving] = useState(false);
   const [repoResolveError, setRepoResolveError] = useState("");
@@ -173,16 +176,30 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     };
   }, [skillDiscoverOpen, mode]);
 
-  const skillCount = state?.skill_stats.by_source.codex ?? 0;
+  const skillCount = useMemo(
+    () => (state?.installed_skills ?? []).reduce((count, skill) => count + (skill.installed_apps?.codex ? 1 : 0), 0),
+    [state?.installed_skills],
+  );
   const mcpCount = state?.mcp_servers.length ?? 0;
   const skills = useMemo(() => state?.installed_skills ?? [], [state?.installed_skills]);
-  const skillRepos = useMemo(
-    () => [...(state?.skill_repos ?? [])].sort((a, b) => `${a.platform ?? "github"}:${a.owner}/${a.name}`.localeCompare(`${b.platform ?? "github"}:${b.owner}/${b.name}`)),
-    [state?.skill_repos],
-  );
+  const skillRepos = useMemo(() => state?.skill_repos ?? [], [state?.skill_repos]);
+  const repoRanks = useMemo(() => {
+    const index = new Map<string, number>();
+    skillRepos.forEach((repo, order) => {
+      index.set(repoRecordKey(repo.platform ?? "github", repo.owner, repo.name), order);
+    });
+    return index;
+  }, [skillRepos]);
   const mcpServers = useMemo(() => state?.mcp_servers ?? [], [state?.mcp_servers]);
   const discoveredSkills = useMemo(() => {
-    const items = [...(discoveryResponse?.items ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+    const items = [...(discoveryResponse?.items ?? [])].sort((a, b) => {
+      const leftRank = repoRanks.get(repoRecordKey(a.platform, a.repo_owner, a.repo_name)) ?? Number.MAX_SAFE_INTEGER;
+      const rightRank = repoRanks.get(repoRecordKey(b.platform, b.repo_owner, b.repo_name)) ?? Number.MAX_SAFE_INTEGER;
+      if (leftRank !== rightRank) {
+        return leftRank - rightRank;
+      }
+      return a.name.localeCompare(b.name);
+    });
     const query = discoveryQuery.trim().toLowerCase();
     if (!query) {
       return items;
@@ -190,7 +207,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     return items.filter((item) =>
       [item.name, item.description ?? "", item.repo_owner, item.repo_name, item.source_path].join(" ").toLowerCase().includes(query),
     );
-  }, [discoveryQuery, discoveryResponse?.items]);
+  }, [discoveryQuery, discoveryResponse?.items, repoRanks]);
 
   async function handleImportSkills() {
     setImportBusy(true);
@@ -491,6 +508,35 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     void openExternalUrl(buildRepoURL(repo.platform ?? "github", repo.owner, repo.name));
   }
 
+  async function handleRepoReorder(targetRepo: ToolingSkillRepo) {
+    if (!repoDragKey) {
+      return;
+    }
+    const targetKey = repoRecordKey(targetRepo.platform ?? "github", targetRepo.owner, targetRepo.name);
+    const reordered = reorderReposByKey(skillRepos, repoDragKey, targetKey);
+    if (reordered === skillRepos) {
+      return;
+    }
+    setState((current) => (current ? { ...current, skill_repos: reordered } : current));
+    setRepoOrdering(true);
+    try {
+      const next = await reorderToolingRepos(
+        reordered.map((repo) => ({
+          platform: repo.platform ?? "github",
+          owner: repo.owner,
+          name: repo.name,
+        })),
+      );
+      setState((current) => (current ? { ...current, skill_repos: next } : current));
+    } catch (error) {
+      void messageApi.error(error instanceof Error ? error.message : t("仓库排序失败"));
+      await reload({ background: true });
+    } finally {
+      setRepoOrdering(false);
+      setRepoDragKey(null);
+    }
+  }
+
   if (loading || !state) {
     return (
       <div className="dashboard-page tooling-page tooling-loading">
@@ -542,6 +588,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
                   key={skill.managed_path}
                   title={skill.name}
                   description={skill.description || skill.directory}
+                  updateAvailable={Boolean(skill.update_available)}
                   statuses={buildManagedStatuses(skill.installed_apps)}
                   busy={skillBusyName === skill.name}
                   toggleLabel={skill.installed_apps?.codex ? t(`停用 ${skill.name} 于 Codex`) : t(`启用 ${skill.name} 到 Codex`)}
@@ -654,7 +701,17 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
               <RepoManageRow
                 key={repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
                 repo={repo}
-                busy={repoBusyKey === repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
+                busy={repoOrdering || repoBusyKey === repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
+                dragging={repoDragKey === repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
+                onDragStart={() => setRepoDragKey(repoRecordKey(repo.platform ?? "github", repo.owner, repo.name))}
+                onDragOver={(event) => {
+                  event.preventDefault();
+                }}
+                onDrop={(event) => {
+                  event.preventDefault();
+                  void handleRepoReorder(repo);
+                }}
+                onDragEnd={() => setRepoDragKey(null)}
                 onView={() => handleRepoView(repo)}
                 onEdit={() => openRepoEdit(repo)}
                 onDelete={() => void handleRepoRemove(repo)}
@@ -758,7 +815,7 @@ function markDiscoveredSkillInstalled(
 }
 
 function repoRecordKey(platform: string, owner: string, name: string): string {
-  return `${platform}:${owner}/${name}`;
+  return `${(platform || "github").toLowerCase()}:${owner.toLowerCase()}/${name.toLowerCase()}`;
 }
 
 function createEmptyRepoForm(): RepoEditorForm {
@@ -892,21 +949,43 @@ function DiscoveredSkillCard({
 function RepoManageRow({
   repo,
   busy,
+  dragging,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
   onView,
   onEdit,
   onDelete,
 }: {
   repo: ToolingSkillRepo;
   busy?: boolean;
+  dragging?: boolean;
+  onDragStart: () => void;
+  onDragOver: (event: DragEvent<HTMLDivElement>) => void;
+  onDrop: (event: DragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
   onView: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }) {
   const repoUrl = buildRepoURL(repo.platform ?? "github", repo.owner, repo.name);
   return (
-    <div className="tooling-repo-row">
+    <div
+      className={`tooling-repo-row ${dragging ? "is-dragging" : ""}`}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
       <div className="tooling-repo-main">
-        <div className="tooling-repo-title">{`${repo.owner}/${repo.name}`}</div>
+        <div className="tooling-repo-title">
+          <span className="tooling-repo-drag-handle" aria-hidden="true">
+            <DragOutlined />
+          </span>
+          {`${repo.owner}/${repo.name}`}
+        </div>
         <div className="stats-subtitle">{`${repo.skill_count} skills · ${repoUrl}`}</div>
       </div>
       <div className="tooling-repo-actions">
@@ -976,6 +1055,7 @@ function ManagedCard({
   description,
   titleVariant = "default",
   descriptionVariant = "default",
+  updateAvailable = false,
   statuses,
   busy,
   toggleLabel,
@@ -987,6 +1067,7 @@ function ManagedCard({
   description?: string;
   titleVariant?: "default" | "account";
   descriptionVariant?: "default" | "account";
+  updateAvailable?: boolean;
   statuses: ManagedClientStatus[];
   busy?: boolean;
   toggleLabel: string;
@@ -999,7 +1080,10 @@ function ManagedCard({
   return (
     <div className="tooling-item-card">
       <div className="tooling-item-main">
-        <div className={`tooling-item-title ${titleVariant === "account" ? "is-account" : ""}`}>{title}</div>
+        <div className="tooling-item-title-row">
+          <div className={`tooling-item-title ${titleVariant === "account" ? "is-account" : ""}`}>{title}</div>
+          {updateAvailable ? <span className="tooling-status-pill is-update">可更新</span> : null}
+        </div>
         {description ? (
           <div className={`tooling-item-description ${descriptionVariant === "account" ? "is-account" : "is-default"}`}>
             {description}
@@ -1044,6 +1128,21 @@ function ManagedCard({
       </div>
     </div>
   );
+}
+
+function reorderReposByKey(repos: ToolingSkillRepo[], sourceKey: string, targetKey: string): ToolingSkillRepo[] {
+  if (sourceKey === targetKey) {
+    return repos;
+  }
+  const fromIndex = repos.findIndex((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name) === sourceKey);
+  const toIndex = repos.findIndex((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name) === targetKey);
+  if (fromIndex < 0 || toIndex < 0) {
+    return repos;
+  }
+  const next = [...repos];
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
 }
 
 function DiscoveryRow({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -278,6 +278,12 @@ export type ToolingSkillRepo = {
   skill_count: number;
 };
 
+export type ToolingRepoOrderItem = {
+  platform?: "github" | "gitlab";
+  owner: string;
+  name: string;
+};
+
 export type ToolingRepoSearchResult = {
   platform?: "github" | "gitlab";
   owner: string;
@@ -329,6 +335,7 @@ export type ToolingSkillRecord = {
   source_kind: string;
   managed_path: string;
   installed_apps: Record<string, boolean>;
+  update_available?: boolean;
 };
 
 export type ToolingMcpTemplate = {
@@ -1078,6 +1085,19 @@ export async function removeToolingRepo(platform: "github" | "gitlab", owner: st
     const details = await response.text();
     throw new Error(details || "failed to remove tooling repo");
   }
+}
+
+export async function reorderToolingRepos(items: ToolingRepoOrderItem[]): Promise<ToolingSkillRepo[]> {
+  const response = await fetch(apiPath("/tooling/skills/repos/order"), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ items }),
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to reorder tooling repos");
+  }
+  return response.json();
 }
 
 export async function searchToolingRepos(query: string): Promise<{ items: ToolingRepoSearchResult[] }> {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -476,6 +476,14 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   color: var(--text-primary);
 }
 
+.tooling-item-title-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
 .tooling-item-title.is-account {
   font-size: 14px;
   line-height: 1.4;
@@ -998,6 +1006,11 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
 }
 
+.tooling-repo-row.is-dragging {
+  opacity: 0.72;
+  border-color: rgba(62, 91, 232, 0.36);
+}
+
 .tooling-repo-main {
   min-width: 0;
   flex: 1;
@@ -1038,6 +1051,14 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   gap: 8px;
   font-weight: 600;
   color: var(--text-primary);
+}
+
+.tooling-repo-drag-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #94a39b;
+  cursor: grab;
 }
 
 .tooling-repo-actions {


### PR DESCRIPTION
## Summary
- count top-level Codex number by actually enabled skills instead of source stats
- add managed-skill update hint from discovered index cache
- add daily background refresh trigger for discovered skills on tooling state load
- add default ranked repos: openai/skills, anthropics/skills, ComposioHQ/awesome-claude-skills
- support drag-and-drop repo ordering and persist order via new repo reorder API
- sort discovery cards by repo rank first, then by skill name

## Testing
- go test ./... (backend)
- npm test -- --run (frontend)
- npm run build (frontend)
