### PR TITLE
feat(tooling): skill page instant open from cache + cached discovery refresh

### DIFF
--- a/backend/internal/api/tooling_discovery_cache_test.go
+++ b/backend/internal/api/tooling_discovery_cache_test.go
@@ -30,7 +30,7 @@ func TestSkillDiscoveryCacheRefreshDue(t *testing.T) {
 	if due := skillDiscoveryCacheRefreshDue(skillDiscoveryCache{
 		FetchedAt: now.Add(-25 * time.Hour).Format(time.RFC3339),
 	}); !due {
-		t.Fatal("expected cache due when fetched_at is older than 24h")
+		t.Fatal("expected cache due when fetched_at is older than minimum refresh interval")
 	}
 }
 
@@ -96,5 +96,55 @@ func TestToolingHandlerListDiscoveredSkillsReadsCacheOnly(t *testing.T) {
 	}
 	if len(payload.Items) != 1 || payload.Items[0].Name != "Alpha Skill" {
 		t.Fatalf("unexpected paged items: %#v", payload.Items)
+	}
+}
+
+func TestToolingHandlerListDiscoveredSkillsIgnoresRefreshFlagAndReturnsCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cache := skillDiscoveryCache{
+		FetchedAt:         timeNowUTC().Add(-1 * time.Hour).Format(time.RFC3339),
+		NextAutoRefreshAt: timeNowUTC().Add(6 * time.Hour).Format(time.RFC3339),
+		Items: []discoveredSkillRecord{
+			{
+				ID:         "github:openai/skills:main:skills/alpha",
+				Name:       "Alpha Skill",
+				Platform:   "github",
+				RepoOwner:  "openai",
+				RepoName:   "skills",
+				Branch:     "main",
+				SourcePath: "skills/alpha",
+			},
+		},
+	}
+	if err := os.MkdirAll(filepath.Dir(skillDiscoveryCachePath(home)), 0o755); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	if err := saveSkillDiscoveryCache(home, cache); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
+	handler := NewToolingHandler()
+	req := httptest.NewRequest(http.MethodGet, "/tooling/skills/discover?refresh=1&limit=20&offset=0", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /tooling/skills/discover?refresh=1 status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var payload toolingSkillDiscoverResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !payload.Cached {
+		t.Fatal("expected cached=true when serving discovery cache")
+	}
+	if payload.Updating {
+		t.Fatal("expected updating=false when cache is not due, even with refresh=1")
+	}
+	if payload.Total != 1 || len(payload.Items) != 1 {
+		t.Fatalf("unexpected payload: total=%d items=%d", payload.Total, len(payload.Items))
 	}
 }

