### PR TITLE
fix: parse notary statusCode from numeric JSON

### DIFF
--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -66,8 +66,10 @@ field = sys.argv[1]
 payload = sys.argv[2]
 data = json.loads(payload)
 value = data.get(field, "")
-if isinstance(value, str):
-    print(value)
+if value is None:
+    print("")
+else:
+    print(str(value))
 PY
 }
 


### PR DESCRIPTION
## Summary\n- make notary JSON field extraction robust for non-string values\n- ensure statusCode=7000 fallback branch is actually reachable\n- keep all non-7000 notarization failures blocking\n\n## Validation\n- bash -n scripts/desktop/notarize_macos.sh\n- python sanity check for numeric statusCode parsing