### PR TITLE
fix: align skill discovery sync/install/install-status

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -3295,11 +3295,11 @@ func discoverSkillsFromCentral(home string, clients []toolingClientState) ([]dis
 			Branch:   raw.Branch,
 			Enabled:  true,
 		})
-		sourcePath := strings.Trim(strings.TrimSpace(raw.SourcePath), "/")
+		sourcePath := normalizeDiscoveredSourcePath(raw.SourcePath)
 		if sourcePath == "" {
-			sourcePath = strings.Trim(strings.TrimSpace(raw.Name), "/")
+			sourcePath = normalizeDiscoveredSourcePath(raw.Name)
 		}
-		key := firstNonEmpty(strings.TrimSpace(raw.ID), discoveredSkillKey(repo.Platform, repo.Owner+"/"+repo.Name, repo.Branch, sourcePath))
+		key := discoveredSkillKey(repo.Platform, repo.Owner+"/"+repo.Name, repo.Branch, sourcePath)
 		record := discoveredSkillRecord{
 			ID:              key,
 			Name:            firstNonEmpty(strings.TrimSpace(raw.Name), filepath.Base(sourcePath), "Skill"),
@@ -4273,12 +4273,26 @@ func discoveredSkillKey(platform string, sourceRepo string, branch string, sourc
 	if strings.TrimSpace(sourceRepo) == "" {
 		return ""
 	}
+	normalizedSourcePath := normalizeDiscoveredSourcePath(sourcePath)
+	if normalizedSourcePath == "" {
+		return ""
+	}
 	return strings.ToLower(strings.Join([]string{
 		normalizeSkillRepoPlatform(platform),
 		strings.TrimSpace(sourceRepo),
 		firstNonEmpty(branch, "main"),
-		strings.Trim(strings.TrimSpace(sourcePath), "/"),
+		normalizedSourcePath,
 	}, ":"))
+}
+
+func normalizeDiscoveredSourcePath(raw string) string {
+	path := strings.Trim(strings.TrimSpace(raw), "/")
+	path = strings.ReplaceAll(path, "\\", "/")
+	lower := strings.ToLower(path)
+	if strings.HasSuffix(lower, "/skill.md") {
+		path = path[:len(path)-len("/skill.md")]
+	}
+	return strings.Trim(path, "/")
 }
 
 func encodeRepoPath(path string) string {
@@ -4343,10 +4357,22 @@ func installDiscoveredSkillCollection(home string, id string, method string, app
 
 func parseDiscoveredSkillID(id string) (platform string, repoFullName string, branch string, sourcePath string, err error) {
 	parts := strings.SplitN(strings.TrimSpace(id), ":", 4)
-	if len(parts) != 4 {
+	switch len(parts) {
+	case 4:
+		sourcePath = normalizeDiscoveredSourcePath(parts[3])
+		if sourcePath == "" {
+			return "", "", "", "", fmt.Errorf("invalid discovered skill id: %s", id)
+		}
+		return normalizeSkillRepoPlatform(parts[0]), parts[1], firstNonEmpty(parts[2], "main"), sourcePath, nil
+	case 3:
+		legacySourcePath := normalizeDiscoveredSourcePath(parts[2])
+		if legacySourcePath == "" {
+			return "", "", "", "", fmt.Errorf("invalid discovered skill id: %s", id)
+		}
+		return normalizeSkillRepoPlatform(parts[0]), parts[1], "main", legacySourcePath, nil
+	default:
 		return "", "", "", "", fmt.Errorf("invalid discovered skill id: %s", id)
 	}
-	return normalizeSkillRepoPlatform(parts[0]), parts[1], firstNonEmpty(parts[2], "main"), strings.Trim(parts[3], "/"), nil
 }
 
 func fetchDiscoveredSkillFiles(repo skillRepoRecord, sourcePath string) (map[string]string, error) {

--- a/backend/internal/api/tooling_handler_internal_test.go
+++ b/backend/internal/api/tooling_handler_internal_test.go
@@ -190,3 +190,27 @@ func blockToolingDirWithFile(t *testing.T, home string) {
 		t.Fatalf("write blocker file: %v", err)
 	}
 }
+
+func TestNormalizeDiscoveredSourcePathRemovesSkillMarkdownSuffix(t *testing.T) {
+	got := normalizeDiscoveredSourcePath("collections/demo/SKILL.md")
+	if got != "collections/demo" {
+		t.Fatalf("normalizeDiscoveredSourcePath = %q, want collections/demo", got)
+	}
+}
+
+func TestDiscoveredSkillKeyNormalizesSourcePath(t *testing.T) {
+	key := discoveredSkillKey("github", "openai/skills", "main", "collections/demo/SKILL.md")
+	if key != "github:openai/skills:main:collections/demo" {
+		t.Fatalf("discoveredSkillKey = %q, want normalized skill dir key", key)
+	}
+}
+
+func TestParseDiscoveredSkillIDSupportsLegacyCentralFormat(t *testing.T) {
+	platform, repo, branch, sourcePath, err := parseDiscoveredSkillID("github:openai/skills:collections/demo")
+	if err != nil {
+		t.Fatalf("parseDiscoveredSkillID legacy format err = %v", err)
+	}
+	if platform != "github" || repo != "openai/skills" || branch != "main" || sourcePath != "collections/demo" {
+		t.Fatalf("legacy parse result = (%q,%q,%q,%q), want (github,openai/skills,main,collections/demo)", platform, repo, branch, sourcePath)
+	}
+}

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -378,7 +378,7 @@ describe("ToolingPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /发现技能/ }));
 
     const dialog = await screen.findByRole("dialog", { name: /发现技能/ });
-    expect(vi.mocked(api.getToolingDiscoveredSkills)).toHaveBeenCalledWith({ limit: 80, offset: 0, query: "" });
+    expect(vi.mocked(api.refreshToolingDiscoveredSkills)).toHaveBeenCalledWith({ limit: 80, offset: 0, query: "" });
     expect(within(dialog).getByPlaceholderText("搜索发现的技能")).toBeInTheDocument();
     expect(await within(dialog).findByText("最新索引")).toBeInTheDocument();
     expect(within(dialog).getByText("2 skills")).toBeInTheDocument();
@@ -391,10 +391,26 @@ describe("ToolingPage", () => {
     vi.mocked((api as typeof api & { getToolingState: typeof vi.fn }).getToolingState)
       .mockResolvedValueOnce(buildToolingState())
       .mockImplementation(() => new Promise(() => {}));
-    vi.mocked(api.getToolingDiscoveredSkills)
+    vi.mocked(api.refreshToolingDiscoveredSkills)
       .mockResolvedValueOnce(buildDiscoveredSkillResponse())
       .mockResolvedValueOnce(buildDiscoveredSkillResponse())
       .mockImplementationOnce(() => new Promise(() => {}));
+    vi.mocked(api.getToolingDiscoveredSkills).mockResolvedValueOnce(
+      buildDiscoveredSkillResponse({
+        items: [
+          {
+            ...buildDiscoveredSkillResponse().items[0],
+            installed_apps: { codex: false },
+            update_available: false,
+          },
+          {
+            ...buildDiscoveredSkillResponse().items[1],
+            installed_apps: { codex: true },
+            update_available: false,
+          },
+        ],
+      }),
+    );
 
     render(<ToolingPage mode="skills" t={(text) => text} />);
 
@@ -404,7 +420,7 @@ describe("ToolingPage", () => {
     const dialog = await screen.findByRole("dialog", { name: /发现技能/ });
     fireEvent.click(within(dialog).getByRole("button", { name: "刷新技能索引" }));
 
-    await waitFor(() => expect(vi.mocked(api.getToolingDiscoveredSkills)).toHaveBeenCalledWith({ limit: 80, offset: 0, query: "" }));
+    await waitFor(() => expect(vi.mocked(api.refreshToolingDiscoveredSkills)).toHaveBeenCalledWith({ limit: 80, offset: 0, query: "" }));
 
     fireEvent.click(within(dialog).getByRole("button", { name: "查看 Alpha Skill 的仓库页面" }));
     expect(openSpy).toHaveBeenCalledWith("https://github.com/openai/codex-skills/tree/main/skills/alpha", "_blank", "noopener,noreferrer");
@@ -412,49 +428,53 @@ describe("ToolingPage", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "打开 Alpha Skill 的源目录" }));
     expect(openSpy).toHaveBeenCalledWith("https://github.com/openai/codex-skills/tree/main/skills/alpha", "_blank", "noopener,noreferrer");
 
-    fireEvent.click(within(dialog).getByRole("button", { name: "安装 Alpha Skill" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "安装 Zulu Skill" }));
     await waitFor(() =>
       expect(vi.mocked((api as typeof api & { installToolingDiscoveredSkill: typeof vi.fn }).installToolingDiscoveredSkill)).toHaveBeenCalledWith({
-        id: "github:openai/codex-skills:main:skills/alpha",
+        id: "github:openai/codex-skills:main:skills/zulu",
         apps: ["codex"],
       }),
     );
     await waitFor(() =>
-      expect(within(dialog).getByRole("button", { name: "已安装 Alpha Skill" })).toBeDisabled(),
+      expect(vi.mocked((api as typeof api & { getToolingDiscoveredSkills: typeof vi.fn }).getToolingDiscoveredSkills)).toHaveBeenCalledWith({
+        limit: 80,
+        offset: 0,
+        query: "",
+      }),
     );
   });
 
   it("distinguishes install states in discovered skill rows", async () => {
-    vi.mocked((api as typeof api & { getToolingDiscoveredSkills: typeof vi.fn }).getToolingDiscoveredSkills).mockResolvedValue(
-      buildDiscoveredSkillResponse({
-        items: [
-          {
-            ...buildDiscoveredSkillResponse().items[1],
-            installed_apps: { codex: true },
-            update_available: true,
-          },
-          {
-            ...buildDiscoveredSkillResponse().items[0],
-            installed_apps: { codex: true },
-            update_available: false,
-          },
-        ],
-      }),
-    );
+    const discoveredState = buildDiscoveredSkillResponse({
+      items: [
+        {
+          ...buildDiscoveredSkillResponse().items[1],
+          installed_apps: { codex: true },
+          update_available: true,
+        },
+        {
+          ...buildDiscoveredSkillResponse().items[0],
+          installed_apps: { codex: true },
+          update_available: false,
+        },
+      ],
+    });
+    vi.mocked((api as typeof api & { refreshToolingDiscoveredSkills: typeof vi.fn }).refreshToolingDiscoveredSkills).mockResolvedValue(discoveredState);
+    vi.mocked((api as typeof api & { getToolingDiscoveredSkills: typeof vi.fn }).getToolingDiscoveredSkills).mockResolvedValue(discoveredState);
     render(<ToolingPage mode="skills" t={(text) => text} />);
 
     await screen.findByText("Skill 技能");
     fireEvent.click(screen.getByRole("button", { name: /发现技能/ }));
 
     const dialog = await screen.findByRole("dialog", { name: /发现技能/ });
-    expect(within(dialog).getByText("可更新")).toBeInTheDocument();
+    expect(await within(dialog).findByText("可更新")).toBeInTheDocument();
     expect(within(dialog).getAllByText("已安装").length).toBeGreaterThan(0);
     expect(within(dialog).getByRole("button", { name: "更新 Alpha Skill" })).toBeEnabled();
     expect(within(dialog).getByRole("button", { name: "已安装 Zulu Skill" })).toBeDisabled();
   });
 
   it("searches discovered skills on Enter and calls server only once per confirmed query", async () => {
-    vi.mocked(api.getToolingDiscoveredSkills)
+    vi.mocked(api.refreshToolingDiscoveredSkills)
       .mockResolvedValueOnce(
         buildDiscoveredSkillResponse({
           indexed_total: 35,
@@ -487,7 +507,7 @@ describe("ToolingPage", () => {
     fireEvent.change(search, { target: { value: "alpha" } });
     fireEvent.keyDown(search, { key: "Enter", code: "Enter" });
     await within(dialog).findByText("Alpha Skill");
-    expect(vi.mocked(api.getToolingDiscoveredSkills)).toHaveBeenLastCalledWith({ limit: 80, offset: 0, query: "alpha" });
+    expect(vi.mocked(api.refreshToolingDiscoveredSkills)).toHaveBeenLastCalledWith({ limit: 80, offset: 0, query: "alpha" });
   });
 
   it("renders the minimal mcp management layout and toggles codex sync", async () => {

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -35,6 +35,7 @@ import {
   importToolingSkills,
   installToolingDiscoveredSkill,
   removeToolingRepo,
+  refreshToolingDiscoveredSkills,
   resolveToolingRepo,
   reorderToolingRepos,
   updateToolingSkill,
@@ -147,7 +148,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     void reload();
   }, []);
 
-  async function loadDiscoveredSkillsPage(params?: { reset?: boolean; query?: string; forceStatus?: string }) {
+  async function loadDiscoveredSkillsPage(params?: { reset?: boolean; query?: string; forceStatus?: string; refresh?: boolean }) {
     const reset = params?.reset ?? false;
     const query = params?.query ?? discoveryQuery;
     const requestId = discoveryRequestRef.current + 1;
@@ -164,7 +165,8 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     }
     try {
       const nextOffset = reset ? 0 : discoveryOffset;
-      const response = await getToolingDiscoveredSkills({ limit: DISCOVERY_PAGE_SIZE, offset: nextOffset, query });
+      const request = params?.refresh ? refreshToolingDiscoveredSkills : getToolingDiscoveredSkills;
+      const response = await request({ limit: DISCOVERY_PAGE_SIZE, offset: nextOffset, query });
       if (discoveryRequestRef.current !== requestId) {
         return;
       }
@@ -192,7 +194,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     if (!skillDiscoverOpen || mode !== "skills") {
       return;
     }
-    void loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("最新索引") });
+    void loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("最新索引"), refresh: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [skillDiscoverOpen, mode, discoveryQuery]);
 
@@ -371,7 +373,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
 
   async function handleDiscoveryRefresh() {
     try {
-      await loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("最新索引") });
+      await loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("最新索引"), refresh: true });
       await reload({ background: true });
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("刷新发现技能失败"));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1149,7 +1149,28 @@ export async function getToolingDiscoveredSkills(params?: { limit?: number; offs
 }
 
 export async function refreshToolingDiscoveredSkills(params?: { limit?: number; offset?: number; query?: string }): Promise<ToolingSkillDiscoveryResponse> {
-  return getToolingDiscoveredSkills(params);
+  const search = new URLSearchParams();
+  if (typeof params?.limit === "number" && params.limit > 0) {
+    search.set("limit", String(params.limit));
+  }
+  if (typeof params?.offset === "number" && params.offset >= 0) {
+    search.set("offset", String(params.offset));
+  }
+  const query = params?.query?.trim();
+  if (query) {
+    search.set("q", query);
+  }
+  const queryString = search.toString();
+  const response = await fetch(apiPath(`/tooling/skills/discover/refresh${queryString ? `?${queryString}` : ""}`), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to refresh discovered skills");
+  }
+  return response.json();
 }
 
 export async function installToolingDiscoveredSkill(payload: {


### PR DESCRIPTION
## Summary\n- normalize discovered skill source path and canonical id generation\n- support legacy discovered skill id parsing during install\n- switch discovery refresh to server refresh endpoint and align tests\n\n## Verification\n- go test ./internal/api -count=1\n- npm test -- src/features/tooling/ToolingPage.test.tsx