### PR TITLE
feat: cloud skill discovery + public telemetry ingest

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -35,14 +35,12 @@ const (
 	skillDiscoveryAutoRefreshJitterMax = 3 * time.Hour
 	skillMetricsHeartbeatName          = "__client_active__"
 	skillMetricsHeartbeatSource        = "__aigate_client__"
-	skillMetricsActiveReportInterval   = 12 * time.Hour
-	skillMetricsRetryInterval          = time.Hour
-	skillMetricsMaxRetry               = 3
-	skillMetricsPendingQueueMaxItems   = 200
+	skillMetricsActiveReportInterval   = time.Hour
 )
 
 var toolingSupportedApps = []string{"codex"}
 var skillMetricsReportMu sync.Mutex
+var skillMetricsHeartbeatHomes sync.Map
 
 type defaultSkillRepoSeed struct {
 	Platform string
@@ -53,10 +51,7 @@ type defaultSkillRepoSeed struct {
 }
 
 type ToolingHandler struct {
-	mu                  sync.Mutex
-	autoRefreshMu       sync.Mutex
-	autoRefreshInFlight bool
-	autoRefreshLastTry  time.Time
+	mu sync.Mutex
 }
 
 func NewToolingHandler() *ToolingHandler {
@@ -246,8 +241,13 @@ type toolingSkillUpdateRequest struct {
 }
 
 type toolingDiscoveredSkillInstallRequest struct {
-	ID   string   `json:"id"`
-	Apps []string `json:"apps"`
+	ID         string   `json:"id"`
+	Platform   string   `json:"platform,omitempty"`
+	RepoOwner  string   `json:"repo_owner,omitempty"`
+	RepoName   string   `json:"repo_name,omitempty"`
+	Branch     string   `json:"branch,omitempty"`
+	SourcePath string   `json:"source_path,omitempty"`
+	Apps       []string `json:"apps"`
 }
 
 type toolingRepoRequest struct {
@@ -370,12 +370,8 @@ func (h *ToolingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getState(w)
 	case r.Method == http.MethodPut && r.URL.Path == "/tooling/settings":
 		h.updateSettings(w, r)
-	case r.Method == http.MethodGet && r.URL.Path == "/tooling/skills/discover":
-		h.getDiscoveredSkills(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/discover/install":
 		h.installDiscoveredSkill(w, r)
-	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/discover/refresh":
-		h.refreshDiscoveredSkills(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/import":
 		h.importSkills(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/apply":
@@ -428,13 +424,11 @@ func (h *ToolingHandler) getState(w http.ResponseWriter) {
 	cfg, _ = h.syncManagedCodexMcpServers(home, cfg)
 	clients := toolingClientStates(home)
 	skills := scanManagedSkills(home, clients)
-	cache, _ := loadSkillDiscoveryCache(home)
-	applySkillUpdateFlags(skills, cache.Items)
+	ensureToolingClientActiveHeartbeat(home)
 	go reportToolingClientActive(home)
 	repoResults := defaultRepoSearchResults()
 	discoveredServers := discoverMcpServers(home)
 	servers := h.buildMcpViews(home, cfg)
-	h.maybeScheduleDailySkillDiscoveryRefresh(home, cache)
 
 	writeJSON(w, http.StatusOK, toolingStateResponse{
 		SkillSyncMethod:      normalizeSkillSyncMethod(cfg.SkillSyncMethod),
@@ -449,33 +443,20 @@ func (h *ToolingHandler) getState(w http.ResponseWriter) {
 	})
 }
 
-func (h *ToolingHandler) maybeScheduleDailySkillDiscoveryRefresh(home string, cache skillDiscoveryCache) {
-	now := timeNowUTC()
-	if nextAutoAt, _ := time.Parse(time.RFC3339, strings.TrimSpace(cache.NextAutoRefreshAt)); !nextAutoAt.IsZero() && now.Before(nextAutoAt) {
+func ensureToolingClientActiveHeartbeat(home string) {
+	if strings.TrimSpace(home) == "" {
 		return
 	}
-	parsedFetchedAt, _ := time.Parse(time.RFC3339, strings.TrimSpace(cache.FetchedAt))
-	if !parsedFetchedAt.IsZero() && now.Sub(parsedFetchedAt) < 24*time.Hour {
+	if _, exists := skillMetricsHeartbeatHomes.LoadOrStore(home, struct{}{}); exists {
 		return
 	}
-	h.autoRefreshMu.Lock()
-	defer h.autoRefreshMu.Unlock()
-	if h.autoRefreshInFlight {
-		return
-	}
-	if !h.autoRefreshLastTry.IsZero() && now.Sub(h.autoRefreshLastTry) < 5*time.Minute {
-		return
-	}
-	h.autoRefreshInFlight = true
-	h.autoRefreshLastTry = now
-	go func() {
-		defer func() {
-			h.autoRefreshMu.Lock()
-			h.autoRefreshInFlight = false
-			h.autoRefreshMu.Unlock()
-		}()
-		_, _, _ = h.refreshSkillDiscovery(home)
-	}()
+	go func(homeDir string) {
+		ticker := time.NewTicker(skillMetricsActiveReportInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			reportToolingClientActive(homeDir)
+		}
+	}(home)
 }
 
 func (h *ToolingHandler) updateSettings(w http.ResponseWriter, r *http.Request) {
@@ -500,80 +481,19 @@ func (h *ToolingHandler) updateSettings(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, map[string]any{"skill_sync_method": cfg.SkillSyncMethod})
 }
 
-func (h *ToolingHandler) getDiscoveredSkills(w http.ResponseWriter, r *http.Request) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	limit, offset := parseDiscoveredPaging(r.URL.Query())
-	query := strings.TrimSpace(r.URL.Query().Get("q"))
-	cache, ok := loadSkillDiscoveryCache(home)
-	if ok {
-		matched := filterDiscoveredItems(cache.Items, query)
-		items, total := sliceDiscoveredItems(matched, limit, offset)
-		writeJSON(w, http.StatusOK, toolingSkillDiscoverResponse{
-			Cached:       true,
-			FetchedAt:    cache.FetchedAt,
-			IndexedTotal: len(cache.Items),
-			Total:        total,
-			Offset:       offset,
-			Limit:        limit,
-			Query:        query,
-			Items:        items,
-		})
-		return
-	}
-	items, fetchedAt, err := h.refreshSkillDiscovery(home)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
-	}
-	matched := filterDiscoveredItems(items, query)
-	paged, total := sliceDiscoveredItems(matched, limit, offset)
-	writeJSON(w, http.StatusOK, toolingSkillDiscoverResponse{
-		Cached:       false,
-		FetchedAt:    fetchedAt,
-		IndexedTotal: len(items),
-		Total:        total,
-		Offset:       offset,
-		Limit:        limit,
-		Query:        query,
-		Items:        paged,
-	})
-}
-
-func (h *ToolingHandler) refreshDiscoveredSkills(w http.ResponseWriter, r *http.Request) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	items, fetchedAt, err := h.refreshSkillDiscovery(home)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
-	}
-	limit, offset := parseDiscoveredPaging(r.URL.Query())
-	query := strings.TrimSpace(r.URL.Query().Get("q"))
-	matched := filterDiscoveredItems(items, query)
-	paged, total := sliceDiscoveredItems(matched, limit, offset)
-	writeJSON(w, http.StatusOK, toolingSkillDiscoverResponse{
-		Cached:       false,
-		FetchedAt:    fetchedAt,
-		IndexedTotal: len(items),
-		Total:        total,
-		Offset:       offset,
-		Limit:        limit,
-		Query:        query,
-		Items:        paged,
-	})
-}
-
 func (h *ToolingHandler) installDiscoveredSkill(w http.ResponseWriter, r *http.Request) {
 	var req toolingDiscoveredSkillInstallRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		repoFullName := strings.Trim(strings.TrimSpace(req.RepoOwner), "/") + "/" + strings.Trim(strings.TrimSpace(req.RepoName), "/")
+		id = discoveredSkillKey(req.Platform, repoFullName, firstNonEmpty(strings.TrimSpace(req.Branch), "main"), req.SourcePath)
+	}
+	if strings.TrimSpace(id) == "" {
+		http.Error(w, "invalid discovered skill install payload", http.StatusBadRequest)
 		return
 	}
 	home, err := os.UserHomeDir()
@@ -583,12 +503,12 @@ func (h *ToolingHandler) installDiscoveredSkill(w http.ResponseWriter, r *http.R
 	}
 	cfg := h.loadConfig(home)
 	method := normalizeSkillSyncMethod(cfg.SkillSyncMethod)
-	applied, err := installDiscoveredSkillCollection(home, req.ID, method, reqApps(req.Apps))
+	applied, err := installDiscoveredSkillCollection(home, id, method, reqApps(req.Apps))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	go reportDiscoveredSkillInstall(home, req.ID)
+	go reportDiscoveredSkillInstall(home, id)
 	writeJSON(w, http.StatusOK, map[string]any{"applied": applied, "enabled": true, "skill_sync_method": method})
 }
 
@@ -3456,18 +3376,6 @@ type skillMetricsReportState struct {
 	LastActiveAt string `json:"last_active_at,omitempty"`
 }
 
-type pendingSkillMetricsEvent struct {
-	Kind        string            `json:"kind"`
-	Payload     map[string]string `json:"payload"`
-	RetryCount  int               `json:"retry_count"`
-	NextRetryAt string            `json:"next_retry_at,omitempty"`
-	CreatedAt   string            `json:"created_at,omitempty"`
-}
-
-type pendingSkillMetricsQueue struct {
-	Items []pendingSkillMetricsEvent `json:"items"`
-}
-
 type skillMetricsHTTPError struct {
 	StatusCode int
 	Body       string
@@ -3487,10 +3395,6 @@ func toolingAnonymousClientIDPath(home string) string {
 
 func toolingSkillMetricsStatePath(home string) string {
 	return filepath.Join(aigateDataRoot(home), "tooling", "skill-metrics-state.json")
-}
-
-func toolingSkillMetricsPendingPath(home string) string {
-	return filepath.Join(aigateDataRoot(home), "tooling", "skill-metrics-pending.json")
 }
 
 func loadOrCreateToolingAnonymousID(home string) (string, error) {
@@ -3555,40 +3459,6 @@ func saveSkillMetricsState(home string, state skillMetricsReportState) error {
 	return writeAtomic(path, append(raw, '\n'), 0o600)
 }
 
-func loadPendingSkillMetricsQueue(home string) pendingSkillMetricsQueue {
-	path := toolingSkillMetricsPendingPath(home)
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return pendingSkillMetricsQueue{}
-	}
-	var queue pendingSkillMetricsQueue
-	if json.Unmarshal(raw, &queue) != nil {
-		return pendingSkillMetricsQueue{}
-	}
-	if len(queue.Items) > skillMetricsPendingQueueMaxItems {
-		queue.Items = queue.Items[len(queue.Items)-skillMetricsPendingQueueMaxItems:]
-	}
-	return queue
-}
-
-func savePendingSkillMetricsQueue(home string, queue pendingSkillMetricsQueue) error {
-	path := toolingSkillMetricsPendingPath(home)
-	if len(queue.Items) == 0 {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		return nil
-	}
-	raw, err := json.Marshal(queue)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return writeAtomic(path, append(raw, '\n'), 0o600)
-}
-
 func shouldThrottleActiveMetric(home string, now time.Time) bool {
 	state := loadSkillMetricsState(home)
 	lastAt, err := time.Parse(time.RFC3339, strings.TrimSpace(state.LastActiveAt))
@@ -3606,78 +3476,6 @@ func markActiveMetricScheduled(home string, now time.Time) {
 	}
 }
 
-func queueSkillMetricsEvent(home string, kind string, payload map[string]string, nextRetryAt time.Time) {
-	queue := loadPendingSkillMetricsQueue(home)
-	item := pendingSkillMetricsEvent{
-		Kind:        strings.TrimSpace(kind),
-		Payload:     payload,
-		RetryCount:  0,
-		NextRetryAt: nextRetryAt.UTC().Format(time.RFC3339),
-		CreatedAt:   timeNowUTC().UTC().Format(time.RFC3339),
-	}
-	queue.Items = append(queue.Items, item)
-	if len(queue.Items) > skillMetricsPendingQueueMaxItems {
-		queue.Items = queue.Items[len(queue.Items)-skillMetricsPendingQueueMaxItems:]
-	}
-	if err := savePendingSkillMetricsQueue(home, queue); err != nil {
-		fmt.Fprintf(os.Stderr, "save pending skill metrics queue failed: %v\n", err)
-	}
-}
-
-func flushPendingSkillMetricsEvents(home string, baseURL string, now time.Time) {
-	queue := loadPendingSkillMetricsQueue(home)
-	if len(queue.Items) == 0 {
-		return
-	}
-	next := make([]pendingSkillMetricsEvent, 0, len(queue.Items))
-	for _, item := range queue.Items {
-		runAt := parseTimestamp(item.NextRetryAt)
-		if !runAt.IsZero() && now.Before(runAt) {
-			next = append(next, item)
-			continue
-		}
-		statusCode, err := sendSkillMetricsInstallEvent(baseURL, item.Payload)
-		if err == nil {
-			continue
-		}
-		if !shouldRetrySkillMetric(statusCode, err) {
-			fmt.Fprintf(os.Stderr, "drop pending skill metrics event (%s): %v\n", item.Kind, err)
-			continue
-		}
-		item.RetryCount++
-		if item.RetryCount >= skillMetricsMaxRetry {
-			fmt.Fprintf(os.Stderr, "drop pending skill metrics event after retries (%s): %v\n", item.Kind, err)
-			continue
-		}
-		item.NextRetryAt = now.Add(skillMetricsRetryInterval).UTC().Format(time.RFC3339)
-		next = append(next, item)
-	}
-	if err := savePendingSkillMetricsQueue(home, pendingSkillMetricsQueue{Items: next}); err != nil {
-		fmt.Fprintf(os.Stderr, "save pending skill metrics queue failed: %v\n", err)
-	}
-}
-
-func parseTimestamp(raw string) time.Time {
-	if strings.TrimSpace(raw) == "" {
-		return time.Time{}
-	}
-	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(raw))
-	if err != nil {
-		return time.Time{}
-	}
-	return parsed
-}
-
-func shouldRetrySkillMetric(statusCode int, err error) bool {
-	if err == nil {
-		return false
-	}
-	if statusCode == 0 {
-		return true
-	}
-	return statusCode == http.StatusTooManyRequests || statusCode >= 500
-}
-
 func reportDiscoveredSkillInstall(home string, id string) {
 	baseURL := skillMetricsBaseURL()
 	if baseURL == "" {
@@ -3685,8 +3483,6 @@ func reportDiscoveredSkillInstall(home string, id string) {
 	}
 	skillMetricsReportMu.Lock()
 	defer skillMetricsReportMu.Unlock()
-	now := timeNowUTC()
-	flushPendingSkillMetricsEvents(home, baseURL, now)
 	platform, repoFullName, _, sourcePath, err := parseDiscoveredSkillID(id)
 	if err != nil {
 		return
@@ -3712,12 +3508,9 @@ func reportDiscoveredSkillInstall(home string, id string) {
 	if platform == "" {
 		return
 	}
-	statusCode, err := sendSkillMetricsInstallEvent(baseURL, payload)
+	_, err = sendSkillMetricsInstallEvent(baseURL, payload)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "report discovered skill install failed: %v\n", err)
-		if shouldRetrySkillMetric(statusCode, err) {
-			queueSkillMetricsEvent(home, "install", payload, now.Add(skillMetricsRetryInterval))
-		}
 	}
 }
 
@@ -3729,7 +3522,6 @@ func reportToolingClientActive(home string) {
 	skillMetricsReportMu.Lock()
 	defer skillMetricsReportMu.Unlock()
 	now := timeNowUTC()
-	flushPendingSkillMetricsEvents(home, baseURL, now)
 	if shouldThrottleActiveMetric(home, now) {
 		return
 	}
@@ -3747,16 +3539,12 @@ func reportToolingClientActive(home string) {
 		"skill_name":   skillMetricsHeartbeatName,
 		"source_repo":  skillMetricsHeartbeatSource,
 	}
-	statusCode, err := sendSkillMetricsInstallEvent(baseURL, payload)
+	markActiveMetricScheduled(home, now)
+	_, err = sendSkillMetricsInstallEvent(baseURL, payload)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "report tooling active failed: %v\n", err)
-		if shouldRetrySkillMetric(statusCode, err) {
-			queueSkillMetricsEvent(home, "active", payload, now.Add(skillMetricsRetryInterval))
-			markActiveMetricScheduled(home, now)
-		}
 		return
 	}
-	markActiveMetricScheduled(home, now)
 }
 
 func sendSkillMetricsInstallEvent(baseURL string, payload map[string]string) (int, error) {

--- a/backend/internal/api/tooling_handler_internal_test.go
+++ b/backend/internal/api/tooling_handler_internal_test.go
@@ -107,7 +107,7 @@ func TestReportDiscoveredSkillInstallFallsBackWhenAnonymousFileCannotPersist(t *
 	}
 }
 
-func TestReportToolingClientActiveIsThrottledWithinHalfDay(t *testing.T) {
+func TestReportToolingClientActiveIsThrottledWithinOneHour(t *testing.T) {
 	home := t.TempDir()
 
 	var (
@@ -138,45 +138,52 @@ func TestReportToolingClientActiveIsThrottledWithinHalfDay(t *testing.T) {
 	}
 }
 
-func TestReportDiscoveredSkillInstallQueuesOnNetworkFailure(t *testing.T) {
+func TestReportToolingClientActiveReportsAgainAfterOneHour(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now().UTC()
+	if err := saveSkillMetricsState(home, skillMetricsReportState{
+		LastActiveAt: now.Add(-2 * time.Hour).Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	var (
+		mu   sync.Mutex
+		hits int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/events/install" {
+			http.NotFound(w, r)
+			return
+		}
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"inserted":true}`))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("AIGATE_SKILL_METRICS_URL", server.URL)
+
+	reportToolingClientActive(home)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Fatalf("events/install hits = %d, want 1 for overdue active report", hits)
+	}
+}
+
+func TestReportDiscoveredSkillInstallDoesNotQueueOnNetworkFailure(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("AIGATE_SKILL_METRICS_URL", "http://127.0.0.1:1")
 
 	id := discoveredSkillKey("github", "openai/skills", "main", "collections/demo-skill")
 	reportDiscoveredSkillInstall(home, id)
 
-	queue := loadPendingSkillMetricsQueue(home)
-	if len(queue.Items) != 1 {
-		t.Fatalf("pending queue items = %d, want 1", len(queue.Items))
-	}
-	if queue.Items[0].Kind != "install" {
-		t.Fatalf("pending queue kind = %q, want install", queue.Items[0].Kind)
-	}
-	if queue.Items[0].RetryCount != 0 {
-		t.Fatalf("pending queue retry_count = %d, want 0", queue.Items[0].RetryCount)
-	}
-}
-
-func TestFlushPendingSkillMetricsDropsItemAfterMaxRetry(t *testing.T) {
-	home := t.TempDir()
-	queue := pendingSkillMetricsQueue{
-		Items: []pendingSkillMetricsEvent{
-			{
-				Kind:       "install",
-				Payload:    map[string]string{"anonymous_id": "aigate-test", "skill_name": "demo", "source_repo": "openai/skills"},
-				RetryCount: skillMetricsMaxRetry - 1,
-			},
-		},
-	}
-	if err := savePendingSkillMetricsQueue(home, queue); err != nil {
-		t.Fatalf("seed pending queue: %v", err)
-	}
-
-	flushPendingSkillMetricsEvents(home, "http://127.0.0.1:1", time.Now().UTC())
-
-	after := loadPendingSkillMetricsQueue(home)
-	if len(after.Items) != 0 {
-		t.Fatalf("pending queue items = %d, want 0 after max retry", len(after.Items))
+	pendingPath := filepath.Join(aigateDataRoot(home), "tooling", "skill-metrics-pending.json")
+	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("pending queue file should not exist, stat err = %v", err)
 	}
 }
 

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gcssloop/codex-router/backend/internal/api"
 )
@@ -888,380 +887,6 @@ command = "uvx"
 	}
 }
 
-func TestToolingHandlerDiscoverSkillsUsesCacheAndRefreshesLatest(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	defaultArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
-		"README.md": "# OpenAI Skills\n",
-	})
-	anthropicsArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
-		"README.md": "# Anthropic Skills\n",
-	})
-	composioArchive := makeGitHubArchiveZip(t, "awesome-claude-skills-master", map[string]string{
-		"README.md": "# Awesome Claude Skills\n",
-	})
-	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
-		"skills/zulu/SKILL.md":  "# Zulu Skill\nA trailing skill.\n\nUNIQUE-ZULU-BODY\n",
-		"skills/alpha/SKILL.md": "---\ndescription: Alpha summary\n---\n# Alpha Skill\nDetailed alpha body that must not be cached.\n",
-	})
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/openai/skills/archive/refs/heads/main.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(defaultArchive)
-		case r.Method == http.MethodGet && r.URL.Path == "/anthropics/skills/archive/refs/heads/main.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(anthropicsArchive)
-		case r.Method == http.MethodGet && r.URL.Path == "/ComposioHQ/awesome-claude-skills/archive/refs/heads/master.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(composioArchive)
-		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(archive)
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/archive/refs/heads/") && strings.HasSuffix(r.URL.Path, ".zip"):
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(defaultArchive)
-		case strings.Contains(r.URL.Path, "/git/trees/"), strings.Contains(r.URL.Path, "/contents/"):
-			http.Error(w, "legacy github api path should not be used", http.StatusForbidden)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-	t.Setenv("AIGATE_GITHUB_ARCHIVE_BASE", server.URL)
-
-	writeToolingConfig(t, home, map[string]any{
-		"skill_sync_method": "symlink",
-		"skill_repos": []map[string]any{
-			{
-				"platform": "github",
-				"owner":    "openai",
-				"name":     "codex-skills",
-				"branch":   "main",
-				"enabled":  true,
-			},
-		},
-		"mcp_servers": []any{},
-	})
-	writeSkillDiscoveryCache(t, home, map[string]any{
-		"fetched_at": "2026-04-08T10:00:00Z",
-		"items": []map[string]any{
-			{
-				"id":               "github:openai/codex-skills:skills/cached",
-				"name":             "Cached Skill",
-				"description":      "Cached summary",
-				"platform":         "github",
-				"repo_owner":       "openai",
-				"repo_name":        "codex-skills",
-				"branch":           "main",
-				"repo_url":         "https://github.com/openai/codex-skills",
-				"source_path":      "skills/cached",
-				"source_url":       "https://github.com/openai/codex-skills/tree/main/skills/cached",
-				"managed_name":     "cached-skill",
-				"content_hash":     "cached-hash",
-				"installed_apps":   map[string]bool{"codex": false},
-				"update_available": false,
-			},
-		},
-	})
-
-	handler := api.NewToolingHandler()
-
-	cached := doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/discover", nil, nil, http.StatusOK)
-	var cachedPayload map[string]any
-	if err := json.Unmarshal(cached, &cachedPayload); err != nil {
-		t.Fatalf("unmarshal cached discover payload: %v", err)
-	}
-	if cachedPayload["cached"] != true {
-		t.Fatalf("cached flag = %v, want true", cachedPayload["cached"])
-	}
-	items := cachedPayload["items"].([]any)
-	if len(items) != 1 || items[0].(map[string]any)["name"] != "Cached Skill" {
-		t.Fatalf("cached items = %v, want cached skill only", cachedPayload["items"])
-	}
-
-	refreshed := doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/refresh", bytes.NewBufferString(`{}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
-	var refreshedPayload map[string]any
-	if err := json.Unmarshal(refreshed, &refreshedPayload); err != nil {
-		t.Fatalf("unmarshal refreshed discover payload: %v", err)
-	}
-	if refreshedPayload["cached"] != false {
-		t.Fatalf("cached flag after refresh = %v, want false", refreshedPayload["cached"])
-	}
-	refreshedItems := refreshedPayload["items"].([]any)
-	if len(refreshedItems) != 2 {
-		t.Fatalf("refreshed items = %d, want 2", len(refreshedItems))
-	}
-	if refreshedItems[0].(map[string]any)["name"] != "Alpha Skill" || refreshedItems[1].(map[string]any)["name"] != "Zulu Skill" {
-		t.Fatalf("refreshed item order = %v, want alpha then zulu", refreshedPayload["items"])
-	}
-	if strings.TrimSpace(refreshedItems[0].(map[string]any)["content_hash"].(string)) == "" {
-		t.Fatalf("refreshed item content_hash = %v, want non-empty hash", refreshedItems[0].(map[string]any)["content_hash"])
-	}
-
-	cacheRaw := readSkillDiscoveryCacheRaw(t, home)
-	if !strings.Contains(cacheRaw, "Alpha Skill") {
-		t.Fatalf("cache raw = %s, want discovered names cached", cacheRaw)
-	}
-	if strings.Contains(cacheRaw, "Detailed alpha body that must not be cached.") || strings.Contains(cacheRaw, "UNIQUE-ZULU-BODY") {
-		t.Fatalf("cache raw = %s, want index-only cache without full body content", cacheRaw)
-	}
-
-	cfg := readToolingConfig(t, home)
-	repos := cfg["skill_repos"].([]any)
-	var target map[string]any
-	for _, raw := range repos {
-		repo := raw.(map[string]any)
-		if repo["owner"] == "openai" && repo["name"] == "codex-skills" {
-			target = repo
-			break
-		}
-	}
-	if target == nil {
-		t.Fatalf("skill_repos = %v, want openai/codex-skills", cfg["skill_repos"])
-	}
-	if target["skill_count"] != float64(2) {
-		t.Fatalf("skill_count = %v, want 2", target["skill_count"])
-	}
-}
-
-func TestToolingHandlerDiscoverSkillsMarksInstalledUpdatesByHash(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	defaultArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
-		"README.md": "# OpenAI Skills\n",
-	})
-	anthropicsArchive := makeGitHubArchiveZip(t, "skills-main", map[string]string{
-		"README.md": "# Anthropic Skills\n",
-	})
-	composioArchive := makeGitHubArchiveZip(t, "awesome-claude-skills-master", map[string]string{
-		"README.md": "# Awesome Claude Skills\n",
-	})
-	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
-		"skills/alpha/SKILL.md":          "# Alpha Skill\nNew upstream summary.\n",
-		"skills/alpha/assets/config.txt": "v2\n",
-		"skills/zulu/SKILL.md":           "# Zulu Skill\nStable upstream summary.\n",
-	})
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/openai/skills/archive/refs/heads/main.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(defaultArchive)
-		case r.Method == http.MethodGet && r.URL.Path == "/anthropics/skills/archive/refs/heads/main.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(anthropicsArchive)
-		case r.Method == http.MethodGet && r.URL.Path == "/ComposioHQ/awesome-claude-skills/archive/refs/heads/master.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(composioArchive)
-		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(archive)
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/archive/refs/heads/") && strings.HasSuffix(r.URL.Path, ".zip"):
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(defaultArchive)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-	t.Setenv("AIGATE_GITHUB_ARCHIVE_BASE", server.URL)
-
-	writeToolingConfig(t, home, map[string]any{
-		"skill_sync_method": "symlink",
-		"skill_repos": []map[string]any{
-			{
-				"platform": "github",
-				"owner":    "openai",
-				"name":     "codex-skills",
-				"branch":   "main",
-				"enabled":  true,
-			},
-		},
-		"mcp_servers": []any{},
-	})
-
-	managedRoot := filepath.Join(home, ".aigate", "data", "tooling", "skills", "codex-skills-alpha")
-	if err := os.MkdirAll(filepath.Join(managedRoot, "assets"), 0o755); err != nil {
-		t.Fatalf("MkdirAll managed assets: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(managedRoot, "SKILL.md"), []byte("# Alpha Skill\nOld local summary.\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile managed SKILL: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(managedRoot, "assets", "config.txt"), []byte("v1\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile managed asset: %v", err)
-	}
-	if err := writeSkillMetadataForTest(managedRoot, map[string]any{
-		"name":        "codex-skills-alpha",
-		"source_repo": "openai/codex-skills",
-		"source_kind": "discovered",
-		"platform":    "github",
-		"branch":      "main",
-		"source_path": "skills/alpha",
-		"source_url":  "https://github.com/openai/codex-skills/tree/main/skills/alpha",
-	}); err != nil {
-		t.Fatalf("writeSkillMetadata: %v", err)
-	}
-	codexRoot := filepath.Join(home, ".codex", "skills", "codex-skills-alpha")
-	if err := copyDirForTest(managedRoot, codexRoot); err != nil {
-		t.Fatalf("copyDir codex skill: %v", err)
-	}
-
-	handler := api.NewToolingHandler()
-	refreshed := doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/refresh", bytes.NewBufferString(`{}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
-
-	var payload map[string]any
-	if err := json.Unmarshal(refreshed, &payload); err != nil {
-		t.Fatalf("unmarshal refreshed discover payload: %v", err)
-	}
-	items := payload["items"].([]any)
-	alpha := items[0].(map[string]any)
-	if alpha["name"] != "Alpha Skill" {
-		t.Fatalf("first item = %v, want Alpha Skill", alpha["name"])
-	}
-	if alpha["installed_apps"].(map[string]any)["codex"] != true {
-		t.Fatalf("installed_apps = %v, want codex true", alpha["installed_apps"])
-	}
-	if alpha["update_available"] != true {
-		t.Fatalf("update_available = %v, want true", alpha["update_available"])
-	}
-	if alpha["installed_hash"] == alpha["content_hash"] {
-		t.Fatalf("installed_hash = %v, content_hash = %v, want differing hashes", alpha["installed_hash"], alpha["content_hash"])
-	}
-}
-
-func TestToolingHandlerDiscoverSkillsSupportsServerSideQuery(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	writeSkillDiscoveryCache(t, home, map[string]any{
-		"fetched_at": "2026-04-10T10:00:00Z",
-		"items": []map[string]any{
-			{
-				"id":           "github:openai/skills:main:skills/alpha",
-				"name":         "Alpha Skill",
-				"description":  "alpha summary",
-				"platform":     "github",
-				"repo_owner":   "openai",
-				"repo_name":    "skills",
-				"branch":       "main",
-				"repo_url":     "https://github.com/openai/skills",
-				"source_path":  "skills/alpha",
-				"source_url":   "https://github.com/openai/skills/tree/main/skills/alpha",
-				"managed_name": "openai-skills-alpha",
-			},
-			{
-				"id":           "github:openai/skills:main:skills/beta",
-				"name":         "Beta Skill",
-				"description":  "beta summary",
-				"platform":     "github",
-				"repo_owner":   "openai",
-				"repo_name":    "skills",
-				"branch":       "main",
-				"repo_url":     "https://github.com/openai/skills",
-				"source_path":  "skills/beta",
-				"source_url":   "https://github.com/openai/skills/tree/main/skills/beta",
-				"managed_name": "openai-skills-beta",
-			},
-		},
-	})
-
-	handler := api.NewToolingHandler()
-	resp := doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/discover?q=alpha&limit=80&offset=0", nil, nil, http.StatusOK)
-	var payload map[string]any
-	if err := json.Unmarshal(resp, &payload); err != nil {
-		t.Fatalf("unmarshal discover response: %v", err)
-	}
-	if payload["indexed_total"] != float64(2) {
-		t.Fatalf("indexed_total = %v, want 2", payload["indexed_total"])
-	}
-	if payload["total"] != float64(1) {
-		t.Fatalf("total = %v, want 1", payload["total"])
-	}
-	items := payload["items"].([]any)
-	if len(items) != 1 || items[0].(map[string]any)["name"] != "Alpha Skill" {
-		t.Fatalf("items = %v, want only Alpha Skill", payload["items"])
-	}
-}
-
-func TestToolingHandlerRefreshDiscoveryUpdatesRepoStarsAndNextAutoRefresh(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
-		"skills/alpha/SKILL.md": "# Alpha Skill\nA summary.\n",
-	})
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/openai/codex-skills":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"default_branch":"main","stargazers_count":321}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(archive)
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/archive/refs/heads/") && strings.HasSuffix(r.URL.Path, ".zip"):
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(archive)
-		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/"):
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"default_branch":"main","stargazers_count":321}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-	t.Setenv("AIGATE_GITHUB_API_BASE", server.URL)
-	t.Setenv("AIGATE_GITHUB_ARCHIVE_BASE", server.URL)
-
-	writeToolingConfig(t, home, map[string]any{
-		"skill_sync_method": "symlink",
-		"skill_repos": []map[string]any{
-			{
-				"platform":   "github",
-				"owner":      "openai",
-				"name":       "codex-skills",
-				"branch":     "main",
-				"enabled":    true,
-				"star_count": 0,
-			},
-		},
-		"mcp_servers": []any{},
-	})
-
-	handler := api.NewToolingHandler()
-	doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/refresh", bytes.NewBufferString(`{}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
-
-	cfg := readToolingConfig(t, home)
-	repos := cfg["skill_repos"].([]any)
-	repo := repos[0].(map[string]any)
-	if repo["star_count"] != float64(321) {
-		t.Fatalf("star_count = %v, want 321", repo["star_count"])
-	}
-
-	cacheRaw := readSkillDiscoveryCacheRaw(t, home)
-	var cache map[string]any
-	if err := json.Unmarshal([]byte(cacheRaw), &cache); err != nil {
-		t.Fatalf("unmarshal cache: %v", err)
-	}
-	fetchedAt, err := time.Parse(time.RFC3339, cache["fetched_at"].(string))
-	if err != nil {
-		t.Fatalf("parse fetched_at: %v", err)
-	}
-	nextAt, err := time.Parse(time.RFC3339, cache["next_auto_refresh_at"].(string))
-	if err != nil {
-		t.Fatalf("parse next_auto_refresh_at: %v", err)
-	}
-	minNext := fetchedAt.Add(24*time.Hour - time.Minute)
-	maxNext := fetchedAt.Add(27*time.Hour + time.Minute)
-	if nextAt.Before(minNext) || nextAt.After(maxNext) {
-		t.Fatalf("next_auto_refresh_at = %s, want between %s and %s", nextAt.Format(time.RFC3339), minNext.Format(time.RFC3339), maxNext.Format(time.RFC3339))
-	}
-}
-
 func TestToolingHandlerSkillRepoCRUDSupportsPlatformAwareRecords(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1409,6 +1034,58 @@ func TestToolingHandlerCanInstallDiscoveredSkillIntoManagedAndCodexDirs(t *testi
 	}
 	if metaPayload["platform"] != "github" || metaPayload["source_path"] != "skills/alpha" {
 		t.Fatalf("metadata = %s, want discovery source metadata", string(metaRaw))
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "codex-skills-alpha", "SKILL.md")); err != nil {
+		t.Fatalf("expected codex synced skill file: %v", err)
+	}
+}
+
+func TestToolingHandlerDiscoveryListEndpointsRemoved(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	handler := api.NewToolingHandler()
+	doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/discover", nil, nil, http.StatusNotFound)
+	doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/refresh", bytes.NewBufferString(`{}`), map[string]string{"Content-Type": "application/json"}, http.StatusNotFound)
+}
+
+func TestToolingHandlerCanInstallDiscoveredSkillUsingCloudPayloadWithoutID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	archive := makeGitHubArchiveZip(t, "codex-skills-main", map[string]string{
+		"skills/alpha/SKILL.md":          "# Alpha Skill\nInstallable summary from cloud payload.\n",
+		"skills/alpha/assets/config.txt": "v1\n",
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/openai/codex-skills/archive/refs/heads/main.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("AIGATE_GITHUB_ARCHIVE_BASE", server.URL)
+
+	handler := api.NewToolingHandler()
+	installed := doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/install", bytes.NewBufferString(`{
+		"platform":"github",
+		"repo_owner":"openai",
+		"repo_name":"codex-skills",
+		"branch":"main",
+		"source_path":"skills/alpha",
+		"apps":["codex"]
+	}`), map[string]string{"Content-Type": "application/json"}, http.StatusOK)
+	if !strings.Contains(string(installed), `"applied":1`) {
+		t.Fatalf("install response = %s, want applied 1", string(installed))
+	}
+
+	managedRoot := filepath.Join(home, ".aigate", "data", "tooling", "skills", "codex-skills-alpha")
+	if _, err := os.Stat(filepath.Join(managedRoot, "SKILL.md")); err != nil {
+		t.Fatalf("expected managed skill file: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "codex-skills-alpha", "SKILL.md")); err != nil {
 		t.Fatalf("expected codex synced skill file: %v", err)
@@ -1593,29 +1270,4 @@ func readToolingConfig(t *testing.T, home string) map[string]any {
 		t.Fatalf("Unmarshal tooling config: %v", err)
 	}
 	return payload
-}
-
-func writeSkillDiscoveryCache(t *testing.T, home string, payload map[string]any) {
-	t.Helper()
-	path := filepath.Join(home, ".aigate", "data", "tooling", "skill-discovery-cache.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("MkdirAll discovery cache dir: %v", err)
-	}
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		t.Fatalf("Marshal discovery cache: %v", err)
-	}
-	if err := os.WriteFile(path, raw, 0o600); err != nil {
-		t.Fatalf("WriteFile discovery cache: %v", err)
-	}
-}
-
-func readSkillDiscoveryCacheRaw(t *testing.T, home string) string {
-	t.Helper()
-	path := filepath.Join(home, ".aigate", "data", "tooling", "skill-discovery-cache.json")
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile discovery cache: %v", err)
-	}
-	return string(raw)
 }

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -432,6 +432,11 @@ describe("ToolingPage", () => {
     await waitFor(() =>
       expect(vi.mocked((api as typeof api & { installToolingDiscoveredSkill: typeof vi.fn }).installToolingDiscoveredSkill)).toHaveBeenCalledWith({
         id: "github:openai/codex-skills:main:skills/zulu",
+        platform: "github",
+        repo_owner: "openai",
+        repo_name: "codex-skills",
+        branch: "main",
+        source_path: "skills/zulu",
         apps: ["codex"],
       }),
     );

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -170,7 +170,8 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
       if (discoveryRequestRef.current !== requestId) {
         return;
       }
-      const nextItems = reset ? response.items : [...discoveryItems, ...response.items];
+      const mapped = mapDiscoveredInstallState(response.items, state?.installed_skills ?? []);
+      const nextItems = reset ? mapped : [...discoveryItems, ...mapped];
       setDiscoveryItems(nextItems);
       setDiscoveryTotal(response.total);
       setDiscoveryIndexedTotal(typeof response.indexed_total === "number" ? response.indexed_total : response.total);
@@ -383,7 +384,15 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   async function handleDiscoveredSkillInstall(skill: ToolingDiscoveredSkill) {
     setDiscoveryBusyId(skill.id);
     try {
-      await installToolingDiscoveredSkill({ id: skill.id, apps: ["codex"] });
+      await installToolingDiscoveredSkill({
+        id: skill.id,
+        platform: skill.platform,
+        repo_owner: skill.repo_owner,
+        repo_name: skill.repo_name,
+        branch: skill.branch,
+        source_path: skill.source_path,
+        apps: ["codex"],
+      });
       const nextAction = skill.update_available ? t("已更新") : t("安装成功");
       setDiscoveryItems((current) => markDiscoveredSkillInstalled(current, skill.id));
       setDiscoveryStatus(skill.update_available ? t("已更新") : t("已安装"));
@@ -859,6 +868,31 @@ function markDiscoveredSkillInstalled(items: ToolingDiscoveredSkill[], id: strin
       },
       installed_hash: item.content_hash,
       update_available: false,
+    };
+  });
+}
+
+function mapDiscoveredInstallState(items: ToolingDiscoveredSkill[], installedSkills: ToolingSkillRecord[]): ToolingDiscoveredSkill[] {
+  if (items.length === 0) {
+    return items;
+  }
+  const installedByName = new Map<string, ToolingSkillRecord>();
+  for (const skill of installedSkills) {
+    const collectionName = skill.managed_path.split(/[\\/]/).filter(Boolean).at(-1)?.toLowerCase();
+    if (!collectionName) {
+      continue;
+    }
+    installedByName.set(collectionName, skill);
+  }
+  return items.map((item) => {
+    const installed = installedByName.get(item.managed_name.toLowerCase());
+    if (!installed) {
+      return item;
+    }
+    return {
+      ...item,
+      installed_apps: { ...(item.installed_apps ?? {}), codex: Boolean(installed.installed_apps?.codex) },
+      update_available: Boolean(installed.update_available),
     };
   });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1128,6 +1128,19 @@ export async function resolveToolingRepo(input: string): Promise<ToolingResolved
 }
 
 export async function getToolingDiscoveredSkills(params?: { limit?: number; offset?: number; query?: string }): Promise<ToolingSkillDiscoveryResponse> {
+  return requestCloudDiscoveredSkills(params);
+}
+
+export async function refreshToolingDiscoveredSkills(params?: { limit?: number; offset?: number; query?: string }): Promise<ToolingSkillDiscoveryResponse> {
+  return requestCloudDiscoveredSkills(params);
+}
+
+function skillMetricsBaseURL(): string {
+  const value = (import.meta.env.VITE_SKILL_METRICS_BASE_URL as string | undefined)?.trim();
+  return value ? value.replace(/\/$/, "") : "https://aigate-skill-metrics.gcssloop.workers.dev";
+}
+
+function buildDiscoverySearch(params?: { limit?: number; offset?: number; query?: string }): URLSearchParams {
   const search = new URLSearchParams();
   if (typeof params?.limit === "number" && params.limit > 0) {
     search.set("limit", String(params.limit));
@@ -1139,42 +1152,47 @@ export async function getToolingDiscoveredSkills(params?: { limit?: number; offs
   if (query) {
     search.set("q", query);
   }
-  const queryString = search.toString();
-  const response = await fetch(apiPath(`/tooling/skills/discover${queryString ? `?${queryString}` : ""}`));
+  return search;
+}
+
+async function requestCloudDiscoveredSkills(params?: { limit?: number; offset?: number; query?: string }): Promise<ToolingSkillDiscoveryResponse> {
+  const search = buildDiscoverySearch(params);
+  const hasQuery = Boolean(params?.query?.trim());
+  const endpoint = hasQuery ? "/skills/search" : "/skills/final";
+  const response = await fetch(`${skillMetricsBaseURL()}${endpoint}?${search.toString()}`);
   if (!response.ok) {
     const details = await response.text();
     throw new Error(details || "failed to load discovered skills");
   }
-  return response.json();
-}
-
-export async function refreshToolingDiscoveredSkills(params?: { limit?: number; offset?: number; query?: string }): Promise<ToolingSkillDiscoveryResponse> {
-  const search = new URLSearchParams();
-  if (typeof params?.limit === "number" && params.limit > 0) {
-    search.set("limit", String(params.limit));
-  }
-  if (typeof params?.offset === "number" && params.offset >= 0) {
-    search.set("offset", String(params.offset));
-  }
-  const query = params?.query?.trim();
-  if (query) {
-    search.set("q", query);
-  }
-  const queryString = search.toString();
-  const response = await fetch(apiPath(`/tooling/skills/discover/refresh${queryString ? `?${queryString}` : ""}`), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: "{}",
-  });
-  if (!response.ok) {
-    const details = await response.text();
-    throw new Error(details || "failed to refresh discovered skills");
-  }
-  return response.json();
+  const payload = (await response.json()) as Record<string, unknown>;
+  const items = Array.isArray(payload.items) ? (payload.items as ToolingDiscoveredSkill[]) : [];
+  return {
+    cached: typeof payload.cached === "boolean" ? payload.cached : true,
+    fetched_at: typeof payload.fetched_at === "string" ? payload.fetched_at : "",
+    indexed_total: typeof payload.indexed_total === "number"
+      ? payload.indexed_total
+      : typeof payload.total_items === "number"
+      ? payload.total_items
+      : items.length,
+    total: typeof payload.total === "number"
+      ? payload.total
+      : typeof payload.total_items === "number"
+      ? payload.total_items
+      : items.length,
+    offset: typeof payload.offset === "number" ? payload.offset : 0,
+    limit: typeof payload.limit === "number" ? payload.limit : items.length,
+    query: typeof payload.query === "string" ? payload.query : params?.query?.trim() ?? "",
+    items,
+  };
 }
 
 export async function installToolingDiscoveredSkill(payload: {
   id: string;
+  platform?: "github" | "gitlab";
+  repo_owner?: string;
+  repo_name?: string;
+  branch?: string;
+  source_path?: string;
   apps?: string[];
 }): Promise<{ applied: number; enabled: boolean; skill_sync_method?: "symlink" | "copy" }> {
   const response = await fetch(apiPath("/tooling/skills/discover/install"), {

--- a/services/skill-metrics-worker/src/index.ts
+++ b/services/skill-metrics-worker/src/index.ts
@@ -87,6 +87,7 @@ type CatalogSkillItem = {
   repo_url: string;
   source_path: string;
   source_url: string;
+  managed_name: string;
 };
 
 type SkillCatalog = {
@@ -172,7 +173,6 @@ export default {
         return logoutAdmin();
       }
       if (request.method === "POST" && url.pathname === "/events/install") {
-        await assertBearer(request, env.INGEST_BEARER_TOKEN);
         const payload = (await request.json()) as InstallEventPayload;
         const result = await ingestInstallEvent(env, payload);
         return json(result, 201);
@@ -737,16 +737,19 @@ async function buildCatalogFromSkillsSource(
     const itemId = `${key}:${entry.skill_id}`;
     if (dedupe.has(itemId)) continue;
     dedupe.add(itemId);
+    const branch = tracked.branch || "main";
+    const sourcePath = normalizeCatalogSourcePath(entry.skill_id);
     items.push({
-      id: itemId,
+      id: discoveredSkillId(repoInfo.platform, repoInfo.owner, repoInfo.name, branch, sourcePath),
       name: entry.name || entry.skill_id,
       platform: repoInfo.platform,
       repo_owner: repoInfo.owner,
       repo_name: repoInfo.name,
-      branch: tracked.branch || "main",
+      branch,
       repo_url: repoHomeURL(repoInfo.platform, repoInfo.owner, repoInfo.name),
-      source_path: `${entry.skill_id}/SKILL.md`,
-      source_url: repoHomeURL(repoInfo.platform, repoInfo.owner, repoInfo.name),
+      source_path: sourcePath,
+      source_url: repoTreeURL(repoInfo.platform, repoInfo.owner, repoInfo.name, branch, sourcePath),
+      managed_name: buildDiscoveredManagedName(repoInfo.owner, repoInfo.name, sourcePath),
     });
   }
 
@@ -764,13 +767,15 @@ async function buildCatalogFromSkillsSource(
 }
 
 function parseSourceRepo(source: string): { platform: "github" | "gitlab"; owner: string; name: string } | null {
-  const value = source.trim().replace(/^https?:\/\/(www\.)?github\.com\//i, "").replace(/^https?:\/\/(www\.)?gitlab\.com\//i, "");
+  const trimmed = source.trim();
+  const platform = /^https?:\/\/(www\.)?gitlab\.com\//i.test(trimmed) ? "gitlab" : "github";
+  const value = trimmed.replace(/^https?:\/\/(www\.)?github\.com\//i, "").replace(/^https?:\/\/(www\.)?gitlab\.com\//i, "");
   const parts = value.split("/").filter(Boolean);
   if (parts.length < 2) return null;
   const owner = parts[0];
   const name = parts[1];
   if (!owner || !name) return null;
-  return { platform: "github", owner, name };
+  return { platform, owner, name };
 }
 
 async function fetchSkillsSourceEntries(): Promise<SkillsSourceEntry[]> {
@@ -848,6 +853,32 @@ function repoHomeURL(platform: "github" | "gitlab", owner: string, name: string)
     return `https://gitlab.com/${owner}/${name}`;
   }
   return `https://github.com/${owner}/${name}`;
+}
+
+function repoTreeURL(platform: "github" | "gitlab", owner: string, name: string, branch: string, sourcePath: string): string {
+  const root = repoHomeURL(platform, owner, name);
+  const normalizedPath = sourcePath.replace(/^\/+|\/+$/g, "");
+  if (!normalizedPath) {
+    return root;
+  }
+  if (platform === "gitlab") {
+    return `${root}/-/tree/${encodeURIComponent(branch)}/${normalizedPath}`;
+  }
+  return `${root}/tree/${encodeURIComponent(branch)}/${normalizedPath}`;
+}
+
+function normalizeCatalogSourcePath(value: string): string {
+  return value.trim().replace(/^\/+|\/+$/g, "").replace(/\\/g, "/").replace(/\/SKILL\.md$/i, "");
+}
+
+function discoveredSkillId(platform: "github" | "gitlab", owner: string, name: string, branch: string, sourcePath: string): string {
+  return `${platform}:${owner}/${name}:${branch}:${sourcePath}`;
+}
+
+function buildDiscoveredManagedName(owner: string, name: string, sourcePath: string): string {
+  const source = sourcePath.replace(/^\/+|\/+$/g, "").replace(/\\/g, "/");
+  const last = source.split("/").filter(Boolean).at(-1) ?? "skill";
+  return `${name}-${last}`.toLowerCase().replace(/[^a-z0-9._-]+/g, "-");
 }
 
 function sliceCatalog(catalog: SkillCatalog, offset: number, limit: number): SkillCatalog & { total_items: number; offset: number; limit: number } {

--- a/services/skill-metrics-worker/test/index.spec.ts
+++ b/services/skill-metrics-worker/test/index.spec.ts
@@ -70,18 +70,26 @@ describe("skill metrics worker", () => {
 		expect(payload.error).toBe("unauthorized");
 	});
 
-	it("POST /events/install requires bearer token", async () => {
+	it("POST /events/install is public even when bearer token is configured", async () => {
+		const mockDb = {
+			prepare: () => ({
+				bind: () => ({
+					run: async () => ({ meta: { changes: 1 } }),
+				}),
+			}),
+		} as unknown as D1Database;
+		const mockKv = {
+			delete: async () => null,
+		} as unknown as KVNamespace;
 		const request = new Request("https://example.com/events/install", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
 			body: JSON.stringify({ skill_name: "demo-skill" }),
 		});
 		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, { ...noopEnv, INGEST_BEARER_TOKEN: "ingest-token" }, ctx);
+		const response = await worker.fetch(request, { DB: mockDb, SKILL_METRICS_CACHE: mockKv, INGEST_BEARER_TOKEN: "ingest-token" }, ctx);
 		await waitOnExecutionContext(ctx);
-		expect(response.status).toBe(401);
-		const payload = (await response.json()) as { error: string };
-		expect(payload.error).toBe("missing_bearer_token");
+		expect(response.status).toBe(201);
 	});
 
 	it("POST /events/install auto generates anonymous_id when missing", async () => {
@@ -189,8 +197,9 @@ describe("skill metrics worker", () => {
 								repo_name: "skills",
 								branch: "main",
 								repo_url: "https://github.com/openai/skills",
-								source_path: "alpha/SKILL.md",
+								source_path: "alpha",
 								source_url: "https://github.com/openai/skills/tree/main/alpha",
+								managed_name: "skills-alpha",
 							},
 							{
 								id: "github:openai/skills:beta",
@@ -200,8 +209,9 @@ describe("skill metrics worker", () => {
 								repo_name: "skills",
 								branch: "main",
 								repo_url: "https://github.com/openai/skills",
-								source_path: "beta/SKILL.md",
+								source_path: "beta",
 								source_url: "https://github.com/openai/skills/tree/main/beta",
+								managed_name: "skills-beta",
 							},
 						],
 					});


### PR DESCRIPTION
## Summary\n- switch skill discovery/search to cloud APIs and remove local discovery endpoints\n- simplify client telemetry (hourly active heartbeat, install report once, no retry queue)\n- make worker ingest endpoint public for install + active events\n\n## Validation\n- go test ./internal/api -count=1\n- npm test -- src/features/tooling/ToolingPage.test.tsx\n- npm test -- --run (services/skill-metrics-worker)\n- deployed worker and verified POST /events/install returns 201 without Authorization