### PR TITLE
fix(stats): ensure token trend x-axis is time-ordered

### DIFF
--- a/frontend/src/features/stats/StatsCharts.test.ts
+++ b/frontend/src/features/stats/StatsCharts.test.ts
@@ -1,0 +1,32 @@
+import { sortTrendPointsByBucket } from "./StatsCharts";
+
+describe("StatsCharts", () => {
+  it("sorts trend points by bucket time ascending", () => {
+    const points = [
+      { bucket: "2026-04-08T08:00:00Z", request_count: 1, input_tokens: 80, output_tokens: 8, total_tokens: 88, estimated_cost: 0.08, balance_delta: 0, quota_delta: 0 },
+      { bucket: "2026-03-17T08:00:00Z", request_count: 1, input_tokens: 17, output_tokens: 1, total_tokens: 18, estimated_cost: 0.01, balance_delta: 0, quota_delta: 0 },
+      { bucket: "2026-04-02T08:00:00Z", request_count: 1, input_tokens: 42, output_tokens: 4, total_tokens: 46, estimated_cost: 0.04, balance_delta: 0, quota_delta: 0 },
+      { bucket: "2026-03-25T08:00:00Z", request_count: 1, input_tokens: 25, output_tokens: 2, total_tokens: 27, estimated_cost: 0.02, balance_delta: 0, quota_delta: 0 },
+    ];
+
+    const sorted = sortTrendPointsByBucket(points);
+    expect(sorted.map((item) => item.bucket)).toEqual([
+      "2026-03-17T08:00:00Z",
+      "2026-03-25T08:00:00Z",
+      "2026-04-02T08:00:00Z",
+      "2026-04-08T08:00:00Z",
+    ]);
+  });
+
+  it("does not mutate original trend array", () => {
+    const points = [
+      { bucket: "2026-04-02T08:00:00Z", request_count: 1, input_tokens: 42, output_tokens: 4, total_tokens: 46, estimated_cost: 0.04, balance_delta: 0, quota_delta: 0 },
+      { bucket: "2026-03-25T08:00:00Z", request_count: 1, input_tokens: 25, output_tokens: 2, total_tokens: 27, estimated_cost: 0.02, balance_delta: 0, quota_delta: 0 },
+    ];
+    const origin = points.map((item) => item.bucket);
+
+    void sortTrendPointsByBucket(points);
+
+    expect(points.map((item) => item.bucket)).toEqual(origin);
+  });
+});

--- a/frontend/src/features/stats/StatsCharts.tsx
+++ b/frontend/src/features/stats/StatsCharts.tsx
@@ -21,6 +21,17 @@ type ModelDistributionChartProps = {
   language: AppLanguage;
 };
 
+export function sortTrendPointsByBucket(data: UsageTrendPoint[]): UsageTrendPoint[] {
+  return [...data].sort((left, right) => {
+    const leftTime = Date.parse(left.bucket);
+    const rightTime = Date.parse(right.bucket);
+    if (Number.isNaN(leftTime) || Number.isNaN(rightTime)) {
+      return left.bucket.localeCompare(right.bucket);
+    }
+    return leftTime - rightTime;
+  });
+}
+
 function formatCompactNumber(language: AppLanguage, value: number): string {
   const absolute = Math.abs(value);
   if (absolute >= 1_000_000) {
@@ -99,10 +110,11 @@ export function TokenTrendChart({ data, language }: TokenTrendChartProps) {
     if (data.length === 0) {
       return null;
     }
+    const sortedData = sortTrendPointsByBucket(data);
     const theme = readChartTheme();
     const inputLabel = language === "zh-CN" ? "输入" : "Input";
     const outputLabel = language === "zh-CN" ? "输出" : "Output";
-    const withHour = data.length > 0 && data[0]?.bucket.includes("T");
+    const withHour = sortedData.length > 0 && sortedData[0]?.bucket.includes("T");
     return {
       animationDuration: 420,
       animationDurationUpdate: 420,
@@ -149,7 +161,7 @@ export function TokenTrendChart({ data, language }: TokenTrendChartProps) {
       xAxis: {
         type: "category",
         boundaryGap: false,
-        data: data.map((point) => formatBucket(language, point.bucket, withHour)),
+        data: sortedData.map((point) => formatBucket(language, point.bucket, withHour)),
         axisLabel: {
           color: theme.textSecondary,
           fontSize: 11,
@@ -188,7 +200,7 @@ export function TokenTrendChart({ data, language }: TokenTrendChartProps) {
           areaStyle: {
             color: "rgba(59, 130, 246, 0.10)",
           },
-          data: data.map((point) => point.input_tokens),
+          data: sortedData.map((point) => point.input_tokens),
         },
         {
           name: outputLabel,
@@ -199,7 +211,7 @@ export function TokenTrendChart({ data, language }: TokenTrendChartProps) {
           areaStyle: {
             color: "rgba(20, 184, 166, 0.10)",
           },
-          data: data.map((point) => point.output_tokens),
+          data: sortedData.map((point) => point.output_tokens),
         },
       ],
     };


### PR DESCRIPTION
## Summary
- sort token trend points by bucket timestamp before rendering chart axis and series
- add unit tests for ordering and non-mutation behavior

## Testing
- npm --prefix frontend run test -- StatsCharts.test.ts StatsPage.test.tsx