### PR TITLE
fix(proxy): skip auth backup when auth.json is missing

### DIFF
--- a/backend/internal/api/settings_handler.go
+++ b/backend/internal/api/settings_handler.go
@@ -439,7 +439,7 @@ func createCodexBackupSnapshot(home string, kind string, backupSource string) (s
 	for _, file := range files {
 		source := filepath.Join(home, ".codex", file.Name)
 		target := filepath.Join(targetDir, file.Name)
-		if kind == codexBackupKindPreRestore {
+		if kind == codexBackupKindPreRestore || (kind == codexBackupKindRegular && backupSource == backupSourceProxyEnable && file.Name == "auth.json") {
 			if err := copyOptionalFile(source, target); err != nil {
 				return "", "", err
 			}
@@ -887,6 +887,13 @@ func (h *SettingsHandler) restoreCodexBackup(w http.ResponseWriter, r *http.Requ
 	for _, name := range restoreFiles {
 		source := filepath.Join(backupDir, name)
 		target := filepath.Join(codexDir, name)
+		if name == "auth.json" {
+			if err := copyOptionalFile(source, target); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			continue
+		}
 		if err := copyRequiredFile(source, target); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -918,6 +925,9 @@ func (h *SettingsHandler) getCodexBackupFiles(w http.ResponseWriter, r *http.Req
 	for _, name := range []string{"config.toml", "auth.json", "manifest.json"} {
 		raw, err := os.ReadFile(filepath.Join(backupDir, name))
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}

--- a/backend/internal/api/settings_handler_test.go
+++ b/backend/internal/api/settings_handler_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -665,6 +666,41 @@ func TestSettingsHandlerProxyDisableRestoreDoesNotRestoreAuthJSON(t *testing.T) 
 	assertFileNotContains(t, filepath.Join(home, ".codex", "config.toml"), `model_provider = "openai"`)
 	assertFileContains(t, filepath.Join(home, ".codex", "auth.json"), `"token-updated"`)
 	assertFileNotContains(t, filepath.Join(home, ".codex", "auth.json"), `"token-before"`)
+}
+
+func TestSettingsHandlerProxyEnableWithoutAuthJSONSkipsAuthBackup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	prepareCodexFiles(t, home, "model_provider = \"openai\"\n", `{"access_token":"token-before"}`)
+	if err := os.Remove(filepath.Join(home, ".codex", "auth.json")); err != nil {
+		t.Fatalf("remove auth.json: %v", err)
+	}
+
+	handler, _ := newSettingsHandler(t)
+
+	enableReq := httptest.NewRequest(http.MethodPost, "/settings/proxy/enable", nil)
+	enableRec := httptest.NewRecorder()
+	handler.ServeHTTP(enableRec, enableReq)
+	if enableRec.Code != http.StatusOK {
+		t.Fatalf("POST /settings/proxy/enable status = %d, want %d; body=%s", enableRec.Code, http.StatusOK, enableRec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(enableRec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal enable response: %v", err)
+	}
+	backupID, _ := payload["last_backup_id"].(string)
+	if strings.TrimSpace(backupID) == "" {
+		t.Fatal("last_backup_id is empty")
+	}
+
+	backupDir := filepath.Join(home, ".aigate", "data", "codex", "backup", backupID)
+	if _, err := os.Stat(filepath.Join(backupDir, "config.toml")); err != nil {
+		t.Fatalf("stat backup config.toml: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(backupDir, "auth.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("backup auth.json err = %v, want not exists", err)
+	}
 }
 
 func TestSettingsHandlerUpdatingProxyAddressRewritesEnabledConfig(t *testing.T) {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.10",
+  "version": "1.2.11",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.10"
+version = "1.2.11"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.10"
+version = "1.2.11"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/docs/plans/2026-04-10-proxy-enable-skip-auth-backup-plan.md
+++ b/docs/plans/2026-04-10-proxy-enable-skip-auth-backup-plan.md
@@ -1,0 +1,41 @@
+# Proxy Enable Missing Auth Backup Plan (2026-04-10)
+
+## 背景
+
+在 macOS 客户端开启代理时，系统会尝试备份 `~/.codex/auth.json`。当该文件不存在时，备份流程返回错误并阻塞代理开启，导致用户在网络切换或首次环境下无法正常启用代理。
+
+## 根因
+
+代理开启流程将 `auth.json` 视为必需备份文件，缺少“可选文件”语义。相关 API 在列出和恢复备份文件时也将 `auth.json` 缺失视作错误，形成联动失败。
+
+## 目标
+
+1. `proxy_enable` 在 `auth.json` 缺失时继续执行，不阻塞主流程。
+2. 备份文件查询与恢复接口对缺失 `auth.json` 保持容错。
+3. 保留已有备份机制与安全边界，不引入额外权限扩大。
+
+## 变更范围
+
+- `backend/internal/api/settings_handler.go`
+  - 代理开启时将 `auth.json` 备份改为可选逻辑。
+  - 备份文件列表与恢复流程跳过不存在的 `auth.json`，避免返回硬错误。
+- `backend/internal/api/settings_handler_test.go`
+  - 增加/更新回归测试，覆盖缺失 `auth.json` 时代理开启成功的场景。
+
+## 测试策略
+
+1. 目标测试：
+   - `go test ./internal/api -run TestSettingsHandlerProxy -count=1`
+2. 用例重点：
+   - 缺失 `~/.codex/auth.json` 时，`/settings/proxy/enable` 返回成功。
+   - 备份查询与恢复路径不因缺失 `auth.json` 失败。
+
+## 风险与回滚
+
+- 风险：如果未来某些流程强依赖 `auth.json`，跳过备份可能导致恢复后状态不完整。
+- 缓解：仅在文件不存在时跳过，文件存在时仍按原逻辑备份/恢复；日志保留可观测性。
+- 回滚：回滚到前一提交即可恢复严格依赖行为。
+
+## 发布说明
+
+该修复属于代理稳定性补丁，建议作为 `v1.2.11` 发布，附带说明“缺失 `auth.json` 不再阻塞代理开启”。

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.10",
+  "version": "1.2.11",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary\n- make proxy enable tolerant when ~/.codex/auth.json is missing\n- keep codex backup restore/list APIs tolerant for optional auth.json\n- add plan doc and bump release metadata to 1.2.11\n\n## Verification\n- cd backend && go test ./internal/api -run TestSettingsHandlerProxy -count=1