### PR TITLE
feat(tooling): optimize repo manager layout and interactions

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.9",
+  "version": "1.2.10",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.9"
+version = "1.2.10"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.9"
+version = "1.2.10"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.9",
+  "version": "1.2.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -515,7 +515,8 @@ describe("ToolingPage", () => {
     const repoDialog = (await screen.findAllByRole("dialog")).at(-1)!;
     expect(within(repoDialog).queryByLabelText("仓库平台")).not.toBeInTheDocument();
     expect(within(repoDialog).getByText("openai/codex-superpowers")).toBeInTheDocument();
-    expect(within(repoDialog).getByText("12 skills · https://github.com/openai/codex-superpowers")).toBeInTheDocument();
+    expect(within(repoDialog).getByText("12 skills")).toBeInTheDocument();
+    expect(within(repoDialog).getByText("https://github.com/openai/codex-superpowers")).toBeInTheDocument();
 
     fireEvent.click(within(repoDialog).getByRole("button", { name: "添加仓库" }));
 
@@ -534,10 +535,10 @@ describe("ToolingPage", () => {
 
     await waitFor(() => expect(api.addToolingRepo).toHaveBeenCalledWith("gitlab", "gitlab-org", "codex-superpowers", "develop"));
 
-    fireEvent.click(within(repoDialog).getByRole("button", { name: "查看 openai/codex-superpowers" }));
+    fireEvent.click(within(repoDialog).getByRole("button", { name: "查看仓库 openai/codex-superpowers" }));
     expect(openSpy).toHaveBeenCalledWith("https://github.com/openai/codex-superpowers", "_blank", "noopener,noreferrer");
 
-    fireEvent.click(within(repoDialog).getByRole("button", { name: "编辑 openai/codex-superpowers" }));
+    fireEvent.click(within(repoDialog).getByRole("button", { name: "编辑仓库 openai/codex-superpowers" }));
 
     const editDialog = (await screen.findAllByRole("dialog")).at(-1)!;
     expect(within(editDialog).getByDisplayValue("https://github.com/openai/codex-superpowers")).toBeDisabled();
@@ -559,8 +560,7 @@ describe("ToolingPage", () => {
       ),
     );
 
-    await waitFor(() => expect(within(repoDialog).getByRole("button", { name: "删除 openai/codex-superpowers" })).not.toBeDisabled());
-    fireEvent.click(within(repoDialog).getByRole("button", { name: "删除 openai/codex-superpowers" }));
+    fireEvent.click(within(repoDialog).getByRole("button", { name: "删除仓库 openai/codex-superpowers" }));
     await waitFor(() => expect(api.removeToolingRepo).toHaveBeenCalledWith("github", "openai", "codex-superpowers"));
   });
 

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -2,14 +2,28 @@ import {
   CheckCircleOutlined,
   CloudDownloadOutlined,
   DeleteOutlined,
-  DragOutlined,
+  EditOutlined,
+  HolderOutlined,
   LinkOutlined,
   PlusOutlined,
   ReloadOutlined,
   SearchOutlined,
 } from "@ant-design/icons";
 import { Button, Card, Checkbox, Empty, Input, Modal, Select, Space, Spin, Typography, message } from "antd";
-import { useEffect, useMemo, useRef, useState, type DragEvent } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  PointerSensor,
+  closestCenter,
+  type DragEndEvent,
+  type DragStartEvent,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
 import {
   addToolingRepo,
@@ -97,8 +111,13 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   const [repoResolving, setRepoResolving] = useState(false);
   const [repoResolveError, setRepoResolveError] = useState("");
   const repoResolveRequestRef = useRef(0);
+  const repoDragSnapshotRef = useRef<ToolingSkillRepo[] | null>(null);
   const [skillBusyName, setSkillBusyName] = useState<string | null>(null);
   const [mcpBusyId, setMcpBusyId] = useState<string | null>(null);
+  const repoDragSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+  );
 
   async function reload(options?: { background?: boolean }) {
     const background = options?.background ?? false;
@@ -508,15 +527,25 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     void openExternalUrl(buildRepoURL(repo.platform ?? "github", repo.owner, repo.name));
   }
 
