### PR TITLE
fix: resolve desktop update deadlock and release v1.3.1

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.2.12",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.2.12",
+      "version": "1.3.1",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.2.12",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.2.12"
+version = "1.3.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.2.12"
+version = "1.3.1"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -556,11 +556,16 @@ fn get_update_state<R: Runtime>(app: AppHandle<R>) -> Result<UpdateStatePayload,
 #[tauri::command]
 async fn check_for_app_update<R: Runtime>(app: AppHandle<R>) -> Result<UpdateStatePayload, String> {
     let current_version = app.package_info().version.to_string();
-    {
+    let checking_snapshot = {
         let mut manager = lock_update_manager()?;
         if !manager.begin_check() {
-            return Ok(current_update_snapshot(&current_version));
+            Some(normalize_update_snapshot(manager.snapshot(), &current_version))
+        } else {
+            None
         }
+    };
+    if let Some(snapshot) = checking_snapshot {
+        return Ok(snapshot);
     }
 
     match resolve_update_future_with_timeout(fetch_update(&app), UPDATE_CHECK_TIMEOUT, "check update").await {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.2.12",
+  "version": "1.3.1",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.2.12",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.2.12",
+      "version": "1.3.1",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.2.12",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary\n- fix desktop update deadlock caused by nested UPDATE_MANAGER lock acquisition in check_for_app_update\n- keep concurrent check path lock-free for snapshot return\n- bump app version to 1.3.1 across desktop/frontend manifests\n\n## Verification\n- cargo test update_manager --manifest-path desktop/src-tauri/Cargo.toml\n- npm --prefix frontend run test