### PR TITLE
feat: enrich installed skills links and audits metadata

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -122,6 +122,10 @@ type managedSkillRecord struct {
 	SourceClient    string          `json:"source_client,omitempty"`
 	SourceRepo      string          `json:"source_repo,omitempty"`
 	SourceKind      string          `json:"source_kind"`
+	Platform        string          `json:"platform,omitempty"`
+	Branch          string          `json:"branch,omitempty"`
+	SourcePath      string          `json:"source_path,omitempty"`
+	SourceURL       string          `json:"source_url,omitempty"`
 	ManagedPath     string          `json:"managed_path"`
 	InstalledApps   map[string]bool `json:"installed_apps"`
 	UpdateAvailable bool            `json:"update_available"`
@@ -177,19 +181,61 @@ type toolingSkillDiscoverResponse struct {
 	Items        []discoveredSkillRecord `json:"items"`
 }
 
+type toolingInstalledSkillsEnrichedResponse struct {
+	Cached    bool                               `json:"cached"`
+	FetchedAt string                             `json:"fetched_at,omitempty"`
+	Items     []toolingInstalledSkillEnrichedRow `json:"items"`
+}
+
+type toolingInstalledSkillEnrichedRow struct {
+	ManagedName   string               `json:"managed_name"`
+	Name          string               `json:"name"`
+	SourceKind    string               `json:"source_kind"`
+	Platform      string               `json:"platform,omitempty"`
+	SourceRepo    string               `json:"source_repo,omitempty"`
+	Branch        string               `json:"branch,omitempty"`
+	SourcePath    string               `json:"source_path,omitempty"`
+	SourceURL     string               `json:"source_url,omitempty"`
+	SkillsShURL   string               `json:"skills_sh_url,omitempty"`
+	AuditsSummary *toolingAuditSummary `json:"audits_summary,omitempty"`
+}
+
+type toolingAuditSummary struct {
+	MatchConfidence float64                       `json:"match_confidence"`
+	Providers       []toolingAuditProviderSummary `json:"providers"`
+}
+
+type toolingAuditProviderSummary struct {
+	Provider string `json:"provider"`
+	Label    string `json:"label"`
+	Status   string `json:"status"`
+	URL      string `json:"url"`
+}
+
 type centralDiscoveredSkillResponse struct {
 	FetchedAt string `json:"fetched_at"`
 	Total     int    `json:"total_items"`
 	Items     []struct {
-		ID         string `json:"id"`
-		Name       string `json:"name"`
-		Platform   string `json:"platform"`
-		RepoOwner  string `json:"repo_owner"`
-		RepoName   string `json:"repo_name"`
-		Branch     string `json:"branch"`
-		RepoURL    string `json:"repo_url"`
-		SourcePath string `json:"source_path"`
-		SourceURL  string `json:"source_url"`
+		ID            string `json:"id"`
+		Name          string `json:"name"`
+		Platform      string `json:"platform"`
+		RepoOwner     string `json:"repo_owner"`
+		RepoName      string `json:"repo_name"`
+		Branch        string `json:"branch"`
+		RepoURL       string `json:"repo_url"`
+		SourcePath    string `json:"source_path"`
+		SourceURL     string `json:"source_url"`
+		ManagedName   string `json:"managed_name"`
+		SkillsShURL   string `json:"skills_sh_url"`
+		AuditsSummary struct {
+			MatchConfidence float64 `json:"match_confidence"`
+			Providers       []struct {
+				Provider string `json:"provider"`
+				Label    string `json:"label"`
+				Status   string `json:"status"`
+				URL      string `json:"url"`
+			} `json:"providers"`
+		} `json:"audits_summary"`
 	} `json:"items"`
 }
 
@@ -382,6 +428,8 @@ func (h *ToolingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.importSkills(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/apply":
 		h.applySkills(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/tooling/skills/installed/enriched":
+		h.listInstalledSkillsEnriched(w)
 	case r.Method == http.MethodGet && r.URL.Path == "/tooling/skills/repos":
 		h.listSkillRepos(w)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/repos":
@@ -446,6 +494,65 @@ func (h *ToolingHandler) getState(w http.ResponseWriter) {
 		DiscoveredMcpServers: discoveredServers,
 		McpTemplates:         toolingTemplates,
 		McpServers:           servers,
+	})
+}
+
+func (h *ToolingHandler) listInstalledSkillsEnriched(w http.ResponseWriter) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	clients := toolingClientStates(home)
+	skills := scanManagedSkills(home, clients)
+	rows := make([]toolingInstalledSkillEnrichedRow, 0, len(skills))
+	for _, skill := range skills {
+		rows = append(rows, toolingInstalledSkillEnrichedRow{
+			ManagedName: skillCollectionNameFromManagedPath(skill.ManagedPath),
+			Name:        strings.TrimSpace(skill.Name),
+			SourceKind:  strings.TrimSpace(skill.SourceKind),
+			Platform:    normalizeSkillRepoPlatform(skill.Platform),
+			SourceRepo:  strings.TrimSpace(skill.SourceRepo),
+			Branch:      strings.TrimSpace(skill.Branch),
+			SourcePath:  normalizeDiscoveredSourcePath(skill.SourcePath),
+			SourceURL:   strings.TrimSpace(skill.SourceURL),
+		})
+	}
+	if len(rows) == 0 {
+		writeJSON(w, http.StatusOK, toolingInstalledSkillsEnrichedResponse{
+			Cached:    true,
+			FetchedAt: timeNowUTC().Format(time.RFC3339),
+			Items:     rows,
+		})
+		return
+	}
+
+	baseURL := skillMetricsBaseURL(home)
+	if strings.TrimSpace(baseURL) == "" {
+		writeJSON(w, http.StatusOK, toolingInstalledSkillsEnrichedResponse{
+			Cached:    true,
+			FetchedAt: timeNowUTC().Format(time.RFC3339),
+			Items:     rows,
+		})
+		return
+	}
+	catalog, err := fetchCentralSkillsCatalog(baseURL)
+	if err != nil {
+		writeJSON(w, http.StatusOK, toolingInstalledSkillsEnrichedResponse{
+			Cached:    true,
+			FetchedAt: timeNowUTC().Format(time.RFC3339),
+			Items:     rows,
+		})
+		return
+	}
+	overlay := buildInstalledSkillCatalogOverlay(catalog)
+	for idx := range rows {
+		applyInstalledSkillOverlay(&rows[idx], overlay)
+	}
+	writeJSON(w, http.StatusOK, toolingInstalledSkillsEnrichedResponse{
+		Cached:    true,
+		FetchedAt: firstNonEmpty(strings.TrimSpace(catalog.FetchedAt), timeNowUTC().Format(time.RFC3339)),
+		Items:     rows,
 	})
 }
 
@@ -1679,6 +1786,10 @@ func scanManagedSkills(home string, clients []toolingClientState) []managedSkill
 			SourceClient:    meta.SourceClient,
 			SourceRepo:      meta.SourceRepo,
 			SourceKind:      firstNonEmpty(meta.SourceKind, "manual"),
+			Platform:        normalizeSkillRepoPlatform(meta.Platform),
+			Branch:          strings.TrimSpace(meta.Branch),
+			SourcePath:      normalizeDiscoveredSourcePath(meta.SourcePath),
+			SourceURL:       strings.TrimSpace(meta.SourceURL),
 			ManagedPath:     entry.FullPath,
 			InstalledApps:   map[string]bool{},
 			UpdateAvailable: false,
@@ -1751,6 +1862,20 @@ func writeSkillMetadata(dir string, meta skillMetadata) error {
 
 func skillKey(dir string) string {
 	return strings.ToLower(filepath.Clean(dir))
+}
+
+func skillCollectionNameFromManagedPath(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(filepath.ToSlash(trimmed), "/")
+	for idx := len(parts) - 1; idx >= 0; idx-- {
+		if strings.TrimSpace(parts[idx]) != "" {
+			return parts[idx]
+		}
+	}
+	return ""
 }
 
 func managedSkillsRoot(home string) string {
@@ -3357,6 +3482,143 @@ func reorderDiscoveredWithRecommendations(items []discoveredSkillRecord, recomme
 		result = append(result, byID[id])
 	}
 	return result
+}
+
+type installedSkillCatalogOverlay struct {
+	byID       map[string]toolingInstalledSkillEnrichedRow
+	byRepoPath map[string]toolingInstalledSkillEnrichedRow
+	byRepoName map[string]toolingInstalledSkillEnrichedRow
+}
+
+func buildInstalledSkillCatalogOverlay(catalog centralDiscoveredSkillResponse) installedSkillCatalogOverlay {
+	overlay := installedSkillCatalogOverlay{
+		byID:       map[string]toolingInstalledSkillEnrichedRow{},
+		byRepoPath: map[string]toolingInstalledSkillEnrichedRow{},
+		byRepoName: map[string]toolingInstalledSkillEnrichedRow{},
+	}
+	for _, item := range catalog.Items {
+		row := toolingInstalledSkillEnrichedRow{
+			Name:        strings.TrimSpace(item.Name),
+			Platform:    normalizeSkillRepoPlatform(item.Platform),
+			SourceRepo:  strings.TrimSpace(item.RepoOwner) + "/" + strings.TrimSpace(item.RepoName),
+			Branch:      strings.TrimSpace(item.Branch),
+			SourcePath:  normalizeDiscoveredSourcePath(item.SourcePath),
+			SourceURL:   strings.TrimSpace(item.SourceURL),
+			SkillsShURL: strings.TrimSpace(item.SkillsShURL),
+		}
+		if len(item.AuditsSummary.Providers) > 0 {
+			summary := toolingAuditSummary{
+				MatchConfidence: item.AuditsSummary.MatchConfidence,
+				Providers:       make([]toolingAuditProviderSummary, 0, len(item.AuditsSummary.Providers)),
+			}
+			for _, provider := range item.AuditsSummary.Providers {
+				summary.Providers = append(summary.Providers, toolingAuditProviderSummary{
+					Provider: strings.TrimSpace(provider.Provider),
+					Label:    strings.TrimSpace(provider.Label),
+					Status:   strings.TrimSpace(provider.Status),
+					URL:      strings.TrimSpace(provider.URL),
+				})
+			}
+			row.AuditsSummary = &summary
+		}
+		overlayRow := row
+		id := discoveredSkillKey(row.Platform, row.SourceRepo, row.Branch, row.SourcePath)
+		if id != "" {
+			overlay.byID[id] = overlayRow
+		}
+		repoKey := installedSkillOverlayRepoKey(row.SourceRepo)
+		if repoKey != "" {
+			if pathKey := installedSkillOverlayRepoPathKey(repoKey, row.SourcePath); pathKey != "" {
+				overlay.byRepoPath[pathKey] = overlayRow
+			}
+			nameKey := installedSkillOverlayRepoNameKey(repoKey, firstNonEmpty(row.Name, item.ManagedName, filepath.Base(strings.Trim(row.SourcePath, "/"))))
+			if nameKey != "" {
+				overlay.byRepoName[nameKey] = overlayRow
+			}
+		}
+	}
+	return overlay
+}
+
+func applyInstalledSkillOverlay(row *toolingInstalledSkillEnrichedRow, overlay installedSkillCatalogOverlay) {
+	if row == nil {
+		return
+	}
+	match := toolingInstalledSkillEnrichedRow{}
+	found := false
+	repoKey := installedSkillOverlayRepoKey(row.SourceRepo)
+	id := discoveredSkillKey(row.Platform, row.SourceRepo, firstNonEmpty(row.Branch, "main"), row.SourcePath)
+	if id != "" {
+		if item, ok := overlay.byID[id]; ok {
+			match = item
+			found = true
+		}
+	}
+	if !found && repoKey != "" && row.SourcePath != "" {
+		if item, ok := overlay.byRepoPath[installedSkillOverlayRepoPathKey(repoKey, row.SourcePath)]; ok {
+			match = item
+			found = true
+		}
+	}
+	if !found && repoKey != "" {
+		name := firstNonEmpty(row.Name, row.ManagedName, filepath.Base(strings.Trim(row.SourcePath, "/")))
+		if item, ok := overlay.byRepoName[installedSkillOverlayRepoNameKey(repoKey, name)]; ok {
+			match = item
+			found = true
+		}
+	}
+	if !found {
+		return
+	}
+	if strings.TrimSpace(row.SourceURL) == "" {
+		row.SourceURL = match.SourceURL
+	}
+	if strings.TrimSpace(row.Platform) == "" {
+		row.Platform = match.Platform
+	}
+	if strings.TrimSpace(row.Branch) == "" {
+		row.Branch = match.Branch
+	}
+	if strings.TrimSpace(row.SourcePath) == "" {
+		row.SourcePath = match.SourcePath
+	}
+	if strings.TrimSpace(row.SkillsShURL) == "" {
+		row.SkillsShURL = match.SkillsShURL
+	}
+	if row.AuditsSummary == nil && match.AuditsSummary != nil {
+		row.AuditsSummary = match.AuditsSummary
+	}
+}
+
+func installedSkillOverlayRepoKey(sourceRepo string) string {
+	trimmed := strings.ToLower(strings.Trim(strings.TrimSpace(sourceRepo), "/"))
+	return strings.TrimPrefix(trimmed, "github:")
+}
+
+func installedSkillOverlayRepoPathKey(repoKey string, sourcePath string) string {
+	repoKey = strings.TrimSpace(repoKey)
+	sourcePath = normalizeDiscoveredSourcePath(sourcePath)
+	if repoKey == "" || sourcePath == "" {
+		return ""
+	}
+	return repoKey + "|" + strings.ToLower(sourcePath)
+}
+
+func installedSkillOverlayRepoNameKey(repoKey string, name string) string {
+	repoKey = strings.TrimSpace(repoKey)
+	name = normalizeInstalledSkillName(name)
+	if repoKey == "" || name == "" {
+		return ""
+	}
+	return repoKey + "|" + name
+}
+
+func normalizeInstalledSkillName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, "_", "-")
+	name = strings.ReplaceAll(name, " ", "-")
+	name = strings.Trim(name, "-")
+	return name
 }
 
 func fetchCentralSkillsCatalog(baseURL string) (centralDiscoveredSkillResponse, error) {

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -77,6 +77,90 @@ func TestToolingHandlerListsManagedSkillsEvenWhenSyncedBySymlink(t *testing.T) {
 	}
 }
 