-  async function handleRepoReorder(targetRepo: ToolingSkillRepo) {
-    if (!repoDragKey) {
+  function handleRepoDragStart(event: DragStartEvent) {
+    repoDragSnapshotRef.current = skillRepos;
+    setRepoDragKey(String(event.active.id));
+  }
+
+  async function handleRepoDragEnd(event: DragEndEvent) {
+    const sourceKey = String(event.active.id);
+    const targetKey = event.over ? String(event.over.id) : "";
+    setRepoDragKey(null);
+    repoDragSnapshotRef.current = null;
+    if (!targetKey || sourceKey === targetKey) {
       return;
     }
-    const targetKey = repoRecordKey(targetRepo.platform ?? "github", targetRepo.owner, targetRepo.name);
-    const reordered = reorderReposByKey(skillRepos, repoDragKey, targetKey);
-    if (reordered === skillRepos) {
+    const sourceIndex = skillRepos.findIndex((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name) === sourceKey);
+    const targetIndex = skillRepos.findIndex((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name) === targetKey);
+    if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) {
       return;
     }
+    const reordered = arrayMove(skillRepos, sourceIndex, targetIndex);
     setState((current) => (current ? { ...current, skill_repos: reordered } : current));
     setRepoOrdering(true);
     try {
@@ -533,9 +562,19 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
       await reload({ background: true });
     } finally {
       setRepoOrdering(false);
-      setRepoDragKey(null);
     }
   }
+
+  const draggingRepo = useMemo(() => {
+    if (!repoDragKey) {
+      return null;
+    }
+    return (
+      skillRepos.find((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name) === repoDragKey) ??
+      repoDragSnapshotRef.current?.find((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name) === repoDragKey) ??
+      null
+    );
+  }, [repoDragKey, skillRepos]);
 
   if (loading || !state) {
     return (
@@ -686,6 +725,8 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         }}
         footer={null}
         destroyOnHidden
+        width="100vw"
+        style={{ top: 0, paddingBottom: 0 }}
         className="tooling-repo-manager-modal"
       >
         <div className="tooling-repo-manager-shell">
@@ -697,26 +738,36 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
           </div>
 
           <div className="tooling-discovery-list tooling-repo-manager-list">
-            {skillRepos.length > 0 ? skillRepos.map((repo) => (
-              <RepoManageRow
-                key={repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
-                repo={repo}
-                busy={repoOrdering || repoBusyKey === repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
-                dragging={repoDragKey === repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
-                onDragStart={() => setRepoDragKey(repoRecordKey(repo.platform ?? "github", repo.owner, repo.name))}
-                onDragOver={(event) => {
-                  event.preventDefault();
-                }}
-                onDrop={(event) => {
-                  event.preventDefault();
-                  void handleRepoReorder(repo);
-                }}
-                onDragEnd={() => setRepoDragKey(null)}
-                onView={() => handleRepoView(repo)}
-                onEdit={() => openRepoEdit(repo)}
-                onDelete={() => void handleRepoRemove(repo)}
-              />
-            )) : <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无已管理仓库")} />}
+            {skillRepos.length > 0 ? (
+              <DndContext sensors={repoDragSensors} collisionDetection={closestCenter} onDragStart={handleRepoDragStart} onDragEnd={(event) => void handleRepoDragEnd(event)}>
+                <SortableContext items={skillRepos.map((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name))} strategy={verticalListSortingStrategy}>
+                  {skillRepos.map((repo) => (
+                    <SortableRepoManageRow
+                      key={repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
+                      repo={repo}
+                      busy={repoOrdering || repoBusyKey === repoRecordKey(repo.platform ?? "github", repo.owner, repo.name)}
+                      onView={() => handleRepoView(repo)}
+                      onEdit={() => openRepoEdit(repo)}
+                      onDelete={() => void handleRepoRemove(repo)}
+                    />
+                  ))}
+                </SortableContext>
+                <DragOverlay>
+                  {draggingRepo ? (
+                    <RepoManageRow
+                      repo={draggingRepo}
+                      dragging
+                      overlay
+                      onView={() => {}}
+                      onEdit={() => {}}
+                      onDelete={() => {}}
+                    />
+                  ) : null}
+                </DragOverlay>
+              </DndContext>
+            ) : (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("暂无已管理仓库")} />
+            )}
           </div>
         </div>
       </Modal>
@@ -950,10 +1001,12 @@ function RepoManageRow({
   repo,
   busy,
   dragging,
-  onDragStart,
-  onDragOver,
-  onDrop,
-  onDragEnd,
+  overlay,
+  rowRef,
+  style,
+  handleAttributes,
+  handleListeners,
+  setHandleRef,
   onView,
   onEdit,
   onDelete,
@@ -961,45 +1014,101 @@ function RepoManageRow({
   repo: ToolingSkillRepo;
   busy?: boolean;
   dragging?: boolean;
-  onDragStart: () => void;
-  onDragOver: (event: DragEvent<HTMLDivElement>) => void;
-  onDrop: (event: DragEvent<HTMLDivElement>) => void;
-  onDragEnd: () => void;
+  overlay?: boolean;
+  rowRef?: (node: HTMLDivElement | null) => void;
+  style?: CSSProperties;
+  handleAttributes?: Record<string, unknown>;
+  handleListeners?: Record<string, unknown>;
+  setHandleRef?: (node: HTMLButtonElement | null) => void;
   onView: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }) {
   const repoUrl = buildRepoURL(repo.platform ?? "github", repo.owner, repo.name);
+  const repoName = `${repo.owner}/${repo.name}`;
   return (
     <div
-      className={`tooling-repo-row ${dragging ? "is-dragging" : ""}`}
-      draggable
-      onDragStart={onDragStart}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      onDragEnd={onDragEnd}
+      ref={rowRef}
+      className={`tooling-repo-row ${dragging ? "is-sortable-dragging" : ""} ${overlay ? "is-overlay" : ""}`}
+      style={style}
     >
-      <div className="tooling-repo-main">
-        <div className="tooling-repo-title">
-          <span className="tooling-repo-drag-handle" aria-hidden="true">
-            <DragOutlined />
-          </span>
-          {`${repo.owner}/${repo.name}`}
+      <div className="tooling-repo-leading">
+        <button
+          type="button"
+          ref={setHandleRef}
+          className="tooling-repo-drag-handle"
+          aria-label={`拖拽排序 ${repoName}`}
+          disabled={busy || overlay}
+          {...(handleAttributes as Record<string, unknown> | undefined)}
+          {...(handleListeners as Record<string, unknown> | undefined)}
+        >
+          <HolderOutlined />
+        </button>
+        <div className="tooling-repo-main">
+          <div className="tooling-repo-title-row">
+            <div className="tooling-repo-title">{repoName}</div>
+            <span className="tooling-repo-count-tag">{`${repo.skill_count} skills`}</span>
+          </div>
+          <button type="button" className="tooling-repo-link" aria-label={`查看 ${repoName}`} title={repoUrl} onClick={onView}>
+            {repoUrl}
+          </button>
         </div>
-        <div className="stats-subtitle">{`${repo.skill_count} skills · ${repoUrl}`}</div>
       </div>
       <div className="tooling-repo-actions">
-        <button type="button" className="tooling-repo-action-button" aria-label={`查看 ${repo.owner}/${repo.name}`} onClick={onView}>
-          查看
+        <button type="button" className="tooling-repo-action-icon" aria-label={`查看仓库 ${repoName}`} title="查看" onClick={onView} disabled={overlay}>
+          <LinkOutlined />
         </button>
-        <button type="button" className="tooling-repo-action-button" aria-label={`编辑 ${repo.owner}/${repo.name}`} onClick={onEdit}>
-          编辑
+        <button type="button" className="tooling-repo-action-icon" aria-label={`编辑仓库 ${repoName}`} title="编辑" onClick={onEdit} disabled={overlay}>
+          <EditOutlined />
         </button>
-        <button type="button" className="tooling-repo-action-button is-danger" aria-label={`删除 ${repo.owner}/${repo.name}`} disabled={busy} onClick={onDelete}>
-          删除
+        <button
+          type="button"
+          className="tooling-repo-action-icon is-danger"
+          aria-label={`删除仓库 ${repoName}`}
+          title="删除"
+          onClick={onDelete}
+          disabled={busy || overlay}
+        >
+          <DeleteOutlined />
         </button>
       </div>
     </div>
+  );
+}
+
+function SortableRepoManageRow({
+  repo,
+  busy,
+  onView,
+  onEdit,
+  onDelete,
+}: {
+  repo: ToolingSkillRepo;
+  busy?: boolean;
+  onView: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const id = repoRecordKey(repo.platform ?? "github", repo.owner, repo.name);
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <RepoManageRow
+      repo={repo}
+      busy={busy}
+      dragging={isDragging}
+      rowRef={setNodeRef}
+      style={style}
+      handleAttributes={attributes as Record<string, unknown>}
+      handleListeners={listeners as Record<string, unknown>}
+      setHandleRef={setActivatorNodeRef}
+      onView={onView}
+      onEdit={onEdit}
+      onDelete={onDelete}
+    />
   );
 }
 
@@ -1128,21 +1237,6 @@ function ManagedCard({
       </div>
     </div>
   );
-}
-
-function reorderReposByKey(repos: ToolingSkillRepo[], sourceKey: string, targetKey: string): ToolingSkillRepo[] {
-  if (sourceKey === targetKey) {
-    return repos;
-  }
-  const fromIndex = repos.findIndex((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name) === sourceKey);
-  const toIndex = repos.findIndex((repo) => repoRecordKey(repo.platform ?? "github", repo.owner, repo.name) === targetKey);
-  if (fromIndex < 0 || toIndex < 0) {
-    return repos;
-  }
-  const next = [...repos];
-  const [moved] = next.splice(fromIndex, 1);
-  next.splice(toIndex, 0, moved);
-  return next;
 }
 
 function DiscoveryRow({

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -801,10 +801,17 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  height: 100%;
+}
+
+.tooling-repo-manager-modal .ant-modal-content {
+  min-height: 100vh;
+  border-radius: 0;
+  padding: 20px 24px 24px;
 }
 
 .tooling-repo-manager-modal .ant-modal-body {
-  max-height: min(72vh, 720px);
+  height: calc(100vh - 92px);
   overflow: hidden;
 }
 
@@ -817,7 +824,8 @@ html[data-theme-mode="dark"] .top-home-update-dot {
 }
 
 .tooling-repo-manager-list {
-  max-height: min(56vh, 560px);
+  flex: 1;
+  min-height: 0;
   overflow: auto;
   padding-right: 4px;
 }
@@ -987,6 +995,7 @@ html[data-theme-mode="dark"] .top-home-update-dot {
 
 .tooling-repo-row {
   width: 100%;
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1006,14 +1015,29 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
 }
 
-.tooling-repo-row.is-dragging {
+.tooling-repo-row.is-sortable-dragging {
   opacity: 0.72;
   border-color: rgba(62, 91, 232, 0.36);
 }
 
+.tooling-repo-row.is-overlay {
+  box-shadow: 0 20px 34px rgba(15, 23, 42, 0.18);
+}
+
+.tooling-repo-leading {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .tooling-repo-main {
   min-width: 0;
-  flex: 1;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .tooling-delete-confirm-content {
@@ -1045,31 +1069,99 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   word-break: break-all;
 }
 
-.tooling-repo-title {
+.tooling-repo-title-row {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.tooling-repo-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .tooling-repo-drag-handle {
-  display: inline-flex;
+  appearance: none;
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  display: flex;
   align-items: center;
   justify-content: center;
-  color: #94a39b;
+  color: #9aa3b2;
   cursor: grab;
+  touch-action: none;
+  transition: background 0.16s ease, color 0.16s ease;
+}
+
+.tooling-repo-drag-handle:active {
+  cursor: grabbing;
+}
+
+.tooling-repo-drag-handle:hover {
+  color: var(--text-primary);
+  background: var(--interactive-soft);
+}
+
+.tooling-repo-drag-handle:disabled {
+  cursor: not-allowed;
+  opacity: 0.46;
+}
+
+.tooling-repo-count-tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: rgba(62, 91, 232, 0.1);
+  color: #2f49c8;
+  border: 1px solid rgba(62, 91, 232, 0.2);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.tooling-repo-link {
+  appearance: none;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: left;
+  line-height: 1.4;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tooling-repo-link:hover {
+  color: #2f49c8;
+  text-decoration: underline;
 }
 
 .tooling-repo-actions {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 6px;
+  gap: 8px;
   opacity: 0;
   pointer-events: none;
   transform: translateY(2px);
   transition: opacity 120ms ease, transform 120ms ease;
+  flex-shrink: 0;
 }
 
 .tooling-repo-row:hover .tooling-repo-actions,
@@ -1079,33 +1171,36 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   transform: translateY(0);
 }
 
-.tooling-repo-action-button {
+.tooling-repo-action-icon {
   appearance: none;
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--text-secondary);
-  min-height: 30px;
-  padding: 0 10px;
-  border-radius: 10px;
-  font-size: 13px;
-  font-weight: 500;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid rgba(62, 91, 232, 0.1);
+  background: #f2f4ff;
+  color: #3e5be8;
   cursor: pointer;
-  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease, opacity 120ms ease;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
 }
 
-.tooling-repo-action-button:hover {
-  color: #2448d8;
-  background: rgba(62, 91, 232, 0.06);
+.tooling-repo-action-icon:hover,
+.tooling-repo-action-icon:focus {
+  color: #2f49c8 !important;
+  background: rgba(62, 91, 232, 0.12) !important;
+  border-color: rgba(62, 91, 232, 0.2);
 }
 
-.tooling-repo-action-button.is-danger:hover {
-  color: #c2410c;
-  background: rgba(249, 115, 22, 0.08);
+.tooling-repo-action-icon.is-danger:hover,
+.tooling-repo-action-icon.is-danger:focus {
+  color: #c2410c !important;
+  background: rgba(249, 115, 22, 0.1) !important;
+  border-color: rgba(249, 115, 22, 0.24);
 }
 
-.tooling-repo-action-button:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
+.tooling-repo-action-icon:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
 .tooling-template-row {
@@ -1154,14 +1249,19 @@ html[data-theme-mode="dark"] .top-home-update-dot {
   }
 
   .tooling-repo-row {
-    align-items: flex-start;
+    align-items: stretch;
     flex-direction: column;
+  }
+
+  .tooling-repo-leading {
+    width: 100%;
   }
 
   .tooling-repo-actions {
     opacity: 1;
     pointer-events: auto;
     transform: none;
+    margin-left: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- make skill repo manager modal full-screen with scrollable content area
- align repo row interaction with homepage style: centered drag handle and right-side expanded icon actions
- align title/subtitle left edge and keep subtitle as full-width link
- update tooling page tests and bump release metadata to 1.2.10

## Verification
- npm test -- --run src/features/tooling/ToolingPage.test.tsx
- npm run build