--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -36,7 +36,8 @@ const (
 	githubArchiveRetryMaxAttempts      = 3
 	githubArchiveRetryBaseDelay        = 1500 * time.Millisecond
 	githubRepoRequestInterval          = 250 * time.Millisecond
-	skillDiscoveryAutoRefreshJitterMax = 3 * time.Hour
+	skillDiscoveryAutoRefreshMin       = 12 * time.Hour
+	skillDiscoveryAutoRefreshJitterMax = 12 * time.Hour
 	skillMetricsHeartbeatName          = "__client_active__"
 	skillMetricsHeartbeatSource        = "__aigate_client__"
 	skillMetricsActiveReportInterval   = time.Hour
@@ -680,22 +681,13 @@ func (h *ToolingHandler) listDiscoveredSkills(w http.ResponseWriter, r *http.Req
 	queryValues := r.URL.Query()
 	limit, offset := parseDiscoveredPaging(queryValues)
 	queryText := strings.TrimSpace(queryValues.Get("q"))
-	forceRefresh := isTruthyEnv(queryValues.Get("refresh"))
-	liveRefresh := isTruthyEnv(queryValues.Get("live"))
-
-	if forceRefresh && liveRefresh {
-		if _, _, err := h.refreshSkillDiscovery(home); err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
-			return
-		}
-	}
 
 	cache, cacheOK := loadSkillDiscoveryCache(home)
 	if !cacheOK {
 		cache = skillDiscoveryCache{Items: []discoveredSkillRecord{}}
 	}
 
-	shouldRefresh := !liveRefresh && (forceRefresh || skillDiscoveryCacheRefreshDue(cache))
+	shouldRefresh := skillDiscoveryCacheRefreshDue(cache)
 	if shouldRefresh && !shouldDisableSkillDiscoveryBackgroundRefresh() {
 		h.triggerSkillDiscoveryRefresh(home)
 	}
@@ -2272,7 +2264,7 @@ func skillDiscoveryCacheRefreshDue(cache skillDiscoveryCache) bool {
 	if err != nil {
 		return true
 	}
-	return now.Sub(parsedFetchedAt) >= 24*time.Hour
+	return now.Sub(parsedFetchedAt) >= skillDiscoveryAutoRefreshMin
 }
 
 func (h *ToolingHandler) refreshSkillDiscovery(home string) ([]discoveredSkillRecord, string, error) {
@@ -2499,7 +2491,7 @@ func fetchGitHubRepoStarsCount(owner string, name string) (int, error) {
 }
 
 func nextSkillDiscoveryAutoRefreshAt(now time.Time) time.Time {
-	return now.Add(24*time.Hour + randomDuration(skillDiscoveryAutoRefreshJitterMax))
+	return now.Add(skillDiscoveryAutoRefreshMin + randomDuration(skillDiscoveryAutoRefreshJitterMax))
 }
 
 func randomDuration(max time.Duration) time.Duration {

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.3.18"
+version = "1.3.19"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.3.18",
+  "version": "1.3.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/tooling/ToolingPage.test.tsx
+++ b/frontend/src/features/tooling/ToolingPage.test.tsx
@@ -20,6 +20,8 @@ vi.mock("../../lib/api", async () => {
     invalidateToolingInstalledSkillsEnrichedCache: vi.fn(),
     getToolingDiscoveredSkills: vi.fn(),
     refreshToolingDiscoveredSkills: vi.fn(),
+    readCachedToolingState: vi.fn(),
+    writeCachedToolingState: vi.fn(),
     installToolingDiscoveredSkill: vi.fn(),
     searchToolingRepos: vi.fn(),
     resolveToolingRepo: vi.fn(),
@@ -233,6 +235,8 @@ describe("ToolingPage", () => {
         ],
       }),
     );
+    vi.mocked((api as typeof api & { readCachedToolingState: typeof vi.fn }).readCachedToolingState).mockReturnValue(null);
+    vi.mocked((api as typeof api & { writeCachedToolingState: typeof vi.fn }).writeCachedToolingState).mockImplementation(() => {});
     vi.mocked((api as typeof api & { installToolingDiscoveredSkill: typeof vi.fn }).installToolingDiscoveredSkill).mockResolvedValue({
       applied: 1,
       enabled: true,
@@ -434,7 +438,7 @@ describe("ToolingPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /发现技能/ }));
 
     const dialog = await screen.findByRole("dialog", { name: /发现技能/ });
-    expect(vi.mocked(api.refreshToolingDiscoveredSkills)).toHaveBeenCalledWith({ limit: 80, offset: 0, query: "" });
+    expect(vi.mocked(api.getToolingDiscoveredSkills)).toHaveBeenCalledWith({ limit: 80, offset: 0, query: "" });
     expect(within(dialog).getByPlaceholderText("搜索发现的技能")).toBeInTheDocument();
     expect(await within(dialog).findByText("最新索引")).toBeInTheDocument();
     expect(within(dialog).getByText("2 skills")).toBeInTheDocument();
@@ -446,7 +450,7 @@ describe("ToolingPage", () => {
     vi.mocked((api as typeof api & { getToolingSkillsState: typeof vi.fn }).getToolingSkillsState)
       .mockResolvedValueOnce(buildToolingState())
       .mockImplementation(() => new Promise(() => {}));
-    vi.mocked(api.refreshToolingDiscoveredSkills)
+    vi.mocked(api.getToolingDiscoveredSkills)
       .mockResolvedValueOnce(buildDiscoveredSkillResponse())
       .mockResolvedValueOnce(buildDiscoveredSkillResponse())
       .mockImplementationOnce(() => new Promise(() => {}));
@@ -475,7 +479,7 @@ describe("ToolingPage", () => {
     const dialog = await screen.findByRole("dialog", { name: /发现技能/ });
     fireEvent.click(within(dialog).getByRole("button", { name: "刷新技能索引" }));
 
-    await waitFor(() => expect(vi.mocked(api.refreshToolingDiscoveredSkills)).toHaveBeenCalledWith({ limit: 80, offset: 0, query: "" }));
+    await waitFor(() => expect(vi.mocked(api.getToolingDiscoveredSkills)).toHaveBeenCalledWith({ limit: 80, offset: 0, query: "" }));
 
     fireEvent.click(within(dialog).getByRole("button", { name: "查看 Alpha Skill 的仓库页面" }));
     expect(vi.mocked(desktopShell.openExternalUrl)).toHaveBeenCalledWith("https://github.com/openai/codex-skills/tree/main/skills/alpha");
@@ -519,7 +523,6 @@ describe("ToolingPage", () => {
         },
       ],
     });
-    vi.mocked((api as typeof api & { refreshToolingDiscoveredSkills: typeof vi.fn }).refreshToolingDiscoveredSkills).mockResolvedValue(discoveredState);
     vi.mocked((api as typeof api & { getToolingDiscoveredSkills: typeof vi.fn }).getToolingDiscoveredSkills).mockResolvedValue(discoveredState);
     render(<ToolingPage mode="skills" t={(text) => text} />);
 
@@ -534,7 +537,7 @@ describe("ToolingPage", () => {
   });
 
   it("searches discovered skills on Enter and calls server only once per confirmed query", async () => {
-    vi.mocked(api.refreshToolingDiscoveredSkills)
+    vi.mocked(api.getToolingDiscoveredSkills)
       .mockResolvedValueOnce(
         buildDiscoveredSkillResponse({
           indexed_total: 35,
@@ -567,7 +570,25 @@ describe("ToolingPage", () => {
     fireEvent.change(search, { target: { value: "alpha" } });
     fireEvent.keyDown(search, { key: "Enter", code: "Enter" });
     await within(dialog).findByText("Alpha Skill");
-    expect(vi.mocked(api.refreshToolingDiscoveredSkills)).toHaveBeenLastCalledWith({ limit: 80, offset: 0, query: "alpha" });
+    expect(vi.mocked(api.getToolingDiscoveredSkills)).toHaveBeenLastCalledWith({ limit: 80, offset: 0, query: "alpha" });
+  });
+
+  it("renders cached tooling state immediately and updates state cache after background refresh", async () => {
+    const cached = buildToolingState();
+    const deferred = createDeferred<api.ToolingState>();
+    vi.mocked((api as typeof api & { readCachedToolingState: typeof vi.fn }).readCachedToolingState).mockReturnValue(cached);
+    vi.mocked(api.getToolingState).mockImplementation(() => deferred.promise);
+
+    render(<ToolingPage mode="skills" t={(text) => text} />);
+
+    expect(screen.getByText("Skill 技能")).toBeInTheDocument();
+    expect(screen.getByText("superpowers")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+    deferred.resolve(cached);
+    await waitFor(() =>
+      expect(vi.mocked((api as typeof api & { writeCachedToolingState: typeof vi.fn }).writeCachedToolingState)).toHaveBeenCalledWith(cached),
+    );
   });
 
   it("renders the minimal mcp management layout and toggles codex sync", async () => {

--- a/frontend/src/features/tooling/ToolingPage.tsx
+++ b/frontend/src/features/tooling/ToolingPage.tsx
@@ -39,11 +39,12 @@ import {
   invalidateToolingInstalledSkillsEnrichedCache,
   installToolingDiscoveredSkill,
   removeToolingRepo,
-  refreshToolingDiscoveredSkills,
+  readCachedToolingState,
   resolveToolingRepo,
   reorderToolingRepos,
   updateToolingSkill,
   updateToolingRepo,
+  writeCachedToolingState,
   type ToolingDiscoveredSkill,
   type ToolingInstalledSkillEnriched,
   type ToolingMcpServer,
@@ -94,9 +95,10 @@ const managedClients: ManagedClientDescriptor[] = [
 ];
 
 export function ToolingPage({ mode, t }: ToolingPageProps) {
+  const cachedToolingState = readCachedToolingState();
   const [messageApi, contextHolder] = message.useMessage();
-  const [loading, setLoading] = useState(true);
-  const [state, setState] = useState<ToolingState | null>(null);
+  const [loading, setLoading] = useState(() => cachedToolingState === null);
+  const [state, setState] = useState<ToolingState | null>(() => cachedToolingState);
   const [installedSkillEnrichedByManagedName, setInstalledSkillEnrichedByManagedName] = useState<Record<string, ToolingInstalledSkillEnriched>>({});
   const [skillDiscoverOpen, setSkillDiscoverOpen] = useState(false);
   const [repoManagerOpen, setRepoManagerOpen] = useState(false);
@@ -125,6 +127,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   const repoResolveRequestRef = useRef(0);
   const repoDragSnapshotRef = useRef<ToolingSkillRepo[] | null>(null);
   const discoveryRequestRef = useRef(0);
+  const hasBootstrappedStateRef = useRef(cachedToolingState !== null);
   const discoveryListRef = useRef<HTMLDivElement | null>(null);
   const [skillBusyName, setSkillBusyName] = useState<string | null>(null);
   const [mcpBusyId, setMcpBusyId] = useState<string | null>(null);
@@ -141,6 +144,8 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     try {
       const next = mode === "skills" ? await getToolingSkillsState() : await getToolingMcpState();
       setState(next);
+      writeCachedToolingState(next);
+      hasBootstrappedStateRef.current = true;
       if (mode !== "skills") {
         setInstalledSkillEnrichedByManagedName({});
       } else {
@@ -158,7 +163,9 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
         }
       }
     } catch (error) {
-      void messageApi.error(error instanceof Error ? error.message : t("加载技能与 MCP 管理失败"));
+      if (!hasBootstrappedStateRef.current) {
+        void messageApi.error(error instanceof Error ? error.message : t("加载技能与 MCP 管理失败"));
+      }
     } finally {
       if (!background) {
         setLoading(false);
@@ -167,11 +174,11 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
   }
 
   useEffect(() => {
-    void reload();
+    void reload({ background: hasBootstrappedStateRef.current });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);
 
-  async function loadDiscoveredSkillsPage(params?: { reset?: boolean; query?: string; forceStatus?: string; refresh?: boolean }) {
+  async function loadDiscoveredSkillsPage(params?: { reset?: boolean; query?: string; forceStatus?: string }) {
     const reset = params?.reset ?? false;
     const query = params?.query ?? discoveryQuery;
     const requestId = discoveryRequestRef.current + 1;
@@ -188,8 +195,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     }
     try {
       const nextOffset = reset ? 0 : discoveryOffset;
-      const request = params?.refresh ? refreshToolingDiscoveredSkills : getToolingDiscoveredSkills;
-      const response = await request({ limit: DISCOVERY_PAGE_SIZE, offset: nextOffset, query });
+      const response = await getToolingDiscoveredSkills({ limit: DISCOVERY_PAGE_SIZE, offset: nextOffset, query });
       if (discoveryRequestRef.current !== requestId) {
         return;
       }
@@ -219,7 +225,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
     if (!skillDiscoverOpen || mode !== "skills") {
       return;
     }
-    void loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("最新索引"), refresh: true });
+    void loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("最新缓存") });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [skillDiscoverOpen, mode, discoveryQuery]);
 
@@ -400,7 +406,7 @@ export function ToolingPage({ mode, t }: ToolingPageProps) {
 
   async function handleDiscoveryRefresh() {
     try {
-      await loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("后台更新中"), refresh: true });
+      await loadDiscoveredSkillsPage({ reset: true, query: discoveryQuery, forceStatus: t("最新缓存") });
       await reload({ background: true });
     } catch (error) {
       void messageApi.error(error instanceof Error ? error.message : t("刷新发现技能失败"));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1023,6 +1023,46 @@ export async function getToolingMcpState(): Promise<ToolingState> {
   return response.json();
 }
 
+const TOOLING_STATE_CACHE_KEY = "aigate:tooling:state:v1";
+let toolingStateCache: ToolingState | null = null;
+
+export function readCachedToolingState(): ToolingState | null {
+  if (toolingStateCache) {
+    return toolingStateCache;
+  }
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(TOOLING_STATE_CACHE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as {
+      payload?: ToolingState;
+    };
+    if (!parsed?.payload || typeof parsed.payload !== "object") {
+      return null;
+    }
+    toolingStateCache = parsed.payload;
+    return toolingStateCache;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedToolingState(state: ToolingState): void {
+  toolingStateCache = state;
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(TOOLING_STATE_CACHE_KEY, JSON.stringify({ payload: state }));
+  } catch {
+    // ignore cache persistence failures
+  }
+}
+
 const TOOLING_INSTALLED_ENRICHED_CACHE_TTL_MS = 5 * 60 * 1000;
 const TOOLING_INSTALLED_ENRICHED_CACHE_KEY = "aigate:tooling:installed-enriched:v1";
 let toolingInstalledEnrichedCache:


### PR DESCRIPTION
## Summary
- make Tooling skill/mcp page hydrate from local tooling-state cache and refresh in background
- keep discovered skills requests cache-only (remove front-end forced refresh flow)
- adjust backend discovery auto refresh to 12-24h randomized window and keep cache responses immediate
- add/adjust tests for cache-only behavior and cached first paint
- bump version to v1.3.19

## Verification
- go test ./internal/api -run 'TestSkillDiscoveryCacheRefreshDue|TestToolingHandlerListDiscoveredSkills'
- npm --prefix frontend test -- ToolingPage.test.tsx