### PR TITLE
fix: fallback when Apple notarization team is unconfigured

### DIFF
--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -208,6 +208,8 @@ submit_output="$(xcrun notarytool submit "$NOTARY_TARGET_PATH" \
 
 notary_id="$(extract_notary_field id "$submit_output")"
 notary_status="$(extract_notary_field status "$submit_output")"
+notary_status_code="$(extract_notary_field statusCode "$submit_output")"
+notary_status_summary="$(extract_notary_field statusSummary "$submit_output")"
 
 if [[ -z "$notary_id" || -z "$notary_status" ]]; then
   echo "Unexpected notarytool response:"
@@ -217,6 +219,14 @@ fi
 
 if [[ "$notary_status" != "Accepted" ]]; then
   echo "Notarization failed with status: $notary_status"
+  if [[ "$notary_status_code" == "7000" ]]; then
+    echo "Apple team is not configured for notarization yet (statusCode=7000)."
+    if [[ -n "$notary_status_summary" ]]; then
+      echo "Notary summary: $notary_status_summary"
+    fi
+    echo "Skip notarization and continue release packaging."
+    exit 0
+  fi
   xcrun notarytool log "$notary_id" \
     --key "$APPLE_API_KEY_PATH" \
     --key-id "$APPLE_API_KEY_ID" \


### PR DESCRIPTION
## Summary\n- handle Apple notary rejection statusCode=7000 as a non-blocking warning\n- keep failing release on all other notarization failures\n- unblock macOS asset upload when team notarization is not configured\n\n## Validation\n- bash -n scripts/desktop/notarize_macos.sh\n- verified previous release failure log reports statusCode 7000