### PR TITLE
release: v1.3.18

### DIFF
--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -50,6 +50,7 @@ var toolingAnonymousIDCache sync.Map
 var defaultToolingSkillMetricsBaseURL = defaultSkillMetricsBaseURL
 var toolingHTTPClientMu sync.RWMutex
 var toolingHTTPClientOverride *http.Client
+var skillDiscoveryAutoRefreshHomes sync.Map
 
 type defaultSkillRepoSeed struct {
 	Platform string
@@ -453,6 +454,10 @@ func (h *ToolingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/tooling/state":
 		h.getState(w)
+	case r.Method == http.MethodGet && r.URL.Path == "/tooling/skills/state":
+		h.getSkillsState(w)
+	case r.Method == http.MethodGet && r.URL.Path == "/tooling/mcp/state":
+		h.getMcpState(w)
 	case r.Method == http.MethodPut && r.URL.Path == "/tooling/settings":
 		h.updateSettings(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/tooling/skills/discover/install":
@@ -503,6 +508,18 @@ func (h *ToolingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *ToolingHandler) getState(w http.ResponseWriter) {
+	h.writeToolingState(w, true, true)
+}
+
+func (h *ToolingHandler) getSkillsState(w http.ResponseWriter) {
+	h.writeToolingState(w, true, false)
+}
+
+func (h *ToolingHandler) getMcpState(w http.ResponseWriter) {
+	h.writeToolingState(w, false, true)
+}
+
+func (h *ToolingHandler) writeToolingState(w http.ResponseWriter, includeSkills bool, includeMCP bool) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -510,26 +527,47 @@ func (h *ToolingHandler) getState(w http.ResponseWriter) {
 	}
 
 	cfg := h.loadConfig(home)
-	cfg, _ = h.syncManagedCodexMcpServers(home, cfg)
 	clients := toolingClientStates(home)
-	skills := scanManagedSkills(home, clients)
-	ensureToolingClientActiveHeartbeat(home)
-	go reportToolingClientActive(home)
-	repoResults := defaultRepoSearchResults()
-	discoveredServers := discoverMcpServers(home)
-	servers := h.buildMcpViews(home, cfg)
+	skills := []managedSkillRecord{}
+	skillStats := skillStatsResponse{Total: 0, BySource: map[string]int{}}
+	skillRepos := []skillRepoRecord{}
+	repoResults := []repoSearchResult{}
+	discoveredServers := []toolingDiscoveredMcpServerView{}
+	servers := []toolingMcpServerView{}
+
+	if includeSkills {
+		skills = scanManagedSkills(home, clients)
+		skillStats = buildSkillStats(skills)
+		skillRepos = cfg.SkillRepos
+		repoResults = defaultRepoSearchResults()
+		ensureSkillDiscoveryAutoRefresh(home, h)
+		ensureToolingClientActiveHeartbeat(home)
+		go reportToolingClientActive(home)
+	}
+	if includeMCP {
+		cfg, _ = h.syncManagedCodexMcpServers(home, cfg)
+		discoveredServers = discoverMcpServers(home)
+		servers = h.buildMcpViews(home, cfg)
+	}
 
 	writeJSON(w, http.StatusOK, toolingStateResponse{
 		SkillSyncMethod:      normalizeSkillSyncMethod(cfg.SkillSyncMethod),
 		Clients:              clients,
-		SkillStats:           buildSkillStats(skills),
-		SkillRepos:           cfg.SkillRepos,
+		SkillStats:           skillStats,
+		SkillRepos:           skillRepos,
 		InstalledSkills:      skills,
 		RepoSearchResults:    repoResults,
 		DiscoveredMcpServers: discoveredServers,
-		McpTemplates:         toolingTemplates,
+		McpTemplates:         chooseMcpTemplates(includeMCP),
 		McpServers:           servers,
 	})
+}
+
+func chooseMcpTemplates(includeMCP bool) []mcpTemplateRecord {
+	if !includeMCP {
+		return []mcpTemplateRecord{}
+	}
+	return toolingTemplates
 }
 
 func (h *ToolingHandler) listInstalledSkillsEnriched(w http.ResponseWriter) {
@@ -643,13 +681,21 @@ func (h *ToolingHandler) listDiscoveredSkills(w http.ResponseWriter, r *http.Req
 	limit, offset := parseDiscoveredPaging(queryValues)
 	queryText := strings.TrimSpace(queryValues.Get("q"))
 	forceRefresh := isTruthyEnv(queryValues.Get("refresh"))
+	liveRefresh := isTruthyEnv(queryValues.Get("live"))
+
+	if forceRefresh && liveRefresh {
+		if _, _, err := h.refreshSkillDiscovery(home); err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+	}
 
 	cache, cacheOK := loadSkillDiscoveryCache(home)
 	if !cacheOK {
 		cache = skillDiscoveryCache{Items: []discoveredSkillRecord{}}
 	}
 
-	shouldRefresh := forceRefresh || skillDiscoveryCacheRefreshDue(cache)
+	shouldRefresh := !liveRefresh && (forceRefresh || skillDiscoveryCacheRefreshDue(cache))
 	if shouldRefresh && !shouldDisableSkillDiscoveryBackgroundRefresh() {
 		h.triggerSkillDiscoveryRefresh(home)
 	}
@@ -668,6 +714,33 @@ func (h *ToolingHandler) listDiscoveredSkills(w http.ResponseWriter, r *http.Req
 		Query:        queryText,
 		Items:        paged,
 	})
+}
+
+func ensureSkillDiscoveryAutoRefresh(home string, h *ToolingHandler) {
+	if shouldDisableSkillDiscoveryBackgroundRefresh() {
+		return
+	}
+	if strings.TrimSpace(home) == "" {
+		return
+	}
+	if _, exists := skillDiscoveryAutoRefreshHomes.LoadOrStore(home, struct{}{}); exists {
+		return
+	}
+	go func(homeDir string) {
+		checkAndRefresh := func() {
+			cache, _ := loadSkillDiscoveryCache(homeDir)
+			if !skillDiscoveryCacheRefreshDue(cache) {
+				return
+			}
+			h.triggerSkillDiscoveryRefresh(homeDir)
+		}
+		checkAndRefresh()
+		ticker := time.NewTicker(time.Hour)
+		defer ticker.Stop()
+		for range ticker.C {
+			checkAndRefresh()
+		}
+	}(home)
 }
 
 func (h *ToolingHandler) installDiscoveredSkill(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -162,6 +162,7 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 	apiMux.Handle("/tooling/skills/repos", toolingHandler)
 	apiMux.Handle("/tooling/skills/repos/search", toolingHandler)
 	apiMux.Handle("/tooling/skills/repos/", toolingHandler)
+	apiMux.Handle("/tooling/mcp/state", toolingHandler)
 	apiMux.Handle("/tooling/mcp/templates", toolingHandler)
 	apiMux.Handle("/tooling/mcp/servers", toolingHandler)
 	apiMux.Handle("/tooling/mcp/servers/", toolingHandler)

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.3.17",
+      "version": "1.3.18",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.3.17",
+  "version": "1.3.18",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.3.17"
+version = "1.3.18"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.3.17"
+version = "1.3.18"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.3.17",
+      "version": "1.3.18",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.3.17",
+  "version": "1.3.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -11,6 +11,8 @@ vi.mock("../../lib/api", async () => {
   return {
     ...actual,
     getToolingState: vi.fn(),
+    getToolingSkillsState: vi.fn(),
+    getToolingMcpState: vi.fn(),
     importToolingSkills: vi.fn(),
     updateToolingSkill: vi.fn(),
     deleteToolingSkill: vi.fn(),
@@ -204,7 +206,8 @@ function createDeferred<T>() {
 describe("ToolingPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(api.getToolingState).mockResolvedValue(buildToolingState());
+    vi.mocked(api.getToolingSkillsState).mockResolvedValue(buildToolingState());
+    vi.mocked(api.getToolingMcpState).mockResolvedValue(buildToolingState());
     vi.mocked(api.importToolingSkills).mockResolvedValue({ imported: 1 });
     vi.mocked(api.updateToolingSkill).mockResolvedValue({ applied: 1, enabled: true, skill_sync_method: "symlink" });
     vi.mocked(api.deleteToolingSkill).mockResolvedValue();
@@ -382,7 +385,7 @@ describe("ToolingPage", () => {
       managed_path: "/tmp/aigate/tooling/skills/superpowers",
       installed_apps: { codex: true },
     };
-    vi.mocked(api.getToolingState)
+    vi.mocked(api.getToolingSkillsState)
       .mockResolvedValueOnce({
         ...buildToolingState(),
         installed_skills: [managedCollection],
@@ -440,7 +443,7 @@ describe("ToolingPage", () => {
   });
 
   it("supports manual refresh, viewing source repo, and installing a discovered skill", async () => {
-    vi.mocked((api as typeof api & { getToolingState: typeof vi.fn }).getToolingState)
+    vi.mocked((api as typeof api & { getToolingSkillsState: typeof vi.fn }).getToolingSkillsState)
       .mockResolvedValueOnce(buildToolingState())
       .mockImplementation(() => new Promise(() => {}));
     vi.mocked(api.refreshToolingDiscoveredSkills)
@@ -594,7 +597,7 @@ describe("ToolingPage", () => {
 
   it("shows binary mcp servers with friendly title and path as subtitle", async () => {
     const binaryPath = "/Applications/Pencil.app/Contents/Resources/app.asar.unpacked/out/mcp-server-darwin-arm64";
-    vi.mocked(api.getToolingState).mockResolvedValue({
+    vi.mocked(api.getToolingMcpState).mockResolvedValue({
       ...buildToolingState(),
       mcp_servers: [
         {
@@ -660,7 +663,7 @@ describe("ToolingPage", () => {
   it("keeps the current content visible while a toggle refresh is pending", async () => {
     const initialState = buildToolingState();
     const refreshDeferred = createDeferred<api.ToolingState>();
-    vi.mocked(api.getToolingState)
+    vi.mocked(api.getToolingSkillsState)
       .mockResolvedValueOnce(initialState)
       .mockImplementationOnce(() => refreshDeferred.promise);
 

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -32,7 +32,8 @@ import {
   deleteToolingSkill,
   getToolingDiscoveredSkills,
   getToolingInstalledSkillsEnriched,
-  getToolingState,
+  getToolingMcpState,
+  getToolingSkillsState,
   importToolingMcpServers,
   importToolingSkills,
   invalidateToolingInstalledSkillsEnrichedCache,
@@ -138,19 +139,23 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
       setLoading(true);
     }
     try {
-      const next = await getToolingState();
+      const next = mode === "skills" ? await getToolingSkillsState() : await getToolingMcpState();
       setState(next);
-      try {
-        const enriched = await getToolingInstalledSkillsEnriched(next.installed_skills ?? []);
-        setInstalledSkillEnrichedByManagedName(
-          Object.fromEntries(
-            (enriched.items ?? [])
-              .filter((item) => typeof item.managed_name === "string" && item.managed_name.trim() !== "")
-              .map((item) => [item.managed_name.trim().toLowerCase(), item]),
-          ),
-        );
-      } catch {
+      if (mode !== "skills") {
         setInstalledSkillEnrichedByManagedName({});
+      } else {
+        try {
+          const enriched = await getToolingInstalledSkillsEnriched(next.installed_skills ?? []);
+          setInstalledSkillEnrichedByManagedName(
+            Object.fromEntries(
+              (enriched.items ?? [])
+                .filter((item) => typeof item.managed_name === "string" && item.managed_name.trim() !== "")
+                .map((item) => [item.managed_name.trim().toLowerCase(), item]),
+            ),
+          );
+        } catch {
+          setInstalledSkillEnrichedByManagedName({});
+        }
       }
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("加载技能与 MCP 管理失败"));
@@ -163,7 +168,8 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
 
   useEffect(() => {
     void reload();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode]);
 
   async function loadDiscoveredSkillsPage(params?: { reset?: boolean; query?: string; forceStatus?: string; refresh?: boolean }) {
     const reset = params?.reset ?? false;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1007,6 +1007,22 @@ export async function getToolingState(): Promise<ToolingState> {
   return response.json();
 }
 
+export async function getToolingSkillsState(): Promise<ToolingState> {
+  const response = await fetch(apiPath("/tooling/skills/state"));
+  if (!response.ok) {
+    throw new Error("failed to load tooling skills state");
+  }
+  return response.json();
+}
+
+export async function getToolingMcpState(): Promise<ToolingState> {
+  const response = await fetch(apiPath("/tooling/mcp/state"));
+  if (!response.ok) {
+    throw new Error("failed to load tooling mcp state");
+  }
+  return response.json();
+}
+
 const TOOLING_INSTALLED_ENRICHED_CACHE_TTL_MS = 5 * 60 * 1000;
 const TOOLING_INSTALLED_ENRICHED_CACHE_KEY = "aigate:tooling:installed-enriched:v1";
 let toolingInstalledEnrichedCache:
@@ -1328,6 +1344,7 @@ async function requestToolingDiscoveredSkills(
   const search = buildDiscoverySearch(params);
   if (refresh) {
     search.set("refresh", "1");
+    search.set("live", "1");
   }
   const response = await fetch(apiPath(`/tooling/skills/discover?${search.toString()}`));
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- split tooling state endpoints by mode: /tooling/skills/state and /tooling/mcp/state
- make MCP page load mode-specific data only to avoid skill discovery/enrich blocking
- add live discovery refresh path for discovery modal and keep skills page local-first
- bump desktop/frontend version to 1.3.18

## Verification
- go test ./internal/api ./internal/bootstrap
- npm test -- ToolingPage.test.tsx --run