+func TestToolingHandlerListsInstalledSkillsEnrichedWithCatalogLinks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	managedRoot := filepath.Join(home, ".aigate", "data", "tooling", "skills", "codex-skills-ai-seo")
+	seedSkill(t, managedRoot, "AI SEO skill")
+	if err := writeSkillMetadataForTest(managedRoot, map[string]any{
+		"name":        "AI SEO",
+		"source_repo": "openai/codex-skills",
+		"source_kind": "discovered",
+		"platform":    "github",
+		"branch":      "main",
+		"source_path": "ai-seo",
+	}); err != nil {
+		t.Fatalf("writeSkillMetadata: %v", err)
+	}
+
+	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/skills/final" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"fetched_at":"2026-04-12T09:00:00Z",
+			"total_items":1,
+			"items":[
+				{
+					"id":"github:openai/codex-skills:main:skills/ai-seo",
+					"name":"AI SEO",
+					"platform":"github",
+					"repo_owner":"openai",
+					"repo_name":"codex-skills",
+					"branch":"main",
+					"repo_url":"https://github.com/openai/codex-skills",
+					"source_path":"skills/ai-seo",
+					"source_url":"https://github.com/openai/codex-skills/tree/main/skills/ai-seo",
+					"skills_sh_url":"https://skills.sh/s/ai-seo",
+					"audits_summary":{
+						"match_confidence":1,
+						"providers":[
+							{"provider":"snyk","label":"Snyk","status":"pass","url":"https://skills.sh/audits/ai-seo/snyk"}
+						]
+					}
+				}
+			]
+		}`))
+	}))
+	defer metricsServer.Close()
+
+	writeToolingConfig(t, home, map[string]any{
+		"skill_sync_method":       "symlink",
+		"skill_metrics_base_url":  metricsServer.URL,
+		"skill_repo_registry_url": metricsServer.URL,
+	})
+
+	handler := api.NewToolingHandler()
+	body := doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/installed/enriched", nil, nil, http.StatusOK)
+	var payload struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(payload.Items))
+	}
+	item := payload.Items[0]
+	if item["source_url"] != "https://github.com/openai/codex-skills/tree/main/skills/ai-seo" {
+		t.Fatalf("source_url = %v, want normalized catalog source URL", item["source_url"])
+	}
+	if item["skills_sh_url"] != "https://skills.sh/s/ai-seo" {
+		t.Fatalf("skills_sh_url = %v, want skills.sh URL", item["skills_sh_url"])
+	}
+	audits, ok := item["audits_summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("audits_summary missing: %v", item["audits_summary"])
+	}
+	providers, ok := audits["providers"].([]any)
+	if !ok || len(providers) != 1 {
+		t.Fatalf("providers = %v, want 1 provider", audits["providers"])
+	}
+}
+
 func TestToolingHandlerImportsNamespacedCodexSkills(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -2142,6 +2142,93 @@ describe("AccountsPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps usage status dot gray when usage driver is not configured", async () => {
+    const checkedAt = new Date("2026-03-19T08:35:00.000Z");
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-compatible",
+        account_name: "no-usage-driver",
+        source_icon: "openai",
+        auth_mode: "api_key",
+        base_url: "https://example.com/v1",
+        account_driver: "builtin_api_key",
+        usage_driver: "",
+        usage_config_json: "",
+        status: "active",
+        is_active: false,
+        priority: 1,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 1,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                account_id: 1,
+                balance: 0,
+                quota_remaining: 0,
+                rpm_remaining: 0,
+                tpm_remaining: 0,
+                health_score: 1,
+                recent_error_rate: 0,
+                last_total_tokens: 0,
+                last_input_tokens: 0,
+                last_output_tokens: 0,
+                model_context_window: 0,
+                primary_used_percent: 0,
+                secondary_used_percent: 0,
+                checked_at: checkedAt.toISOString(),
+                stale: true,
+                last_error: "usage refresh failed",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("no-usage-driver")).toBeInTheDocument();
+    const dot = screen.getByLabelText("no-usage-driver-usage-health");
+    expect(dot).toHaveClass("is-unknown");
+    expect(dot).not.toHaveClass("is-danger");
+  });
+
   it("renders ppchat daily remaining usage meter on the card", async () => {
     const nextMidnight = new Date();
     nextMidnight.setHours(24, 0, 0, 0);

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -430,8 +430,22 @@ function formatCheckedAt(value: string | undefined, language: AppLanguage) {
 }
 
 function getUsageHealthState(
-  record: Pick<AccountRecord, "checked_at" | "stale">,
+  record: Pick<
+    AccountRecord,
+    "checked_at" | "stale" | "usage_driver" | "usage_config_json"
+  >,
 ): "ok" | "warning" | "danger" | "unknown" {
+  const usageDriver = (record.usage_driver || "").trim().toLowerCase();
+  const usageConfig = parseUsageConfig(record.usage_config_json);
+  const luaScript =
+    typeof usageConfig.script === "string" ? String(usageConfig.script) : "";
+  const hasBuiltinUsageDriver = usageDriver.startsWith("builtin_");
+  const hasLuaUsageDriver =
+    usageDriver === "lua" && luaScript.trim() !== "";
+
+  if (!hasBuiltinUsageDriver && !hasLuaUsageDriver) {
+    return "unknown";
+  }
   if (!record.checked_at) {
     return "unknown";
   }

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -14,6 +14,8 @@ vi.mock("../../lib/api", async () => {
     importToolingSkills: vi.fn(),
     updateToolingSkill: vi.fn(),
     deleteToolingSkill: vi.fn(),
+    getToolingInstalledSkillsEnriched: vi.fn(),
+    invalidateToolingInstalledSkillsEnrichedCache: vi.fn(),
     getToolingDiscoveredSkills: vi.fn(),
     refreshToolingDiscoveredSkills: vi.fn(),
     installToolingDiscoveredSkill: vi.fn(),
@@ -206,6 +208,11 @@ describe("ToolingPage", () => {
     vi.mocked(api.importToolingSkills).mockResolvedValue({ imported: 1 });
     vi.mocked(api.updateToolingSkill).mockResolvedValue({ applied: 1, enabled: true, skill_sync_method: "symlink" });
     vi.mocked(api.deleteToolingSkill).mockResolvedValue();
+    vi.mocked((api as typeof api & { getToolingInstalledSkillsEnriched: typeof vi.fn }).getToolingInstalledSkillsEnriched).mockResolvedValue({
+      cached: true,
+      fetched_at: "2026-04-12T09:00:00Z",
+      items: [],
+    });
     vi.mocked((api as typeof api & { getToolingDiscoveredSkills: typeof vi.fn }).getToolingDiscoveredSkills).mockResolvedValue(buildDiscoveredSkillResponse());
     vi.mocked((api as typeof api & { refreshToolingDiscoveredSkills: typeof vi.fn }).refreshToolingDiscoveredSkills).mockResolvedValue(
       buildDiscoveredSkillResponse({
@@ -303,6 +310,38 @@ describe("ToolingPage", () => {
     expect(screen.queryByText("当前安装技能列表")).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText("搜索技能")).not.toBeInTheDocument();
     expect(screen.queryByText("仓库管理")).not.toBeInTheDocument();
+  });
+
+  it("shows source links and audits for installed skills from enriched endpoint", async () => {
+    vi.mocked((api as typeof api & { getToolingInstalledSkillsEnriched: typeof vi.fn }).getToolingInstalledSkillsEnriched).mockResolvedValue({
+      cached: true,
+      fetched_at: "2026-04-12T09:00:00Z",
+      items: [
+        {
+          managed_name: "superpowers",
+          name: "superpowers",
+          source_kind: "discovered",
+          source_url: "https://github.com/openai/skills/tree/main/superpowers",
+          skills_sh_url: "https://skills.sh/s/superpowers",
+          audits_summary: {
+            match_confidence: 1,
+            providers: [{ provider: "snyk", label: "Snyk", status: "pass", url: "https://skills.sh/audits/superpowers/snyk" }],
+          },
+        },
+      ],
+    });
+
+    render(<ToolingPage mode="skills" t={(text) => text} />);
+
+    expect(await screen.findByText("superpowers")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("查看原始来源"));
+    expect(desktopShell.openExternalUrl).toHaveBeenCalledWith("https://github.com/openai/skills/tree/main/superpowers");
+
+    fireEvent.click(screen.getByLabelText("查看 skills.sh 页面"));
+    expect(desktopShell.openExternalUrl).toHaveBeenCalledWith("https://skills.sh/s/superpowers");
+
+    fireEvent.click(screen.getByRole("button", { name: "Snyk" }));
+    expect(desktopShell.openExternalUrl).toHaveBeenCalledWith("https://skills.sh/audits/superpowers/snyk");
   });
 
   it("imports, toggles, and deletes skill collections", async () => {

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -31,9 +31,11 @@ import {
   deleteToolingMcpServer,
   deleteToolingSkill,
   getToolingDiscoveredSkills,
+  getToolingInstalledSkillsEnriched,
   getToolingState,
   importToolingMcpServers,
   importToolingSkills,
+  invalidateToolingInstalledSkillsEnrichedCache,
   installToolingDiscoveredSkill,
   removeToolingRepo,
   refreshToolingDiscoveredSkills,
@@ -42,6 +44,7 @@ import {
   updateToolingSkill,
   updateToolingRepo,
   type ToolingDiscoveredSkill,
+  type ToolingInstalledSkillEnriched,
   type ToolingMcpServer,
   type ToolingResolvedRepo,
   type ToolingSkillRecord,
@@ -93,6 +96,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   const [messageApi, contextHolder] = message.useMessage();
   const [loading, setLoading] = useState(true);
   const [state, setState] = useState<ToolingState | null>(null);
+  const [installedSkillEnrichedByManagedName, setInstalledSkillEnrichedByManagedName] = useState<Record<string, ToolingInstalledSkillEnriched>>({});
   const [skillDiscoverOpen, setSkillDiscoverOpen] = useState(false);
   const [repoManagerOpen, setRepoManagerOpen] = useState(false);
   const [discoveryQueryInput, setDiscoveryQueryInput] = useState("");
@@ -136,6 +140,18 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     try {
       const next = await getToolingState();
       setState(next);
+      try {
+        const enriched = await getToolingInstalledSkillsEnriched(next.installed_skills ?? []);
+        setInstalledSkillEnrichedByManagedName(
+          Object.fromEntries(
+            (enriched.items ?? [])
+              .filter((item) => typeof item.managed_name === "string" && item.managed_name.trim() !== "")
+              .map((item) => [item.managed_name.trim().toLowerCase(), item]),
+          ),
+        );
+      } catch {
+        setInstalledSkillEnrichedByManagedName({});
+      }
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("加载技能与 MCP 管理失败"));
     } finally {
@@ -258,6 +274,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     setImportBusy(true);
     try {
       await importToolingSkills("codex");
+      invalidateToolingInstalledSkillsEnrichedCache();
       void messageApi.success(t("导入完成"));
       await reload({ background: true });
     } catch (error) {
@@ -294,6 +311,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         setSkillBusyName(skill.name);
         try {
           await deleteToolingSkill(collectionName);
+          invalidateToolingInstalledSkillsEnrichedCache();
           void messageApi.success(t("删除成功"));
           await reload({ background: true });
         } catch (error) {
@@ -395,6 +413,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         apps: ["codex"],
       });
       const nextAction = skill.update_available ? t("已更新") : t("安装成功");
+      invalidateToolingInstalledSkillsEnrichedCache();
       setDiscoveryItems((current) => markDiscoveredSkillInstalled(current, skill.id));
       setDiscoveryStatus(skill.update_available ? t("已更新") : t("已安装"));
       void messageApi.success(nextAction);
@@ -627,24 +646,44 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         <div className="tooling-managed-list">
           {mode === "skills" ? (
             skills.length > 0 ? (
-              skills.map((skill) => (
-                <ManagedCard
-                  key={skill.managed_path}
-                  t={t}
-                  title={skill.name}
-                  description={skill.description || skill.directory}
-                  managedName={skillCollectionName(skill)}
-                  updateAvailable={Boolean(skill.update_available)}
-                  statuses={buildManagedStatuses(skill.installed_apps)}
-                  busy={skillBusyName === skill.name}
-                  toggleLabel={skill.installed_apps?.codex ? t(`停用 ${skill.name} 于 Codex`) : t(`启用 ${skill.name} 到 Codex`)}
-                  openDirLabel={t(`打开 ${skill.name} 安装目录`)}
-                  deleteLabel={t(`删除 ${skill.name}`)}
-                  onToggle={() => void handleSkillToggle(skill)}
-                  onOpenDir={() => void handleOpenManagedSkillDirectory(skill)}
-                  onDelete={() => confirmDeleteSkill(skill)}
-                />
-              ))
+              skills.map((skill) => {
+                const managedName = skillCollectionName(skill);
+                const enriched = installedSkillEnrichedByManagedName[managedName.toLowerCase()];
+                return (
+                  <ManagedCard
+                    key={skill.managed_path}
+                    t={t}
+                    title={skill.name}
+                    description={skill.description || skill.directory}
+                    managedName={managedName}
+                    updateAvailable={Boolean(skill.update_available)}
+                    statuses={buildManagedStatuses(skill.installed_apps)}
+                    busy={skillBusyName === skill.name}
+                    toggleLabel={skill.installed_apps?.codex ? t(`停用 ${skill.name} 于 Codex`) : t(`启用 ${skill.name} 到 Codex`)}
+                    openDirLabel={t(`打开 ${skill.name} 安装目录`)}
+                    deleteLabel={t(`删除 ${skill.name}`)}
+                    sourceURL={enriched?.source_url}
+                    skillsShURL={enriched?.skills_sh_url}
+                    auditProviders={enriched?.audits_summary?.providers ?? []}
+                    onToggle={() => void handleSkillToggle(skill)}
+                    onOpenDir={() => void handleOpenManagedSkillDirectory(skill)}
+                    onViewSource={() => {
+                      if (!enriched?.source_url) {
+                        return;
+                      }
+                      void openExternalUrl(enriched.source_url);
+                    }}
+                    onViewSkillsSh={() => {
+                      if (!enriched?.skills_sh_url) {
+                        return;
+                      }
+                      void openExternalUrl(enriched.skills_sh_url);
+                    }}
+                    onViewAudit={(url) => void openExternalUrl(url)}
+                    onDelete={() => confirmDeleteSkill(skill)}
+                  />
+                );
+              })
             ) : (
               <Empty description={t("暂无技能")} />
             )
@@ -1269,8 +1308,14 @@ function ManagedCard({
   toggleLabel,
   openDirLabel,
   deleteLabel,
+  sourceURL,
+  skillsShURL,
+  auditProviders,
   onToggle,
   onOpenDir,
+  onViewSource,
+  onViewSkillsSh,
+  onViewAudit,
   onDelete,
 }: {
   t: (text: string) => string;
@@ -1285,12 +1330,19 @@ function ManagedCard({
   toggleLabel: string;
   openDirLabel?: string;
   deleteLabel: string;
+  sourceURL?: string;
+  skillsShURL?: string;
+  auditProviders?: Array<{ provider: string; label: string; status: string; url: string }>;
   onToggle: () => void;
   onOpenDir?: () => void;
+  onViewSource?: () => void;
+  onViewSkillsSh?: () => void;
+  onViewAudit?: (url: string) => void;
   onDelete: () => void;
 }) {
   const primaryStatus = statuses[0];
   const isPrimaryEnabled = primaryStatus?.enabled ?? false;
+  const providers = auditProviders ?? [];
   return (
     <div className="tooling-item-card">
       <div className="tooling-item-main">
@@ -1304,6 +1356,22 @@ function ManagedCard({
           </div>
         ) : null}
         {managedName ? <div className="tooling-item-description is-default">{`${t("托管名")}: ${managedName}`}</div> : null}
+        {providers.length > 0 ? (
+          <div className="tooling-audit-badges">
+            {providers.map((provider) => (
+              <button
+                key={`${provider.provider}-${provider.url}`}
+                type="button"
+                className={`tooling-audit-provider is-${provider.status}`}
+                title={`${provider.label} · ${provider.status}`}
+                onClick={() => onViewAudit?.(provider.url)}
+                disabled={!provider.url}
+              >
+                {provider.label}
+              </button>
+            ))}
+          </div>
+        ) : null}
       </div>
       <div className="tooling-item-aside">
         <div className="tooling-item-statuses" aria-label="安装目标状态">
@@ -1320,6 +1388,16 @@ function ManagedCard({
           ))}
         </div>
         <div className="tooling-item-hover-actions">
+          {sourceURL ? (
+            <button type="button" className="tooling-item-icon-action" aria-label={t("查看原始来源")} onClick={onViewSource} disabled={busy}>
+              <LinkOutlined />
+            </button>
+          ) : null}
+          {skillsShURL ? (
+            <button type="button" className="tooling-item-icon-action" aria-label={t("查看 skills.sh 页面")} onClick={onViewSkillsSh} disabled={busy}>
+              skills.sh
+            </button>
+          ) : null}
           {onOpenDir ? (
             <button type="button" className="tooling-item-icon-action" aria-label={openDirLabel || t("打开目录")} onClick={onOpenDir} disabled={busy}>
               <FolderOpenOutlined />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -349,9 +349,40 @@ export type ToolingSkillRecord = {
   source_client?: string;
   source_repo?: string;
   source_kind: string;
+  platform?: "github" | "gitlab" | string;
+  branch?: string;
+  source_path?: string;
+  source_url?: string;
   managed_path: string;
   installed_apps: Record<string, boolean>;
   update_available?: boolean;
+};
+
+export type ToolingInstalledSkillEnriched = {
+  managed_name: string;
+  name: string;
+  source_kind: string;
+  platform?: "github" | "gitlab" | string;
+  source_repo?: string;
+  branch?: string;
+  source_path?: string;
+  source_url?: string;
+  skills_sh_url?: string;
+  audits_summary?: {
+    match_confidence: number;
+    providers: Array<{
+      provider: string;
+      label: string;
+      status: "pass" | "warn" | "fail" | "info" | string;
+      url: string;
+    }>;
+  };
+};
+
+export type ToolingInstalledSkillEnrichedResponse = {
+  cached: boolean;
+  fetched_at?: string;
+  items: ToolingInstalledSkillEnriched[];
 };
 
 export type ToolingMcpTemplate = {
@@ -973,6 +1004,135 @@ export async function getToolingState(): Promise<ToolingState> {
     throw new Error("failed to load tooling state");
   }
   return response.json();
+}
+
+const TOOLING_INSTALLED_ENRICHED_CACHE_TTL_MS = 5 * 60 * 1000;
+const TOOLING_INSTALLED_ENRICHED_CACHE_KEY = "aigate:tooling:installed-enriched:v1";
+let toolingInstalledEnrichedCache:
+  | {
+      expiresAt: number;
+      signature: string;
+      payload: ToolingInstalledSkillEnrichedResponse;
+    }
+  | null = null;
+
+function buildInstalledSkillsSignature(items: ToolingSkillRecord[]): string {
+  return items
+    .map((item) =>
+      [
+        item.managed_path || "",
+        item.name || "",
+        item.source_kind || "",
+        item.source_repo || "",
+        item.source_path || "",
+        item.source_url || "",
+      ].join("|"),
+    )
+    .sort()
+    .join(";");
+}
+
+function readInstalledEnrichedCacheFromStorage():
+  | {
+      expiresAt: number;
+      signature: string;
+      payload: ToolingInstalledSkillEnrichedResponse;
+    }
+  | null {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(TOOLING_INSTALLED_ENRICHED_CACHE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as {
+      expiresAt?: number;
+      signature?: string;
+      payload?: ToolingInstalledSkillEnrichedResponse;
+    };
+    if (
+      !parsed ||
+      typeof parsed.expiresAt !== "number" ||
+      typeof parsed.signature !== "string" ||
+      !parsed.payload ||
+      !Array.isArray(parsed.payload.items)
+    ) {
+      return null;
+    }
+    return {
+      expiresAt: parsed.expiresAt,
+      signature: parsed.signature,
+      payload: parsed.payload,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeInstalledEnrichedCacheToStorage(value: {
+  expiresAt: number;
+  signature: string;
+  payload: ToolingInstalledSkillEnrichedResponse;
+}) {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(TOOLING_INSTALLED_ENRICHED_CACHE_KEY, JSON.stringify(value));
+  } catch {
+    // ignore cache persistence failures
+  }
+}
+
+export function invalidateToolingInstalledSkillsEnrichedCache(): void {
+  toolingInstalledEnrichedCache = null;
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.removeItem(TOOLING_INSTALLED_ENRICHED_CACHE_KEY);
+  } catch {
+    // ignore cache persistence failures
+  }
+}
+
+export async function getToolingInstalledSkillsEnriched(
+  installedSkills: ToolingSkillRecord[],
+  options?: { force?: boolean },
+): Promise<ToolingInstalledSkillEnrichedResponse> {
+  const signature = buildInstalledSkillsSignature(installedSkills);
+  const now = Date.now();
+  if (!options?.force && toolingInstalledEnrichedCache && toolingInstalledEnrichedCache.signature === signature && toolingInstalledEnrichedCache.expiresAt > now) {
+    return toolingInstalledEnrichedCache.payload;
+  }
+  if (!options?.force && !toolingInstalledEnrichedCache) {
+    const persisted = readInstalledEnrichedCacheFromStorage();
+    if (persisted && persisted.signature === signature && persisted.expiresAt > now) {
+      toolingInstalledEnrichedCache = persisted;
+      return persisted.payload;
+    }
+  }
+  const response = await fetch(apiPath("/tooling/skills/installed/enriched"));
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || "failed to load installed skills enriched data");
+  }
+  const payload = (await response.json()) as ToolingInstalledSkillEnrichedResponse;
+  const normalized: ToolingInstalledSkillEnrichedResponse = {
+    cached: typeof payload.cached === "boolean" ? payload.cached : true,
+    fetched_at: typeof payload.fetched_at === "string" ? payload.fetched_at : "",
+    items: Array.isArray(payload.items) ? payload.items : [],
+  };
+  const cacheEntry = {
+    expiresAt: now + TOOLING_INSTALLED_ENRICHED_CACHE_TTL_MS,
+    signature,
+    payload: normalized,
+  };
+  toolingInstalledEnrichedCache = cacheEntry;
+  writeInstalledEnrichedCacheToStorage(cacheEntry);
+  return normalized;
 }
 
 export async function saveToolingSkillSyncMethod(skill_sync_method: "symlink" | "copy"): Promise<void> {


### PR DESCRIPTION
## Summary
- show gray account status when no usage driver configured
- add backend enriched installed skills endpoint with catalog/audit/source links
- add frontend installed skills enrichment cache and UI entries for source + skills.sh + audits

## Testing
- go test ./internal/api -run 'TestToolingHandlerListsInstalledSkillsEnrichedWithCatalogLinks|TestToolingHandlerCanInstallDiscoveredSkillWithSkillsPrefixFallback' -v
- npm --prefix frontend run test -- ToolingPage.test.tsx AccountsPage.test.tsx