### PR TITLE
release: v1.3.15

### DIFF
--- a/backend/internal/api/tooling_discovery_cache_test.go
+++ b/backend/internal/api/tooling_discovery_cache_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSkillDiscoveryCacheRefreshDue(t *testing.T) {
+	now := timeNowUTC()
+
+	if due := skillDiscoveryCacheRefreshDue(skillDiscoveryCache{
+		FetchedAt:         now.Format(time.RFC3339),
+		NextAutoRefreshAt: now.Add(2 * time.Hour).Format(time.RFC3339),
+	}); due {
+		t.Fatal("expected cache not due when next auto refresh is in the future")
+	}
+
+	if due := skillDiscoveryCacheRefreshDue(skillDiscoveryCache{
+		FetchedAt:         now.Format(time.RFC3339),
+		NextAutoRefreshAt: now.Add(-1 * time.Minute).Format(time.RFC3339),
+	}); !due {
+		t.Fatal("expected cache due when next auto refresh is in the past")
+	}
+
+	if due := skillDiscoveryCacheRefreshDue(skillDiscoveryCache{
+		FetchedAt: now.Add(-25 * time.Hour).Format(time.RFC3339),
+	}); !due {
+		t.Fatal("expected cache due when fetched_at is older than 24h")
+	}
+}
+
+func TestToolingHandlerListDiscoveredSkillsReadsCacheOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cache := skillDiscoveryCache{
+		FetchedAt:         timeNowUTC().Add(-1 * time.Hour).Format(time.RFC3339),
+		NextAutoRefreshAt: timeNowUTC().Add(2 * time.Hour).Format(time.RFC3339),
+		Items: []discoveredSkillRecord{
+			{
+				ID:         "github:openai/skills:main:skills/alpha",
+				Name:       "Alpha Skill",
+				Platform:   "github",
+				RepoOwner:  "openai",
+				RepoName:   "skills",
+				Branch:     "main",
+				SourcePath: "skills/alpha",
+			},
+			{
+				ID:         "github:openai/skills:main:skills/zulu",
+				Name:       "Zulu Skill",
+				Platform:   "github",
+				RepoOwner:  "openai",
+				RepoName:   "skills",
+				Branch:     "main",
+				SourcePath: "skills/zulu",
+			},
+		},
+	}
+	if err := os.MkdirAll(filepath.Dir(skillDiscoveryCachePath(home)), 0o755); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	if err := saveSkillDiscoveryCache(home, cache); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
+	handler := NewToolingHandler()
+	req := httptest.NewRequest(http.MethodGet, "/tooling/skills/discover?limit=1&offset=0&q=alpha", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /tooling/skills/discover status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var payload toolingSkillDiscoverResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !payload.Cached {
+		t.Fatal("expected cached=true for local discovery cache response")
+	}
+	if payload.Updating {
+		t.Fatal("expected updating=false when cache is fresh")
+	}
+	if payload.IndexedTotal != 2 {
+		t.Fatalf("indexed_total = %d, want 2", payload.IndexedTotal)
+	}
+	if payload.Total != 1 {
+		t.Fatalf("total = %d, want 1 for filtered query", payload.Total)
+	}
+	if len(payload.Items) != 1 || payload.Items[0].Name != "Alpha Skill" {
+		t.Fatalf("unexpected paged items: %#v", payload.Items)
+	}
+}

