### PR TITLE
release: v1.3.14

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -557,6 +558,9 @@ func (h *ToolingHandler) listInstalledSkillsEnriched(w http.ResponseWriter) {
 }
 
 func ensureToolingClientActiveHeartbeat(home string) {
+	if shouldDisableSkillMetricsReporting() {
+		return
+	}
 	if strings.TrimSpace(home) == "" {
 		return
 	}
@@ -3877,6 +3881,9 @@ func markActiveMetricScheduled(home string, now time.Time) {
 }
 
 func reportDiscoveredSkillInstall(home string, id string) {
+	if shouldDisableSkillMetricsReporting() {
+		return
+	}
 	baseURL := skillMetricsBaseURL(home)
 	if baseURL == "" {
 		return
@@ -3918,6 +3925,9 @@ func reportDiscoveredSkillInstall(home string, id string) {
 }
 
 func reportToolingClientActive(home string) {
+	if shouldDisableSkillMetricsReporting() {
+		return
+	}
 	baseURL := skillMetricsBaseURL(home)
 	if baseURL == "" {
 		return
@@ -3967,6 +3977,25 @@ func toolingClientTelemetryMeta() map[string]string {
 		meta["client_version"] = version
 	}
 	return meta
+}
+
+func shouldDisableSkillMetricsReporting() bool {
+	if isTruthyEnv(os.Getenv("AIGATE_DISABLE_SKILL_METRICS_REPORTING")) {
+		return true
+	}
+	if flag.Lookup("test.v") != nil && !isTruthyEnv(os.Getenv("AIGATE_ENABLE_TEST_SKILL_METRICS_REPORTING")) {
+		return true
+	}
+	return false
+}
+
+func isTruthyEnv(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func sendSkillMetricsInstallEvent(baseURL string, payload map[string]string) (int, error) {

--- a/backend/internal/api/tooling_handler_internal_test.go
+++ b/backend/internal/api/tooling_handler_internal_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestReportToolingClientActiveFallsBackWhenAnonymousFileCannotPersist(t *testing.T) {
+	enableSkillMetricsReportingForTest(t)
 	home := t.TempDir()
 	blockToolingDirWithFile(t, home)
 
@@ -70,6 +71,7 @@ func TestReportToolingClientActiveFallsBackWhenAnonymousFileCannotPersist(t *tes
 }
 
 func TestReportDiscoveredSkillInstallFallsBackWhenAnonymousFileCannotPersist(t *testing.T) {
+	enableSkillMetricsReportingForTest(t)
 	home := t.TempDir()
 	blockToolingDirWithFile(t, home)
 
@@ -127,6 +129,7 @@ func TestReportDiscoveredSkillInstallFallsBackWhenAnonymousFileCannotPersist(t *
 }
 
 func TestReportToolingClientActiveIsThrottledWithinOneHour(t *testing.T) {
+	enableSkillMetricsReportingForTest(t)
 	home := t.TempDir()
 
 	var (
@@ -158,6 +161,7 @@ func TestReportToolingClientActiveIsThrottledWithinOneHour(t *testing.T) {
 }
 
 func TestReportToolingClientActiveReportsAgainAfterOneHour(t *testing.T) {
+	enableSkillMetricsReportingForTest(t)
 	home := t.TempDir()
 	now := time.Now().UTC()
 	if err := saveSkillMetricsState(home, skillMetricsReportState{
@@ -194,6 +198,7 @@ func TestReportToolingClientActiveReportsAgainAfterOneHour(t *testing.T) {
 }
 
 func TestReportDiscoveredSkillInstallDoesNotQueueOnNetworkFailure(t *testing.T) {
+	enableSkillMetricsReportingForTest(t)
 	home := t.TempDir()
 	setToolingSkillMetricsBaseURL(t, home, "http://127.0.0.1:1")
 
@@ -207,6 +212,7 @@ func TestReportDiscoveredSkillInstallDoesNotQueueOnNetworkFailure(t *testing.T) 
 }
 
 func TestLoadOrCreateToolingAnonymousIDMigratesLegacyPath(t *testing.T) {
+	enableSkillMetricsReportingForTest(t)
 	home := t.TempDir()
 	legacyPath := filepath.Join(home, ".aigate", "tooling", "anonymous-client.json")
 	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
@@ -234,6 +240,7 @@ func TestLoadOrCreateToolingAnonymousIDMigratesLegacyPath(t *testing.T) {
 }
 
 func TestLoadOrCreateToolingAnonymousIDStableWhenPersistFails(t *testing.T) {
+	enableSkillMetricsReportingForTest(t)
 	home := t.TempDir()
 	blockToolingDirWithFile(t, home)
 
@@ -250,6 +257,37 @@ func TestLoadOrCreateToolingAnonymousIDStableWhenPersistFails(t *testing.T) {
 	}
 	if first != second {
 		t.Fatalf("anonymous ids should be stable when persist fails: first=%q second=%q", first, second)
+	}
+}
+
+func TestReportToolingClientActiveDisabledByDefaultInGoTestProcess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AIGATE_ENABLE_TEST_SKILL_METRICS_REPORTING", "")
+
+	var (
+		mu   sync.Mutex
+		hits int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/events/install" {
+			http.NotFound(w, r)
+			return
+		}
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"inserted":true}`))
+	}))
+	t.Cleanup(server.Close)
+	setToolingSkillMetricsBaseURL(t, home, server.URL)
+
+	reportToolingClientActive(home)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 0 {
+		t.Fatalf("events/install hits = %d, want 0 when reporting is disabled in test process", hits)
 	}
 }
 
@@ -272,6 +310,11 @@ func setToolingSkillMetricsBaseURL(t *testing.T, home string, baseURL string) {
 	if err := saveToolingConfig(home, cfg); err != nil {
 		t.Fatalf("save tooling config: %v", err)
 	}
+}
+
+func enableSkillMetricsReportingForTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("AIGATE_ENABLE_TEST_SKILL_METRICS_REPORTING", "1")
 }
 
 func setDefaultToolingSkillMetricsBaseURLForTest(t *testing.T, baseURL string) {

--- a/backend/internal/usage/repository.go
+++ b/backend/internal/usage/repository.go
@@ -358,7 +358,16 @@ func initializeTrendBuckets(filter EventFilter, bucketSize time.Duration) ([]Tre
 	}
 	points := make([]TrendPoint, 0)
 	indexByBucket := make(map[time.Time]int)
-	for bucket := filter.From.UTC(); bucket.Before(filter.To.UTC()); bucket = bucket.Add(bucketSize) {
+	for cursor := filter.From.UTC(); cursor.Before(filter.To.UTC()); cursor = cursor.Add(bucketSize) {
+		bucket := cursor
+		if bucketSize == time.Hour {
+			bucket = bucket.Truncate(time.Hour)
+		} else {
+			bucket = time.Date(bucket.Year(), bucket.Month(), bucket.Day(), 0, 0, 0, 0, time.UTC)
+		}
+		if _, exists := indexByBucket[bucket]; exists {
+			continue
+		}
 		points = append(points, TrendPoint{Bucket: bucket})
 		indexByBucket[bucket] = len(points) - 1
 	}

--- a/backend/internal/usage/repository_test.go
+++ b/backend/internal/usage/repository_test.go
@@ -356,6 +356,40 @@ func TestSQLiteRepositoryTrendEventsByHour(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepositoryTrendEventsByDayIncludesSingleBucketPerDay(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	repo := usage.NewSQLiteRepository(store.DB())
+
+	from := time.Date(2026, 3, 14, 16, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 3, 17, 16, 0, 0, 0, time.UTC)
+	points, err := repo.TrendEventsByHour(usage.EventFilter{
+		From:          &from,
+		To:            &to,
+		BucketSize:    24 * time.Hour,
+		IncludeZeroes: true,
+	})
+	if err != nil {
+		t.Fatalf("TrendEventsByHour returned error: %v", err)
+	}
+	if len(points) != 3 {
+		t.Fatalf("len(points) = %d, want 3 daily buckets", len(points))
+	}
+	for idx, point := range points {
+		if point.Bucket.Hour() != 0 || point.Bucket.Minute() != 0 {
+			t.Fatalf("points[%d].Bucket = %v, want UTC day bucket at 00:00", idx, point.Bucket)
+		}
+	}
+}
+
 func TestSQLiteRepositoryModelDistribution(t *testing.T) {
 	t.Parallel()
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.3.13",
+      "version": "1.3.14",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.3.13",
+  "version": "1.3.14",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.3.13"
+version = "1.3.14"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.3.13"
+version = "1.3.14"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.3.13",
+      "version": "1.3.14",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.3.13",
+  "version": "1.3.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/stats/StatsCharts.test.ts
+++ b/frontend/src/features/stats/StatsCharts.test.ts
@@ -1,4 +1,4 @@
-import { sortTrendPointsByBucket } from "./StatsCharts";
+import { sortTrendPointsByBucket, trendBucketsNeedHour } from "./StatsCharts";
 
 describe("StatsCharts", () => {
   it("sorts trend points by bucket time ascending", () => {
@@ -28,5 +28,21 @@ describe("StatsCharts", () => {
     void sortTrendPointsByBucket(points);
 
     expect(points.map((item) => item.bucket)).toEqual(origin);
+  });
+
+  it("hides hour labels for day-level buckets", () => {
+    const points = [
+      { bucket: "2026-04-10T00:00:00Z", request_count: 1, input_tokens: 10, output_tokens: 1, total_tokens: 11, estimated_cost: 0.01, balance_delta: 0, quota_delta: 0 },
+      { bucket: "2026-04-11T00:00:00Z", request_count: 1, input_tokens: 20, output_tokens: 2, total_tokens: 22, estimated_cost: 0.02, balance_delta: 0, quota_delta: 0 },
+    ];
+    expect(trendBucketsNeedHour(points)).toBe(false);
+  });
+
+  it("shows hour labels for hour-level buckets", () => {
+    const points = [
+      { bucket: "2026-04-11T08:00:00Z", request_count: 1, input_tokens: 20, output_tokens: 2, total_tokens: 22, estimated_cost: 0.02, balance_delta: 0, quota_delta: 0 },
+      { bucket: "2026-04-11T09:00:00Z", request_count: 1, input_tokens: 30, output_tokens: 3, total_tokens: 33, estimated_cost: 0.03, balance_delta: 0, quota_delta: 0 },
+    ];
+    expect(trendBucketsNeedHour(points)).toBe(true);
   });
 });

--- a/frontend/src/features/stats/StatsCharts.tsx
+++ b/frontend/src/features/stats/StatsCharts.tsx
@@ -32,6 +32,16 @@ export function sortTrendPointsByBucket(data: UsageTrendPoint[]): UsageTrendPoin
   });
 }
 
+export function trendBucketsNeedHour(data: UsageTrendPoint[]): boolean {
+  return data.some((point) => {
+    const date = new Date(point.bucket);
+    if (Number.isNaN(date.getTime())) {
+      return false;
+    }
+    return date.getUTCHours() !== 0 || date.getUTCMinutes() !== 0 || date.getUTCSeconds() !== 0;
+  });
+}
+
 function formatCompactNumber(language: AppLanguage, value: number): string {
   const absolute = Math.abs(value);
   if (absolute >= 1_000_000) {
@@ -114,7 +124,7 @@ export function TokenTrendChart({ data, language }: TokenTrendChartProps) {
     const theme = readChartTheme();
     const inputLabel = language === "zh-CN" ? "输入" : "Input";
     const outputLabel = language === "zh-CN" ? "输出" : "Output";
-    const withHour = sortedData.length > 0 && sortedData[0]?.bucket.includes("T");
+    const withHour = trendBucketsNeedHour(sortedData);
     return {
       animationDuration: 420,
       animationDurationUpdate: 420,

--- a/packages/npm/ai-gate-cli/README.md
+++ b/packages/npm/ai-gate-cli/README.md
@@ -1,0 +1,30 @@
+# ai-gate CLI (npm placeholder)
+
+This directory is an isolated npm package skeleton for publishing the `ai-gate` command.
+
+## Current status
+
+- Publishable placeholder package
+- Includes executable `ai-gate` command
+- Includes placeholder `skill` subcommands
+
+## Local verification
+
+```bash
+cd packages/npm/ai-gate-cli
+npm run smoke
+npm run pack:check
+```
+
+## Publish
+
+```bash
+cd packages/npm/ai-gate-cli
+npm publish
+```
+
+If the package name `ai-gate` is unavailable, update `name` in `package.json` (for example, to a scoped package), then publish with:
+
+```bash
+npm publish --access public
+```

--- a/packages/npm/ai-gate-cli/bin/ai-gate.js
+++ b/packages/npm/ai-gate-cli/bin/ai-gate.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const { run } = require("../src/cli");
+
+const code = run(process.argv.slice(2));
+if (typeof code === "number") {
+  process.exitCode = code;
+}

--- a/packages/npm/ai-gate-cli/package.json
+++ b/packages/npm/ai-gate-cli/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@gcssloop/ai-gate",
+  "version": "0.0.1",
+  "description": "AI Gate CLI placeholder package",
+  "license": "MIT",
+  "private": false,
+  "type": "commonjs",
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "ai-gate": "bin/ai-gate.js",
+    "aigate": "bin/ai-gate.js"
+  },
+  "files": [
+    "bin",
+    "src",
+    "scripts",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "ai-gate",
+    "cli",
+    "skill"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GcsSloop/ai-gate.git",
+    "directory": "packages/npm/ai-gate-cli"
+  },
+  "homepage": "https://github.com/GcsSloop/ai-gate",
+  "bugs": {
+    "url": "https://github.com/GcsSloop/ai-gate/issues"
+  },
+  "scripts": {
+    "smoke": "node ./scripts/smoke.js",
+    "pack:check": "npm pack --dry-run"
+  }
+}

--- a/packages/npm/ai-gate-cli/scripts/smoke.js
+++ b/packages/npm/ai-gate-cli/scripts/smoke.js
@@ -1,0 +1,20 @@
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+
+const bin = path.join(__dirname, "..", "bin", "ai-gate.js");
+
+function run(args) {
+  const res = spawnSync(process.execPath, [bin, ...args], { encoding: "utf8" });
+  if (res.status !== 0) {
+    console.error(res.stdout);
+    console.error(res.stderr);
+    throw new Error(`command failed: ai-gate ${args.join(" ")}`);
+  }
+}
+
+run(["--help"]);
+run(["--version"]);
+run(["skill", "--help"]);
+run(["skill", "add", "github:openai/skills:main:code-review"]);
+
+console.log("smoke passed");

--- a/packages/npm/ai-gate-cli/src/cli.js
+++ b/packages/npm/ai-gate-cli/src/cli.js
@@ -1,0 +1,111 @@
+function printRootHelp() {
+  console.log("ai-gate CLI (placeholder)");
+  console.log("");
+  console.log("Usage:");
+  console.log("  ai-gate skill <subcommand> [options]");
+  console.log("");
+  console.log("Skill subcommands:");
+  console.log("  add <skill-ref>    Install a skill by discovered id or repository reference");
+  console.log("  list               List installed skills (placeholder)");
+  console.log("  remove <name>      Remove an installed skill (placeholder)");
+  console.log("");
+  console.log("Examples:");
+  console.log("  ai-gate skill add github:openai/skills:main:code-review");
+  console.log("  ai-gate skill add https://github.com/openai/skills --skill code-review");
+}
+
+function printSkillHelp() {
+  console.log("Usage:");
+  console.log("  ai-gate skill add <skill-ref> [--skill <name>] [--agent <name>] [--global]");
+  console.log("  ai-gate skill list");
+  console.log("  ai-gate skill remove <name>");
+}
+
+function parseFlags(args) {
+  const flags = {};
+  const positionals = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = args[i + 1];
+    if (!next || next.startsWith("--")) {
+      flags[key] = true;
+      continue;
+    }
+    flags[key] = next;
+    i += 1;
+  }
+  return { flags, positionals };
+}
+
+function runSkill(args) {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printSkillHelp();
+    return 0;
+  }
+  const sub = args[0];
+  const parsed = parseFlags(args.slice(1));
+  if (sub === "add") {
+    const skillRef = parsed.positionals[0];
+    if (!skillRef) {
+      console.error("Missing <skill-ref>.");
+      printSkillHelp();
+      return 1;
+    }
+    const skillName = parsed.flags.skill || "";
+    const agent = parsed.flags.agent || "codex";
+    const installGlobal = Boolean(parsed.flags.global);
+    console.log("ai-gate skill add (placeholder)");
+    console.log(`  skill-ref: ${skillRef}`);
+    if (skillName) console.log(`  skill: ${skillName}`);
+    console.log(`  agent: ${agent}`);
+    console.log(`  global: ${installGlobal}`);
+    console.log("");
+    console.log("Next step: implement real downloader + installer in this package.");
+    return 0;
+  }
+  if (sub === "list") {
+    console.log("ai-gate skill list (placeholder)");
+    return 0;
+  }
+  if (sub === "remove") {
+    const name = parsed.positionals[0];
+    if (!name) {
+      console.error("Missing <name>.");
+      printSkillHelp();
+      return 1;
+    }
+    console.log(`ai-gate skill remove (placeholder): ${name}`);
+    return 0;
+  }
+  console.error(`Unknown skill subcommand: ${sub}`);
+  printSkillHelp();
+  return 1;
+}
+
+function run(args) {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printRootHelp();
+    return 0;
+  }
+  if (args[0] === "--version" || args[0] === "-v") {
+    const pkg = require("../package.json");
+    console.log(pkg.version);
+    return 0;
+  }
+  const top = args[0];
+  if (top === "skill") {
+    return runSkill(args.slice(1));
+  }
+  console.error(`Unknown command: ${top}`);
+  printRootHelp();
+  return 1;
+}
+
+module.exports = {
+  run,
+};


### PR DESCRIPTION
## Summary\n- stabilize backend skill metrics reporting in test context and fix daily trend bucket initialization\n- fix frontend token trend x-axis hour/day label decision\n- add npm placeholder package `@gcssloop/ai-gate` with `ai-gate` and `aigate` aliases\n- bump app version to v1.3.14\n\n## Verification\n- go test ./internal/usage ./internal/api\n- npm run test -- src/features/stats/StatsCharts.test.ts\n- npm run smoke\n- npm run pack:check