--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	toml "github.com/pelletier/go-toml/v2"
@@ -56,7 +57,8 @@ type defaultSkillRepoSeed struct {
 }
 
 type ToolingHandler struct {
-	mu sync.Mutex
+	mu                            sync.Mutex
+	skillDiscoveryRefreshInFlight atomic.Bool
 }
 
 func NewToolingHandler() *ToolingHandler {
@@ -173,6 +175,7 @@ type skillDiscoveryCache struct {
 
 type toolingSkillDiscoverResponse struct {
 	Cached       bool                    `json:"cached"`
+	Updating     bool                    `json:"updating,omitempty"`
 	FetchedAt    string                  `json:"fetched_at,omitempty"`
 	IndexedTotal int                     `json:"indexed_total"`
 	Total        int                     `json:"total"`
@@ -425,6 +428,8 @@ func (h *ToolingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.updateSettings(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/discover/install":
 		h.installDiscoveredSkill(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/tooling/skills/discover":
+		h.listDiscoveredSkills(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/import":
 		h.importSkills(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/apply":
@@ -596,6 +601,44 @@ func (h *ToolingHandler) updateSettings(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"skill_sync_method": cfg.SkillSyncMethod})
+}
+
+func (h *ToolingHandler) listDiscoveredSkills(w http.ResponseWriter, r *http.Request) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	queryValues := r.URL.Query()
+	limit, offset := parseDiscoveredPaging(queryValues)
+	queryText := strings.TrimSpace(queryValues.Get("q"))
+	forceRefresh := isTruthyEnv(queryValues.Get("refresh"))
+
+	cache, cacheOK := loadSkillDiscoveryCache(home)
+	if !cacheOK {
+		cache = skillDiscoveryCache{Items: []discoveredSkillRecord{}}
+	}
+
+	shouldRefresh := forceRefresh || skillDiscoveryCacheRefreshDue(cache)
+	if shouldRefresh && !shouldDisableSkillDiscoveryBackgroundRefresh() {
+		h.triggerSkillDiscoveryRefresh(home)
+	}
+
+	filtered := filterDiscoveredItems(cache.Items, queryText)
+	paged, total := sliceDiscoveredItems(filtered, limit, offset)
+
+	writeJSON(w, http.StatusOK, toolingSkillDiscoverResponse{
+		Cached:       cacheOK,
+		Updating:     h.skillDiscoveryRefreshInFlight.Load(),
+		FetchedAt:    strings.TrimSpace(cache.FetchedAt),
+		IndexedTotal: len(cache.Items),
+		Total:        total,
+		Offset:       offset,
+		Limit:        limit,
+		Query:        queryText,
+		Items:        paged,
+	})
 }
 
 func (h *ToolingHandler) installDiscoveredSkill(w http.ResponseWriter, r *http.Request) {
@@ -2094,6 +2137,40 @@ func pathWithinRoot(root string, path string) bool {
 		return false
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func (h *ToolingHandler) triggerSkillDiscoveryRefresh(home string) {
+	if strings.TrimSpace(home) == "" {
+		return
+	}
+	if !h.skillDiscoveryRefreshInFlight.CompareAndSwap(false, true) {
+		return
+	}
+	go func(homeDir string) {
+		defer h.skillDiscoveryRefreshInFlight.Store(false)
+		if _, _, err := h.refreshSkillDiscovery(homeDir); err != nil {
+			fmt.Fprintf(os.Stderr, "background skill discovery refresh failed: %v\n", err)
+		}
+	}(home)
+}
+
+func skillDiscoveryCacheRefreshDue(cache skillDiscoveryCache) bool {
+	now := timeNowUTC()
+	nextAutoRefreshAt := strings.TrimSpace(cache.NextAutoRefreshAt)
+	if nextAutoRefreshAt != "" {
+		if parsed, err := time.Parse(time.RFC3339, nextAutoRefreshAt); err == nil {
+			return !parsed.After(now)
+		}
+	}
+	fetchedAt := strings.TrimSpace(cache.FetchedAt)
+	if fetchedAt == "" {
+		return true
+	}
+	parsedFetchedAt, err := time.Parse(time.RFC3339, fetchedAt)
+	if err != nil {
+		return true
+	}
+	return now.Sub(parsedFetchedAt) >= 24*time.Hour
 }
 
 func (h *ToolingHandler) refreshSkillDiscovery(home string) ([]discoveredSkillRecord, string, error) {
@@ -3984,6 +4061,16 @@ func shouldDisableSkillMetricsReporting() bool {
 		return true
 	}
 	if flag.Lookup("test.v") != nil && !isTruthyEnv(os.Getenv("AIGATE_ENABLE_TEST_SKILL_METRICS_REPORTING")) {
+		return true
+	}
+	return false
+}
+
+func shouldDisableSkillDiscoveryBackgroundRefresh() bool {
+	if isTruthyEnv(os.Getenv("AIGATE_DISABLE_SKILL_DISCOVERY_BACKGROUND_REFRESH")) {
+		return true
+	}
+	if flag.Lookup("test.v") != nil && !isTruthyEnv(os.Getenv("AIGATE_ENABLE_TEST_SKILL_DISCOVERY_BACKGROUND_REFRESH")) {
 		return true
 	}
 	return false

--- a/backend/internal/api/tooling_handler_test.go
+++ b/backend/internal/api/tooling_handler_test.go
@@ -1119,12 +1119,15 @@ func TestToolingHandlerCanInstallDiscoveredSkillIntoManagedAndCodexDirs(t *testi
 	}
 }
 
-func TestToolingHandlerDiscoveryListEndpointsRemoved(t *testing.T) {
+func TestToolingHandlerDiscoveryListEndpoint(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	handler := api.NewToolingHandler()
-	doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/discover", nil, nil, http.StatusNotFound)
+	body := doToolingRequest(t, handler, http.MethodGet, "/tooling/skills/discover", nil, nil, http.StatusOK)
+	if !strings.Contains(string(body), `"cached":false`) {
+		t.Fatalf("discover response = %s, want cached=false when no local cache exists", string(body))
+	}
 	doToolingRequest(t, handler, http.MethodPost, "/tooling/skills/discover/refresh", bytes.NewBufferString(`{}`), map[string]string{"Content-Type": "application/json"}, http.StatusNotFound)
 }
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.3.14",
+  "version": "1.3.15",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.3.14"
+version = "1.3.15"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.3.14"
+version = "1.3.15"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.3.14",
+  "version": "1.3.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -194,7 +194,8 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
       setDiscoveryIndexedTotal(typeof response.indexed_total === "number" ? response.indexed_total : response.total);
       setDiscoveryOffset(nextItems.length);
       setDiscoveryHasMore(nextItems.length < response.total);
-      setDiscoveryStatus(params?.forceStatus ?? t("最新索引"));
+      const defaultStatus = response.updating ? t("后台更新中") : t("最新索引");
+      setDiscoveryStatus(params?.forceStatus ?? defaultStatus);
     } catch (error) {
       if (discoveryRequestRef.current !== requestId) {
         return;
@@ -393,7 +394,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
 
   async function handleDiscoveryRefresh() {
     try {
-      await loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("最新索引"), refresh: true });
+      await loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("后台更新中"), refresh: true });
       await reload({ background: true });
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("刷新发现技能失败"));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -333,6 +333,7 @@ export type ToolingDiscoveredSkill = {
 
 export type ToolingSkillDiscoveryResponse = {
   cached: boolean;
+  updating?: boolean;
   fetched_at?: string;
   indexed_total?: number;
   total: number;
@@ -1298,16 +1299,11 @@ export async function resolveToolingRepo(input: string): Promise<ToolingResolved
 }
 
 export async function getToolingDiscoveredSkills(params?: { limit?: number; offset?: number; query?: string }): Promise<ToolingSkillDiscoveryResponse> {
-  return requestCloudDiscoveredSkills(params);
+  return requestToolingDiscoveredSkills(params, false);
 }
 
 export async function refreshToolingDiscoveredSkills(params?: { limit?: number; offset?: number; query?: string }): Promise<ToolingSkillDiscoveryResponse> {
-  return requestCloudDiscoveredSkills(params);
-}
-
-function skillMetricsBaseURL(): string {
-  const value = (import.meta.env.VITE_SKILL_METRICS_BASE_URL as string | undefined)?.trim();
-  return value ? value.replace(/\/$/, "") : "https://aigate-skill-metrics.gcssloop.workers.dev";
+  return requestToolingDiscoveredSkills(params, true);
 }
 
 function buildDiscoverySearch(params?: { limit?: number; offset?: number; query?: string }): URLSearchParams {
@@ -1325,11 +1321,15 @@ function buildDiscoverySearch(params?: { limit?: number; offset?: number; query?
   return search;
 }
 
-async function requestCloudDiscoveredSkills(params?: { limit?: number; offset?: number; query?: string }): Promise<ToolingSkillDiscoveryResponse> {
+async function requestToolingDiscoveredSkills(
+  params?: { limit?: number; offset?: number; query?: string },
+  refresh?: boolean,
+): Promise<ToolingSkillDiscoveryResponse> {
   const search = buildDiscoverySearch(params);
-  const hasQuery = Boolean(params?.query?.trim());
-  const endpoint = hasQuery ? "/skills/search" : "/skills/final";
-  const response = await fetch(`${skillMetricsBaseURL()}${endpoint}?${search.toString()}`);
+  if (refresh) {
+    search.set("refresh", "1");
+  }
+  const response = await fetch(apiPath(`/tooling/skills/discover?${search.toString()}`));
   if (!response.ok) {
     const details = await response.text();
     throw new Error(details || "failed to load discovered skills");
@@ -1338,6 +1338,7 @@ async function requestCloudDiscoveredSkills(params?: { limit?: number; offset?: 
   const items = Array.isArray(payload.items) ? (payload.items as ToolingDiscoveredSkill[]) : [];
   return {
     cached: typeof payload.cached === "boolean" ? payload.cached : true,
+    updating: typeof payload.updating === "boolean" ? payload.updating : false,
     fetched_at: typeof payload.fetched_at === "string" ? payload.fetched_at : "",
     indexed_total: typeof payload.indexed_total === "number"
       ? payload.indexed_total


### PR DESCRIPTION
## Summary
- optimize skill discovery page to read local cache for instant load
- move remote skill discovery refresh to backend async background flow
- limit auto refresh cadence to daily while keeping manual refresh non-blocking
- bump app version to v1.3.15

## Verification
- go test ./internal/api
- npm run test -- src/features/tooling/ToolingPage.test.tsx