### PR TITLE
release: v1.4.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,8 @@ jobs:
         run: npm --prefix desktop ci
 
       - name: Build sidecar
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
         run: bash "${{ matrix.sidecar_script }}"
 
       - name: Desktop sidecar tests

--- a/backend/internal/api/account_routing_state.go
+++ b/backend/internal/api/account_routing_state.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"sort"
+	"time"
 
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
 	"github.com/gcssloop/codex-router/backend/internal/routing"
@@ -10,6 +11,10 @@ import (
 
 type activeAccountWriter interface {
 	SetActive(id int64) error
+}
+
+type cooldownAccountWriter interface {
+	Update(account accounts.Account) error
 }
 
 func autoFailoverEnabled(repo settings.ReadRepository) bool {
@@ -71,4 +76,38 @@ func syncActiveAccount(repo activeAccountWriter, account accounts.Account) (bool
 		return false, err
 	}
 	return true, nil
+}
+
+func clearRoutingCooldownIfNeeded(repo cooldownAccountWriter, account accounts.Account) (bool, error) {
+	if repo == nil {
+		return false, nil
+	}
+	if account.CooldownUntil == nil && account.CooldownReason == "" {
+		return false, nil
+	}
+	account.CooldownUntil = nil
+	account.CooldownReason = ""
+	if err := repo.Update(account); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func expandActiveCandidateRetries(candidates []routing.Candidate, attempts int) []routing.Candidate {
+	if attempts <= 1 || len(candidates) == 0 {
+		return candidates
+	}
+	first := candidates[0]
+	if !first.Account.IsActive {
+		return candidates
+	}
+	if !first.Account.RoutingCooldownActive(time.Now().UTC()) {
+		return candidates
+	}
+	expanded := make([]routing.Candidate, 0, len(candidates)+attempts-1)
+	for i := 0; i < attempts; i++ {
+		expanded = append(expanded, first)
+	}
+	expanded = append(expanded, candidates[1:]...)
+	return expanded
 }

--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -578,9 +578,6 @@ func (h *AccountsHandler) completeDeviceAuth(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	accountName := strings.TrimSpace(req.AccountName)
-	if accountName == "" {
-		accountName = "local-codex"
-	}
 	raw, err := h.connector.CompleteDeviceAuth(r.Context(), h.client, req.DeviceCode, req.UserCode)
 	if err != nil {
 		switch {
@@ -598,6 +595,15 @@ func (h *AccountsHandler) completeDeviceAuth(w http.ResponseWriter, r *http.Requ
 	if _, err := auth.LoadLocalAuthFileContent(raw); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+	if accountName == "" {
+		file, err := auth.LoadLocalAuthFileContent(raw)
+		if err == nil {
+			accountName = auth.SuggestedAccountNameFromLocalAuthFile(file)
+		}
+	}
+	if accountName == "" {
+		accountName = "local-codex"
 	}
 	err = h.repo.Create(applyBuiltInDriverDefaults(accounts.Account{
 		ProviderType:      accounts.ProviderOpenAIOfficial,

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"mime/multipart"
@@ -97,6 +98,86 @@ func TestAccountsHandlerAuthorizeReturnsDeviceCode(t *testing.T) {
 	}
 	if _, ok := payload["authorization_url"]; !ok {
 		t.Fatalf("authorization_url missing from response: %#v", payload)
+	}
+}
+
+func TestAccountsHandlerCompleteDeviceAuthUsesInferredName(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	oauthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON := func(value any) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(value)
+		}
+		switch r.URL.Path {
+		case "/device-token":
+			writeJSON(map[string]any{
+				"authorization_code": "auth-code-1",
+				"code_verifier":      "verifier-1",
+			})
+			return
+		case "/oauth-token":
+			writeJSON(map[string]any{
+				"access_token": testJWT(t, map[string]any{
+					"https://api.openai.com/auth": map[string]any{
+						"chatgpt_account_id": "acct-1",
+					},
+				}),
+				"id_token": testJWT(t, map[string]any{
+					"name": "OpenAI Test User",
+				}),
+				"refresh_token": "refresh-1",
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	t.Cleanup(oauthServer.Close)
+
+	connector := auth.NewOAuthConnector(auth.Config{
+		ClientID:              "client-id",
+		TokenURL:              oauthServer.URL + "/oauth-token",
+		DeviceAuthTokenURL:    oauthServer.URL + "/device-token",
+		DeviceRedirectURL:     "https://auth.openai.com/deviceauth/callback",
+		DeviceVerificationURL: "https://auth.openai.com/codex/device",
+	})
+	handler := api.NewAccountsHandler(
+		repo,
+		nil,
+		connector,
+		auth.NewStateStore(5*time.Minute),
+		api.WithAccountsHTTPClient(oauthServer.Client()),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/accounts/auth/device/complete", bytes.NewBufferString(`{
+		"device_code":"dev-1",
+		"user_code":"ABCD-EFGH"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST /accounts/auth/device/complete status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+
+	listed, err := repo.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("List returned %d accounts, want 1", len(listed))
+	}
+	if listed[0].AccountName != "OpenAI Test User" {
+		t.Fatalf("AccountName = %q, want %q", listed[0].AccountName, "OpenAI Test User")
 	}
 }
 
@@ -231,6 +312,23 @@ func TestAccountsHandler(t *testing.T) {
 	if disableRec.Code != http.StatusNoContent {
 		t.Fatalf("POST /accounts/1/disable status = %d, want %d", disableRec.Code, http.StatusNoContent)
 	}
+}
+
+func testJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	headerRaw, err := json.Marshal(map[string]any{"alg": "none", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("Marshal header returned error: %v", err)
+	}
+	claimsRaw, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("Marshal claims returned error: %v", err)
+	}
+	return encodeJWTPart(headerRaw) + "." + encodeJWTPart(claimsRaw) + "."
+}
+
+func encodeJWTPart(raw []byte) string {
+	return base64.RawURLEncoding.EncodeToString(raw)
 }
 
 func TestAccountsHandlerImportLocalCodexAuth(t *testing.T) {

--- a/backend/internal/api/gateway_handler.go
+++ b/backend/internal/api/gateway_handler.go
@@ -183,6 +183,9 @@ func (h *GatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			logResultSummary("gateway", conversationID, account.ID, resp.StatusCode, startedAt, string(upstreamResponse))
 			persistUsageEvent(h.usage, account, "chat_completions", req.Model, "completed", parseChatCompletionsUsage(upstreamResponse, account.ID), startedAt)
+			if changed, err := clearRoutingCooldownIfNeeded(h.accounts, account); err == nil && changed {
+				h.publishAccountRoutingStateChanged()
+			}
 			if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
 				h.publishAccountRoutingStateChanged()
 			}
@@ -319,6 +322,9 @@ func (h *GatewayHandler) serveStream(ctx context.Context, w http.ResponseWriter,
 		}
 		logResultSummary("gateway", conversationID, account.ID, resp.StatusCode, startedAt, "")
 		persistUsageEvent(h.usage, account, "chat_completions", req.Model, "completed", collector.snapshotOrDefault(), startedAt)
+		if changed, err := clearRoutingCooldownIfNeeded(h.accounts, account); err == nil && changed {
+			h.publishAccountRoutingStateChanged()
+		}
 		if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
 			h.publishAccountRoutingStateChanged()
 		}
@@ -345,11 +351,11 @@ func (h *GatewayHandler) publishAccountRoutingStateChanged() {
 func (h *GatewayHandler) orderedCandidates(candidates []routing.Candidate) ([]routing.Candidate, error) {
 	if !autoFailoverEnabled(h.settings) {
 		if candidate, ok := activeCandidate(candidates); ok {
-			return []routing.Candidate{candidate}, nil
+			return expandActiveCandidateRetries([]routing.Candidate{candidate}, activeAccountFailoverRetryAttempts), nil
 		}
 		return orderCandidatesByPriority(candidates), nil
 	}
-	return orderCandidatesActiveFirst(candidates), nil
+	return expandActiveCandidateRetries(orderCandidatesActiveFirst(candidates), activeAccountFailoverRetryAttempts), nil
 }
 
 func resolveCredential(account accounts.Account) (string, error) {

--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -31,8 +31,9 @@ import (
 const officialCodexBaseURL = "https://chatgpt.com/backend-api/codex"
 const defaultCodexInstructions = "You are Codex, a coding agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals. Be pragmatic, concise, and focus on completing the user's task."
 const thinResponsesOfficialLowRemainingThreshold = 3.0
-const thinResponsesCapacityCooldownWindow = 30 * time.Minute
-const thinResponsesRateLimitCooldownWindow = 15 * time.Minute
+const thinResponsesCapacityCooldownWindow = 3 * time.Minute
+const thinResponsesRateLimitCooldownWindow = 1 * time.Minute
+const activeAccountFailoverRetryAttempts = 3
 
 var errThinGatewayRequiresResponsesAccount = errors.New("thin gateway mode requires an account that supports /responses")
 var errThinGatewayActiveAccountUnsupported = errors.New("active account does not support /responses in thin gateway mode")
@@ -199,166 +200,195 @@ func (h *ResponsesHandler) handleResponsesThin(w http.ResponseWriter, r *http.Re
 	var fallbackBody []byte
 
 	for index, candidate := range candidates {
-		account := candidate.Account
-		if !account.NativeResponsesCapable() {
-			logThinGatewayCandidate(account, "skip", "supports_responses=false")
-			continue
+		maxAttempts := 1
+		if candidate.Account.IsActive && candidate.Account.RoutingCooldownActive(time.Now().UTC()) {
+			maxAttempts = activeAccountFailoverRetryAttempts
 		}
-		if reason, ok := h.skipReasonForThinCandidate(candidate); ok {
-			logThinGatewayCandidate(account, "skip", reason)
-			cooldownUntil := computeThinCandidateCooldownUntil(candidate.Snapshot, reason)
-			if shouldCooldownThinCandidate(candidate, reason) {
-				changed, err := h.markThinCandidateCooldown(account, candidate.Snapshot, reason)
-				if err != nil {
-					lastErr = err
-					break
+		for attemptIndex := 0; attemptIndex < maxAttempts; attemptIndex++ {
+			account := candidate.Account
+			if !account.NativeResponsesCapable() {
+				logThinGatewayCandidate(account, "skip", "supports_responses=false")
+				break
+			}
+			if reason, ok := h.skipReasonForThinCandidate(candidate); ok {
+				logThinGatewayCandidate(account, "skip", reason)
+				cooldownUntil := computeThinCandidateCooldownUntil(candidate.Snapshot, reason)
+				if shouldCooldownThinCandidate(candidate, reason) {
+					changed, err := h.markThinCandidateCooldown(account, candidate.Snapshot, reason)
+					if err != nil {
+						lastErr = err
+						break
+					}
+					if changed {
+						h.publishAccountRoutingStateChanged()
+					}
 				}
-				if changed {
-					h.publishAccountRoutingStateChanged()
+				if next, ok := h.nextThinFailoverTarget(candidates, index); ok {
+					logResponsesFailover(conversationID, account, next.Account, reason, "preemptive", req.Model, cooldownUntil)
 				}
+				lastErr = errThinGatewayNoHealthyCandidate
+				break
 			}
-			if next, ok := h.nextThinFailoverTarget(candidates, index); ok {
-				logResponsesFailover(conversationID, account, next.Account, reason, "preemptive", req.Model, cooldownUntil)
-			}
-			lastErr = errThinGatewayNoHealthyCandidate
-			continue
-		}
 
-		if err := ensureOfficialAccountSession(r.Context(), h.client, h.accounts, &account); err != nil {
-			startedAt := time.Now().UTC()
-			persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
-			logFailureSummary("responses", conversationID, account.ID, account.AccountName, "ensure_session", startedAt, err)
-			lastErr = err
-			if shouldFailoverOnThinError(err) {
-				continue
-			}
-			writeThinGatewayFailure(w, req.Stream, http.StatusBadGateway, err)
-			return
-		}
-
-		credential, err := resolveCredential(account)
-		if err != nil {
-			startedAt := time.Now().UTC()
-			persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
-			logFailureSummary("responses", conversationID, account.ID, account.AccountName, "resolve_credential", startedAt, err)
-			lastErr = err
-			if shouldFailoverOnThinError(err) {
-				continue
-			}
-			writeThinGatewayFailure(w, req.Stream, http.StatusBadGateway, err)
-			return
-		}
-
-		startedAt := time.Now().UTC()
-		logUpstreamSummary("responses", conversationID, account, "/responses", req.Model)
-		resp, err := h.executeThinResponsesUpstreamRequest(r.Context(), account, credential, rawBody, req.Stream, conversationID, req.Model, startedAt)
-		if err != nil {
-			persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
-			logFailureSummary("responses", conversationID, account.ID, account.AccountName, "upstream_request", startedAt, err)
-			lastErr = err
-			if shouldFailoverOnThinError(err) {
-				continue
-			}
-			writeThinGatewayFailure(w, req.Stream, http.StatusBadGateway, err)
-			return
-		}
-
-		if resp.StatusCode >= 400 {
-			responseBody, readErr := io.ReadAll(resp.Body)
-			_ = resp.Body.Close()
-			if readErr != nil {
-				persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(readErr)), usage.Snapshot{AccountID: account.ID}, startedAt)
-				logFailureSummary("responses", conversationID, account.ID, account.AccountName, "read_response", startedAt, readErr)
-				lastErr = readErr
-				if shouldFailoverOnThinError(readErr) {
+			if err := ensureOfficialAccountSession(r.Context(), h.client, h.accounts, &account); err != nil {
+				startedAt := time.Now().UTC()
+				persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+				logFailureSummary("responses", conversationID, account.ID, account.AccountName, "ensure_session", startedAt, err)
+				lastErr = err
+				if shouldFailoverOnThinError(err) && attemptIndex+1 < maxAttempts {
 					continue
 				}
-				writeThinGatewayFailure(w, req.Stream, http.StatusBadGateway, readErr)
+				if shouldFailoverOnThinError(err) {
+					break
+				}
+				writeThinGatewayFailure(w, req.Stream, http.StatusBadGateway, err)
 				return
 			}
 
-			runStatus := classifyThinResponseStatus(account, resp, responseBody)
-			upstreamErr := buildUpstreamStatusError(resp.StatusCode, responseBody)
-			logFailureSummary("responses", conversationID, account.ID, account.AccountName, "upstream_status", startedAt, upstreamErr)
-			persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, usage.Snapshot{AccountID: account.ID}, startedAt)
-
-			if shouldFailoverOnThinStatus(runStatus) {
-				cooldownUntil := computeThinCandidateCooldownUntil(candidate.Snapshot, runStatus)
-				changed, err := h.markThinCandidateCooldown(account, candidate.Snapshot, runStatus)
-				if err != nil {
-					lastErr = err
+			credential, err := resolveCredential(account)
+			if err != nil {
+				startedAt := time.Now().UTC()
+				persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+				logFailureSummary("responses", conversationID, account.ID, account.AccountName, "resolve_credential", startedAt, err)
+				lastErr = err
+				if shouldFailoverOnThinError(err) && attemptIndex+1 < maxAttempts {
+					continue
+				}
+				if shouldFailoverOnThinError(err) {
 					break
 				}
-				if changed {
-					h.publishAccountRoutingStateChanged()
-				}
-				if next, ok := h.nextThinFailoverTarget(candidates, index); ok {
-					logResponsesFailover(conversationID, account, next.Account, runStatus, strconv.Itoa(resp.StatusCode), req.Model, cooldownUntil)
-				}
-				fallbackStatusCode = resp.StatusCode
-				fallbackHeaders = resp.Header.Clone()
-				fallbackBody = append(fallbackBody[:0], responseBody...)
-				lastErr = upstreamErr
-				continue
+				writeThinGatewayFailure(w, req.Stream, http.StatusBadGateway, err)
+				return
 			}
 
+			startedAt := time.Now().UTC()
+			logUpstreamSummary("responses", conversationID, account, "/responses", req.Model)
+			resp, err := h.executeThinResponsesUpstreamRequest(r.Context(), account, credential, rawBody, req.Stream, conversationID, req.Model, startedAt)
+			if err != nil {
+				persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+				logFailureSummary("responses", conversationID, account.ID, account.AccountName, "upstream_request", startedAt, err)
+				lastErr = err
+				if shouldFailoverOnThinError(err) {
+					continue
+				}
+				writeThinGatewayFailure(w, req.Stream, http.StatusBadGateway, err)
+				return
+			}
+
+			if resp.StatusCode >= 400 {
+				responseBody, readErr := io.ReadAll(resp.Body)
+				_ = resp.Body.Close()
+				if readErr != nil {
+					persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(readErr)), usage.Snapshot{AccountID: account.ID}, startedAt)
+					logFailureSummary("responses", conversationID, account.ID, account.AccountName, "read_response", startedAt, readErr)
+					lastErr = readErr
+					if shouldFailoverOnThinError(readErr) && attemptIndex+1 < maxAttempts {
+						continue
+					}
+					if shouldFailoverOnThinError(readErr) {
+						break
+					}
+					writeThinGatewayFailure(w, req.Stream, http.StatusBadGateway, readErr)
+					return
+				}
+
+				runStatus := classifyThinResponseStatus(account, resp, responseBody)
+				upstreamErr := buildUpstreamStatusError(resp.StatusCode, responseBody)
+				logFailureSummary("responses", conversationID, account.ID, account.AccountName, "upstream_status", startedAt, upstreamErr)
+				persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, usage.Snapshot{AccountID: account.ID}, startedAt)
+
+				if shouldFailoverOnThinStatus(runStatus) {
+					cooldownUntil := computeThinCandidateCooldownUntil(candidate.Snapshot, runStatus)
+					if shouldCooldownForRunStatus(runStatus) {
+						changed, err := h.markThinCandidateCooldown(account, candidate.Snapshot, runStatus)
+						if err != nil {
+							lastErr = err
+							break
+						}
+						if changed {
+							h.publishAccountRoutingStateChanged()
+						}
+					}
+					if next, ok := h.nextThinFailoverTarget(candidates, index); ok {
+						logResponsesFailover(conversationID, account, next.Account, runStatus, strconv.Itoa(resp.StatusCode), req.Model, cooldownUntil)
+					}
+					fallbackStatusCode = resp.StatusCode
+					fallbackHeaders = resp.Header.Clone()
+					fallbackBody = append(fallbackBody[:0], responseBody...)
+					lastErr = upstreamErr
+					if attemptIndex+1 < maxAttempts {
+						continue
+					}
+					break
+				}
+
+				copyResponseHeaders(w.Header(), resp.Header)
+				w.Header().Set("OpenAI-Model", req.Model)
+				w.WriteHeader(resp.StatusCode)
+				_, _ = w.Write(responseBody)
+				return
+			}
+
+			runStatus := "completed"
 			copyResponseHeaders(w.Header(), resp.Header)
 			w.Header().Set("OpenAI-Model", req.Model)
+			// Some upstream official /responses streams arrive as SSE payloads without a
+			// reliable text/event-stream content type. When the caller requested
+			// stream=true, prefer the SSE path so response.completed usage is not lost.
+			streamResponse := req.Stream || isEventStreamResponse(resp.Header)
+			if streamResponse {
+				collector := newResponsesUsageCollector(account.ID)
+				w.WriteHeader(resp.StatusCode)
+				if err := copyResponseStreamWithObserver(w, resp.Body, collector.Observe); err != nil {
+					runStatus = runStatusForErrorClass(classifyRunError(err))
+					logFailureSummary("responses", conversationID, account.ID, account.AccountName, "read_stream", startedAt, err)
+					persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, usage.Snapshot{AccountID: account.ID}, startedAt)
+					_ = resp.Body.Close()
+					writeThinGatewayFailure(w, true, http.StatusBadGateway, err)
+					return
+				}
+				_ = resp.Body.Close()
+				logResultSummary("responses", conversationID, account.ID, resp.StatusCode, startedAt, "")
+				collector.Save(h.usage)
+				persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, collector.snapshotOrDefault(), startedAt)
+				if changed, err := clearRoutingCooldownIfNeeded(h.accounts, account); err == nil && changed {
+					h.publishAccountRoutingStateChanged()
+				}
+				if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
+					h.publishAccountRoutingStateChanged()
+				}
+				return
+			}
+
+			responseBody, err := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if err != nil {
+				persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
+				logFailureSummary("responses", conversationID, account.ID, account.AccountName, "read_response", startedAt, err)
+				lastErr = err
+				if shouldFailoverOnThinError(err) && attemptIndex+1 < maxAttempts {
+					continue
+				}
+				if shouldFailoverOnThinError(err) {
+					break
+				}
+				writeThinGatewayFailure(w, false, http.StatusBadGateway, err)
+				return
+			}
+
+			result := parseResponsesJSONResponse(responseBody, account.ID)
+			logResultSummary("responses", conversationID, account.ID, resp.StatusCode, startedAt, result.Text)
+			persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, result.Snapshot, startedAt)
+			if changed, err := clearRoutingCooldownIfNeeded(h.accounts, account); err == nil && changed {
+				h.publishAccountRoutingStateChanged()
+			}
+			if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
+				h.publishAccountRoutingStateChanged()
+			}
 			w.WriteHeader(resp.StatusCode)
 			_, _ = w.Write(responseBody)
 			return
 		}
-
-		runStatus := "completed"
-		copyResponseHeaders(w.Header(), resp.Header)
-		w.Header().Set("OpenAI-Model", req.Model)
-		// Some upstream official /responses streams arrive as SSE payloads without a
-		// reliable text/event-stream content type. When the caller requested
-		// stream=true, prefer the SSE path so response.completed usage is not lost.
-		streamResponse := req.Stream || isEventStreamResponse(resp.Header)
-		if streamResponse {
-			collector := newResponsesUsageCollector(account.ID)
-			w.WriteHeader(resp.StatusCode)
-			if err := copyResponseStreamWithObserver(w, resp.Body, collector.Observe); err != nil {
-				runStatus = runStatusForErrorClass(classifyRunError(err))
-				logFailureSummary("responses", conversationID, account.ID, account.AccountName, "read_stream", startedAt, err)
-				persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, usage.Snapshot{AccountID: account.ID}, startedAt)
-				_ = resp.Body.Close()
-				writeThinGatewayFailure(w, true, http.StatusBadGateway, err)
-				return
-			}
-			_ = resp.Body.Close()
-			logResultSummary("responses", conversationID, account.ID, resp.StatusCode, startedAt, "")
-			collector.Save(h.usage)
-			persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, collector.snapshotOrDefault(), startedAt)
-			if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
-				h.publishAccountRoutingStateChanged()
-			}
-			return
-		}
-
-		responseBody, err := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		if err != nil {
-			persistUsageEvent(h.usage, account, "responses", req.Model, runStatusForErrorClass(classifyRunError(err)), usage.Snapshot{AccountID: account.ID}, startedAt)
-			logFailureSummary("responses", conversationID, account.ID, account.AccountName, "read_response", startedAt, err)
-			lastErr = err
-			if shouldFailoverOnThinError(err) {
-				continue
-			}
-			writeThinGatewayFailure(w, false, http.StatusBadGateway, err)
-			return
-		}
-
-		result := parseResponsesJSONResponse(responseBody, account.ID)
-		logResultSummary("responses", conversationID, account.ID, resp.StatusCode, startedAt, result.Text)
-		persistUsageEvent(h.usage, account, "responses", req.Model, runStatus, result.Snapshot, startedAt)
-		if changed, err := syncActiveAccount(h.accounts, account); err == nil && changed {
-			h.publishAccountRoutingStateChanged()
-		}
-		w.WriteHeader(resp.StatusCode)
-		_, _ = w.Write(responseBody)
-		return
 	}
 
 	if lastErr == nil {
@@ -782,7 +812,7 @@ func (h *ResponsesHandler) skipReasonForThinCandidate(candidate routing.Candidat
 	case accounts.StatusInvalid:
 		return "status=invalid", true
 	}
-	if candidate.Account.RoutingCooldownActive(now) {
+	if candidate.Account.RoutingCooldownActive(now) && !candidate.Account.IsActive {
 		return "routing_cooldown", true
 	}
 	if officialRemainingBelowThreshold(candidate) {
@@ -810,7 +840,19 @@ func shouldCooldownThinCandidate(candidate routing.Candidate, reason string) boo
 	if reason == "routing_cooldown" {
 		return false
 	}
-	return reason == "official_remaining_below_3pct"
+	if candidate.Account.IsActive {
+		return false
+	}
+	return false
+}
+
+func shouldCooldownForRunStatus(status string) bool {
+	switch status {
+	case "capacity_failed", "rate_limited":
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldFailoverOnThinError(err error) bool {

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -1236,11 +1236,11 @@ func TestResponsesHandlerThinModeFailsOverAfterOfficialUsageLimit(t *testing.T) 
 	if primaryAccount.Status != accounts.StatusActive {
 		t.Fatalf("status = %q, want %q", primaryAccount.Status, accounts.StatusActive)
 	}
-	if primaryAccount.CooldownUntil == nil {
-		t.Fatal("CooldownUntil = nil, want cooldown timestamp")
+	if primaryAccount.CooldownUntil != nil {
+		t.Fatalf("CooldownUntil = %v, want nil for soft cooldown on usage_limited", primaryAccount.CooldownUntil)
 	}
-	if primaryAccount.CooldownReason != "usage_limited" {
-		t.Fatalf("CooldownReason = %q, want usage_limited", primaryAccount.CooldownReason)
+	if primaryAccount.CooldownReason != "" {
+		t.Fatalf("CooldownReason = %q, want empty for soft cooldown on usage_limited", primaryAccount.CooldownReason)
 	}
 	fallbackAccount, err := accountRepo.GetByID(2)
 	if err != nil {
@@ -1270,6 +1270,125 @@ func TestResponsesHandlerThinModeFailsOverAfterOfficialUsageLimit(t *testing.T) 
 	}
 	if events[1].AccountID != 1 || events[1].Status != "usage_limited" {
 		t.Fatalf("previous event = %+v, want primary usage_limited", events[1])
+	}
+}
+
+func TestResponsesHandlerThinModeRetriesActiveCooldownBeforeFailover(t *testing.T) {
+	t.Parallel()
+
+	primaryCalls := 0
+	primaryUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"You've hit your usage limit. Upgrade to Pro or try again later."}}`)
+	}))
+	defer primaryUpstream.Close()
+
+	secondaryCalls := 0
+	secondaryUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondaryCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_fallback","object":"response","status":"completed","output_text":"fallback-after-retry"}`)
+	}))
+	defer secondaryUpstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	cooldownUntil := time.Now().UTC().Add(5 * time.Minute)
+	for _, account := range []accounts.Account{
+		{
+			ProviderType:      accounts.ProviderOpenAICompatible,
+			AccountName:       "active-cooling",
+			AuthMode:          accounts.AuthModeAPIKey,
+			BaseURL:           primaryUpstream.URL + "/v1",
+			CredentialRef:     "sk-primary",
+			SupportsResponses: true,
+			IsActive:          true,
+			Priority:          1,
+			Status:            accounts.StatusActive,
+			CooldownUntil:     &cooldownUntil,
+			CooldownReason:    "rate_limited",
+		},
+		{
+			ProviderType:      accounts.ProviderOpenAICompatible,
+			AccountName:       "fallback",
+			AuthMode:          accounts.AuthModeAPIKey,
+			BaseURL:           secondaryUpstream.URL + "/v1",
+			CredentialRef:     "sk-fallback",
+			SupportsResponses: true,
+			Priority:          2,
+			Status:            accounts.StatusActive,
+		},
+	} {
+		if err := accountRepo.Create(account); err != nil {
+			t.Fatalf("Create returned error: %v", err)
+		}
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	for _, snapshot := range []usage.Snapshot{
+		{
+			AccountID:            1,
+			QuotaRemaining:       100000,
+			RPMRemaining:         80,
+			TPMRemaining:         80,
+			HealthScore:          0.9,
+			PrimaryUsedPercent:   40,
+			SecondaryUsedPercent: 40,
+			CheckedAt:            time.Now().UTC(),
+		},
+		{
+			AccountID:            2,
+			QuotaRemaining:       100000,
+			RPMRemaining:         100,
+			TPMRemaining:         100,
+			HealthScore:          0.8,
+			PrimaryUsedPercent:   20,
+			SecondaryUsedPercent: 20,
+			CheckedAt:            time.Now().UTC(),
+		},
+	} {
+		if err := usageRepo.Save(snapshot); err != nil {
+			t.Fatalf("Save returned error: %v", err)
+		}
+	}
+
+	settingsRepo := settings.NewSQLiteRepository(store.DB())
+	current := settings.DefaultAppSettings()
+	current.AutoFailoverEnabled = true
+	if err := settingsRepo.SaveAppSettings(current); err != nil {
+		t.Fatalf("SaveAppSettings returned error: %v", err)
+	}
+
+	handler := api.NewResponsesHandler(
+		accountRepo,
+		usageRepo,
+		conversations.NewSQLiteRepository(store.DB()),
+		api.WithResponsesSettings(settingsRepo),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-5.4","input":"ping"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"output_text":"fallback-after-retry"`) {
+		t.Fatalf("body = %s, want fallback response", rec.Body.String())
+	}
+	if primaryCalls != 3 {
+		t.Fatalf("primaryCalls = %d, want 3 retries for active cooling account", primaryCalls)
+	}
+	if secondaryCalls != 1 {
+		t.Fatalf("secondaryCalls = %d, want 1", secondaryCalls)
 	}
 }
 

--- a/backend/internal/api/settings_handler.go
+++ b/backend/internal/api/settings_handler.go
@@ -113,14 +113,10 @@ type proxyState struct {
 }
 
 type proxySession struct {
-	SessionID             string `json:"session_id"`
-	BackupID              string `json:"backup_id"`
-	Mode                  string `json:"mode"`
-	TargetProvider        string `json:"target_provider,omitempty"`
-	PreviousModelProvider string `json:"previous_model_provider,omitempty"`
-	OriginalBaseURL       string `json:"original_base_url,omitempty"`
-	EnabledConfigHash     string `json:"enabled_config_hash"`
-	CreatedAt             string `json:"created_at"`
+	SessionID         string `json:"session_id"`
+	Mode              string `json:"mode"`
+	EnabledConfigHash string `json:"enabled_config_hash"`
+	CreatedAt         string `json:"created_at"`
 }
 
 type proxyStatusResponse struct {
@@ -480,12 +476,6 @@ func (h *SettingsHandler) enableProxy(w http.ResponseWriter) {
 		return
 	}
 
-	backupID, _, err := createCodexBackupSnapshot(home, codexBackupKindRegular, backupSourceProxyEnable)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	configPath := filepath.Join(home, ".codex", "config.toml")
 	raw, err := os.ReadFile(configPath)
 	if err != nil {
@@ -493,58 +483,34 @@ func (h *SettingsHandler) enableProxy(w http.ResponseWriter) {
 		return
 	}
 	content := string(raw)
-	currentProvider := currentModelProvider(content)
 	updated := content
-	mode := "created_aigate_provider"
-	targetProvider := "aigate"
-	originalBaseURL := ""
-
 	proxyBaseURL := h.proxyBaseURL()
-	if isThirdPartyProvider(content, currentProvider) {
-		baseURL, ok := getProviderValue(content, currentProvider, "base_url")
-		if !ok {
-			http.Error(w, "current provider missing base_url; cannot patch provider", http.StatusBadRequest)
-			return
-		}
-		mode = "patched_existing_provider"
-		targetProvider = currentProvider
-		originalBaseURL = baseURL
-		updated = setProviderValue(content, currentProvider, "base_url", strconv.Quote(proxyBaseURL))
-	} else {
-		updated = setModelProvider(content, "aigate")
-		updated = ensureAigateProvider(updated, proxyBaseURL)
-	}
+	updated = setModelProvider(content, "aigate")
+	updated = ensureAigateProvider(updated, proxyBaseURL)
 	if err := writeAtomic(configPath, []byte(updated), 0o600); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	session := proxySession{
-		SessionID:             time.Now().Format("20060102-150405.000"),
-		BackupID:              backupID,
-		Mode:                  mode,
-		TargetProvider:        targetProvider,
-		PreviousModelProvider: currentProvider,
-		OriginalBaseURL:       originalBaseURL,
-		EnabledConfigHash:     hashString(updated),
-		CreatedAt:             time.Now().UTC().Format(time.RFC3339),
+		SessionID:         time.Now().Format("20060102-150405.000"),
+		Mode:              "aigate_only",
+		EnabledConfigHash: hashString(updated),
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339),
 	}
 	if err := writeProxySession(home, session); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	state, _ := readProxyState(home)
-	state.LastBackupID = backupID
 	state.SessionID = session.SessionID
 	_ = writeProxyState(home, state)
 
 	writeJSON(w, http.StatusOK, proxyStatusResponse{
-		Enabled:        true,
-		LastBackupID:   backupID,
-		Mode:           session.Mode,
-		TargetProvider: session.TargetProvider,
-		Host:           h.appSettings().ProxyHost,
-		Port:           h.appSettings().ProxyPort,
+		Enabled: true,
+		Mode:    session.Mode,
+		Host:    h.appSettings().ProxyHost,
+		Port:    h.appSettings().ProxyPort,
 	})
 }
 
@@ -604,7 +570,6 @@ func (h *SettingsHandler) getProxyStatus(w http.ResponseWriter) {
 	}
 	if sessionErr == nil {
 		resp.Mode = session.Mode
-		resp.TargetProvider = session.TargetProvider
 		configPath := filepath.Join(home, ".codex", "config.toml")
 		if raw, err := os.ReadFile(configPath); err == nil {
 			resp.ConfigConflict = hashBytes(raw) != session.EnabledConfigHash
@@ -713,16 +678,8 @@ func (h *SettingsHandler) updateEnabledProxyConfig(value settings.AppSettings) e
 
 	updated := string(raw)
 	proxyBaseURL := proxyBaseURLForSettings(value)
-	if session.Mode == "patched_existing_provider" {
-		targetProvider := strings.TrimSpace(session.TargetProvider)
-		if targetProvider == "" {
-			return fmt.Errorf("proxy session missing target provider")
-		}
-		updated = setProviderValue(updated, targetProvider, "base_url", strconv.Quote(proxyBaseURL))
-	} else {
-		updated = setModelProvider(updated, "aigate")
-		updated = ensureAigateProvider(updated, proxyBaseURL)
-	}
+	updated = setModelProvider(updated, "aigate")
+	updated = ensureAigateProvider(updated, proxyBaseURL)
 
 	if err := writeAtomic(configPath, []byte(updated), 0o600); err != nil {
 		return err
@@ -732,32 +689,8 @@ func (h *SettingsHandler) updateEnabledProxyConfig(value settings.AppSettings) e
 }
 
 func detachProxyConfig(content string, session proxySession) (string, error) {
-	updated := content
-	previousProvider := strings.TrimSpace(session.PreviousModelProvider)
-
-	if session.Mode == "patched_existing_provider" {
-		targetProvider := strings.TrimSpace(session.TargetProvider)
-		if targetProvider == "" {
-			return "", errors.New("proxy session missing target provider")
-		}
-		originalBaseURL := strings.TrimSpace(session.OriginalBaseURL)
-		if originalBaseURL == "" {
-			return "", errors.New("proxy session missing original base_url")
-		}
-		updated = setProviderValue(updated, targetProvider, "base_url", strconv.Quote(originalBaseURL))
-		if previousProvider == "" || previousProvider == "aigate" {
-			previousProvider = targetProvider
-		}
-	}
-
-	if previousProvider == "" || previousProvider == "aigate" {
-		previousProvider = defaultModelProvider
-	}
-	if previousProvider == defaultModelProvider {
-		updated = removeModelProvider(updated)
-	} else {
-		updated = setModelProvider(updated, previousProvider)
-	}
+	_ = session
+	updated := removeModelProvider(content)
 	updated = removeAigateProviderDefinitions(updated)
 	return updated, nil
 }

--- a/backend/internal/api/settings_handler_test.go
+++ b/backend/internal/api/settings_handler_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -690,16 +689,8 @@ func TestSettingsHandlerProxyEnableWithoutAuthJSONSkipsAuthBackup(t *testing.T) 
 		t.Fatalf("unmarshal enable response: %v", err)
 	}
 	backupID, _ := payload["last_backup_id"].(string)
-	if strings.TrimSpace(backupID) == "" {
-		t.Fatal("last_backup_id is empty")
-	}
-
-	backupDir := filepath.Join(home, ".aigate", "data", "codex", "backup", backupID)
-	if _, err := os.Stat(filepath.Join(backupDir, "config.toml")); err != nil {
-		t.Fatalf("stat backup config.toml: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(backupDir, "auth.json")); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("backup auth.json err = %v, want not exists", err)
+	if strings.TrimSpace(backupID) != "" {
+		t.Fatalf("last_backup_id = %q, want empty when proxy enable no longer creates backup", backupID)
 	}
 }
 
@@ -849,7 +840,7 @@ func TestSettingsHandlerProxyDisableIgnoresLegacyForceParam(t *testing.T) {
 	assertFileContains(t, filepath.Join(home, ".codex", "auth.json"), `"token-before"`)
 }
 
-func TestSettingsHandlerEnablePatchesThirdPartyProviderAndDisableRestoresOriginalBaseURL(t *testing.T) {
+func TestSettingsHandlerEnableWithThirdPartyProviderDoesNotMutateProviderBaseURL(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	prepareCodexFiles(t, home, `model_provider = "ppchat"
@@ -868,7 +859,9 @@ wire_api = "responses"
 	if enableRec.Code != http.StatusOK {
 		t.Fatalf("enable status = %d, want %d", enableRec.Code, http.StatusOK)
 	}
-	assertFileContains(t, filepath.Join(home, ".codex", "config.toml"), `model_provider = "ppchat"`)
+	assertFileContains(t, filepath.Join(home, ".codex", "config.toml"), `model_provider = "aigate"`)
+	assertFileContains(t, filepath.Join(home, ".codex", "config.toml"), `base_url = "https://code.ppchat.vip/v1"`)
+	assertFileContains(t, filepath.Join(home, ".codex", "config.toml"), `[model_providers.aigate]`)
 	assertFileContains(t, filepath.Join(home, ".codex", "config.toml"), `base_url = "http://127.0.0.1:6789/ai-router/api"`)
 
 	statusReq := httptest.NewRequest(http.MethodGet, "/settings/proxy/status", nil)
@@ -881,11 +874,8 @@ wire_api = "responses"
 	if err := json.Unmarshal(statusRec.Body.Bytes(), &statusPayload); err != nil {
 		t.Fatalf("unmarshal status: %v", err)
 	}
-	if statusPayload["mode"] != "patched_existing_provider" {
-		t.Fatalf("mode = %v, want patched_existing_provider", statusPayload["mode"])
-	}
-	if statusPayload["target_provider"] != "ppchat" {
-		t.Fatalf("target_provider = %v, want ppchat", statusPayload["target_provider"])
+	if statusPayload["mode"] != "aigate_only" {
+		t.Fatalf("mode = %v, want aigate_only", statusPayload["mode"])
 	}
 
 	disableReq := httptest.NewRequest(http.MethodPost, "/settings/proxy/disable", nil)
@@ -894,7 +884,8 @@ wire_api = "responses"
 	if disableRec.Code != http.StatusOK {
 		t.Fatalf("disable status = %d, want %d", disableRec.Code, http.StatusOK)
 	}
-	assertFileContains(t, filepath.Join(home, ".codex", "config.toml"), `model_provider = "ppchat"`)
+	assertFileNotContains(t, filepath.Join(home, ".codex", "config.toml"), `model_provider = "ppchat"`)
+	assertFileNotContains(t, filepath.Join(home, ".codex", "config.toml"), `model_provider = "aigate"`)
 	assertFileContains(t, filepath.Join(home, ".codex", "config.toml"), `base_url = "https://code.ppchat.vip/v1"`)
 	assertFileNotContains(t, filepath.Join(home, ".codex", "config.toml"), `base_url = "http://127.0.0.1:6789/ai-router/api"`)
 }

--- a/backend/internal/auth/local_import.go
+++ b/backend/internal/auth/local_import.go
@@ -217,3 +217,55 @@ func accountIDFromJWT(token string) string {
 	}
 	return claims.OpenAIAuth.ChatGPTAccountID
 }
+
+func SuggestedAccountNameFromLocalAuthFile(file LocalAuthFile) string {
+	candidates := []string{
+		jwtStringClaim(file.Tokens.IDToken, "name"),
+		jwtStringClaim(file.Tokens.IDToken, "preferred_username"),
+		jwtStringClaim(file.Tokens.IDToken, "nickname"),
+		jwtStringClaim(file.Tokens.IDToken, "email"),
+		jwtStringClaim(file.Tokens.AccessToken, "email"),
+	}
+	for _, candidate := range candidates {
+		name := normalizeSuggestedAccountName(candidate)
+		if name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func jwtStringClaim(token string, key string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	value, ok := claims[key]
+	if !ok {
+		return ""
+	}
+	str, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return str
+}
+
+func normalizeSuggestedAccountName(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if at := strings.Index(trimmed, "@"); at > 0 {
+		trimmed = trimmed[:at]
+	}
+	return strings.Join(strings.Fields(trimmed), " ")
+}

--- a/backend/internal/auth/local_refresh_test.go
+++ b/backend/internal/auth/local_refresh_test.go
@@ -98,6 +98,36 @@ func TestRefreshLocalAuthFile(t *testing.T) {
 	}
 }
 
+func TestSuggestedAccountNameFromLocalAuthFilePrefersDisplayName(t *testing.T) {
+	t.Parallel()
+
+	file := LocalAuthFile{AuthMode: "chatgpt"}
+	file.Tokens.IDToken = testJWT(t, map[string]any{
+		"name":               "OpenAI QA User",
+		"preferred_username": "qa_user",
+		"email":              "qa@example.com",
+	})
+
+	got := SuggestedAccountNameFromLocalAuthFile(file)
+	if got != "OpenAI QA User" {
+		t.Fatalf("SuggestedAccountNameFromLocalAuthFile = %q, want %q", got, "OpenAI QA User")
+	}
+}
+
+func TestSuggestedAccountNameFromLocalAuthFileFallsBackToEmailPrefix(t *testing.T) {
+	t.Parallel()
+
+	file := LocalAuthFile{AuthMode: "chatgpt"}
+	file.Tokens.IDToken = testJWT(t, map[string]any{
+		"email": "demo.user@example.com",
+	})
+
+	got := SuggestedAccountNameFromLocalAuthFile(file)
+	if got != "demo.user" {
+		t.Fatalf("SuggestedAccountNameFromLocalAuthFile = %q, want %q", got, "demo.user")
+	}
+}
+
 func testJWT(t *testing.T, claims map[string]any) string {
 	t.Helper()
 	headerRaw, err := json.Marshal(map[string]any{"alg": "none", "typ": "JWT"})

--- a/backend/internal/settings/failover.go
+++ b/backend/internal/settings/failover.go
@@ -55,6 +55,9 @@ func eligibleForExplicitQueue(account accounts.Account) bool {
 	case accounts.StatusDisabled, accounts.StatusInvalid:
 		return false
 	default:
+		if account.IsActive {
+			return true
+		}
 		return !account.RoutingCooldownActive(time.Now().UTC())
 	}
 }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.3.18",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.3.18",
+      "version": "1.4.6",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.3.18",
+  "version": "1.4.6",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.4.0"
+version = "1.4.6"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.4.0"
+version = "1.4.6"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.4.0",
+  "version": "1.4.6",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.3.18",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.3.18",
+      "version": "1.4.6",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -110,12 +110,11 @@ describe("AccountsPage", () => {
       name: "添加官方账户",
     });
 
-    fireEvent.click(within(officialModal).getByRole("button", { name: "OAuth 登录" }));
-    expect(
-      within(officialModal).getByRole("button", { name: "已完成登录" }),
-    ).toBeDisabled();
+    fireEvent.click(within(officialModal).getByRole("tab", { name: "OAuth 登录" }));
+    expect(within(officialModal).queryByText("登录方式")).toBeNull();
+    expect(within(officialModal).queryByLabelText("账户名称")).toBeNull();
     fireEvent.click(
-      within(officialModal).getByRole("button", { name: "打开 OAuth 登录页" }),
+      within(officialModal).getByRole("button", { name: "使用 ChatGPT 登录" }),
     );
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -126,9 +125,6 @@ describe("AccountsPage", () => {
         "https://auth.openai.com/codex/device",
       );
     });
-    expect(
-      within(officialModal).getByRole("button", { name: "已完成登录" }),
-    ).toBeEnabled();
     expect(within(officialModal).getByText("设备码")).toBeInTheDocument();
     expect(within(officialModal).getByText("ABCD-EFGH")).toBeInTheDocument();
     fireEvent.click(within(officialModal).getByRole("button", { name: "复制设备码" }));
@@ -136,18 +132,12 @@ describe("AccountsPage", () => {
       expect(writeDesktopClipboardText).not.toHaveBeenCalled();
     });
 
-    fireEvent.click(
-      within(officialModal).getByRole("button", {
-        name: /已完成登录/,
-      }),
-    );
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
         "/ai-router/api/accounts/auth/device/complete",
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
-            account_name: "local-codex",
             device_code: "device-auth-id-1",
             user_code: "ABCD-EFGH",
           }),
@@ -161,7 +151,7 @@ describe("AccountsPage", () => {
       name: "添加官方账户",
     });
     fireEvent.click(
-      within(reopenedModal).getByRole("button", { name: "导入本地" }),
+      within(reopenedModal).getByRole("tab", { name: "导入本地" }),
     );
     expect(
       within(reopenedModal).getByRole("button", { name: /导\s*入$/ }),
@@ -307,12 +297,12 @@ describe("AccountsPage", () => {
     expect(officialModal.closest(".ant-modal-wrap")).toHaveClass(
       "ant-modal-centered",
     );
+    fireEvent.click(
+      within(officialModal).getByRole("tab", { name: "导入本地" }),
+    );
     fireEvent.change(within(officialModal).getByLabelText("账户名称"), {
       target: { value: "current-codex" },
     });
-    fireEvent.click(
-      within(officialModal).getByRole("button", { name: "导入本地" }),
-    );
     fireEvent.click(
       within(officialModal).getByRole("button", {
         name: /导\s*入$/,
@@ -427,16 +417,14 @@ describe("AccountsPage", () => {
     ).toBeInTheDocument();
     fireEvent.click(within(detailModal).getByRole("button", { name: "Close" }));
 
-    fireEvent.click(screen.getByRole("button", { name: "编辑-mirror-east" }));
-    const editTestModal = await screen.findByRole("dialog", {
-      name: "编辑账户",
+    expect(
+      screen.queryByRole("button", { name: "复制-mirror-east" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "测试-mirror-east" }));
+    const testModal = await screen.findByRole("dialog", {
+      name: "连接测试",
     });
-    fireEvent.change(within(editTestModal).getByLabelText("输入内容"), {
-      target: { value: "ping" },
-    });
-    fireEvent.click(
-      within(editTestModal).getByRole("button", { name: /测\s*试/ }),
-    );
+    fireEvent.click(within(testModal).getByRole("button", { name: /测\s*试/ }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -449,9 +437,9 @@ describe("AccountsPage", () => {
     });
 
     expect(
-      await within(editTestModal).findByText("远端连通性测试成功"),
+      await within(testModal).findByText("远端连通性测试成功"),
     ).toBeInTheDocument();
-    expect(within(editTestModal).getByText("pong")).toBeInTheDocument();
+    expect(within(testModal).getByText("pong")).toBeInTheDocument();
   });
 
   it("confirms before sharing and only copies after explicit approval", async () => {
@@ -1646,7 +1634,7 @@ describe("AccountsPage", () => {
     expect(order).toEqual(["high-priority", "mid-priority", "low-priority"]);
   });
 
-  it("duplicates an account with the copy action", async () => {
+  it("opens test modal and runs ping after user clicks test", async () => {
     const initialList = [
       {
         id: 1,
@@ -1672,16 +1660,6 @@ describe("AccountsPage", () => {
         secondary_used_percent: 0,
       },
     ];
-    const duplicatedList = [
-      initialList[0],
-      {
-        ...initialList[0],
-        id: 2,
-        account_name: "mirror-east 1",
-        is_active: false,
-      },
-    ];
-    let listCallCount = 0;
 
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -1689,10 +1667,8 @@ describe("AccountsPage", () => {
         url === "/ai-router/api/accounts" &&
         (!init?.method || init.method === "GET")
       ) {
-        const payload = listCallCount === 0 ? initialList : duplicatedList;
-        listCallCount += 1;
         return Promise.resolve(
-          new Response(JSON.stringify(payload), {
+          new Response(JSON.stringify(initialList), {
             status: 200,
             headers: { "Content-Type": "application/json" },
           }),
@@ -1709,11 +1685,17 @@ describe("AccountsPage", () => {
           }),
         );
       }
-      if (
-        url === "/ai-router/api/accounts/1/duplicate" &&
-        init?.method === "POST"
-      ) {
-        return Promise.resolve(new Response(null, { status: 201 }));
+      if (url === "/ai-router/api/accounts/1/test" && init?.method === "POST") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ok: true,
+              message: "远端连通性测试成功",
+              content: "pong",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
       }
       return Promise.resolve(new Response(null, { status: 404 }));
     });
@@ -1724,19 +1706,31 @@ describe("AccountsPage", () => {
 
     expect(await screen.findByText("mirror-east")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "复制-mirror-east" }));
+    expect(
+      screen.queryByRole("button", { name: "复制-mirror-east" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "测试-mirror-east" }));
+    const testModal = await screen.findByRole("dialog", { name: "连接测试" });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/ai-router/api/accounts/1/test",
+      expect.anything(),
+    );
+    fireEvent.click(within(testModal).getByRole("button", { name: /测\s*试/ }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ai-router/api/accounts/1/duplicate",
+        "/ai-router/api/accounts/1/test",
         expect.objectContaining({
           method: "POST",
+          body: JSON.stringify({ model: "gpt-5.4", input: "ping" }),
         }),
       );
     });
 
-    expect(await screen.findByText("mirror-east 1")).toBeInTheDocument();
-    expect(refreshDesktopTrayState).toHaveBeenCalledTimes(1);
+    expect(
+      await within(testModal).findByText("远端连通性测试成功"),
+    ).toBeInTheDocument();
+    expect(within(testModal).getByText("pong")).toBeInTheDocument();
   });
 
   it("renders dual official remaining meters with warning thresholds", async () => {

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -1636,9 +1636,6 @@ export function AccountsPage({
               <div className="account-main-text">
                 <div className="account-title-row">
                   <Text strong>{record.account_name}</Text>
-                  {getRoutingCooldownSeconds(record) ? (
-                    <Tag color="gold">{t(getRoutingCooldownLabel(record))}</Tag>
-                  ) : null}
                   {record.is_active ? (
                     <Tag color="green">{t("当前使用中")}</Tag>
                   ) : null}

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -1,7 +1,7 @@
 import {
+  ApiOutlined,
   BarChartOutlined,
   CheckCircleOutlined,
-  CopyOutlined,
   DeleteOutlined,
   EditOutlined,
   ExportOutlined,
@@ -10,6 +10,7 @@ import {
   PlusOutlined,
 } from "@ant-design/icons";
 import {
+  AutoComplete,
   App as AntApp,
   Avatar,
   Button,
@@ -63,7 +64,6 @@ import {
   createAccount,
   completeOfficialAuthDevice,
   deleteAccount,
-  duplicateAccount,
   fetchPPChatTokenLogs,
   startOfficialAuth,
   getLuaUsageScript,
@@ -96,14 +96,6 @@ const defaultBaseURL = "https://code.ppchat.vip/v1";
 type AddModalMode = "official" | "third_party" | "shared_import" | null;
 type OfficialEntryMode = "oauth" | "local_import";
 
-const statusColorMap: Record<string, string> = {
-  active: "green",
-  cooldown: "gold",
-  degraded: "orange",
-  invalid: "red",
-  disabled: "default",
-};
-
 const statusTextMap: Record<string, string> = {
   active: "可用",
   cooldown: "冷却中",
@@ -133,6 +125,17 @@ const sourceIconMap: Record<SourceIcon, { label: string; icon: string }> = {
   claude_code: { label: "Claude Code", icon: sourceClaudeCodeIcon },
   ppchat: { label: "PPChat", icon: sourcePPChatIcon },
 };
+
+const TEST_MODEL_SUGGESTIONS = [
+  "gpt-5.4",
+  "gpt-5.3-codex",
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "gpt-5.1",
+  "gpt-5.1-codex-max",
+  "gpt-5",
+  "gpt-4.1",
+];
 
 function normalizeSourceIcon(raw?: string): SourceIcon {
   if (raw === "ppchat") {
@@ -700,11 +703,15 @@ export function AccountsPage({
   const [editingAccount, setEditingAccount] = useState<AccountRecord | null>(
     null,
   );
+  const [testingAccount, setTestingAccount] = useState<AccountRecord | null>(
+    null,
+  );
   const [detailAccount, setDetailAccount] = useState<AccountRecord | null>(
     null,
   );
   const [sharedImportError, setSharedImportError] = useState<string>("");
   const [testResult, setTestResult] = useState<AccountTestResult | null>(null);
+  const [testLoading, setTestLoading] = useState(false);
   const [luaTestResult, setLuaTestResult] = useState<AccountTestResult | null>(
     null,
   );
@@ -962,7 +969,7 @@ export function AccountsPage({
     void messageApi.success(t("第三方账户已添加"));
   }
 
-  async function handleCreateOfficial(values: { account_name: string }) {
+  async function handleCreateOfficial(values: { account_name?: string }) {
     setOfficialImporting(true);
     try {
       if (
@@ -971,7 +978,6 @@ export function AccountsPage({
         (officialOAuthSession?.user_code || "").trim() !== ""
       ) {
         await completeOfficialAuthDevice({
-          account_name: values.account_name || "local-codex",
           device_code: officialOAuthSession?.device_code || "",
           user_code: officialOAuthSession?.user_code || "",
         }, { allowPending: false });
@@ -1009,7 +1015,7 @@ export function AccountsPage({
         // Fallback to Codex device login URL when backend oauth metadata is unavailable.
       }
       await openExternalUrl(targetURL);
-      void messageApi.success(t("已打开 OAuth 登录页"));
+      void messageApi.success(t("已打开 ChatGPT 登录页"));
       startOfficialOAuthAutoPoll(startedSession);
     } finally {
       setOfficialOAuthLaunching(false);
@@ -1070,7 +1076,6 @@ export function AccountsPage({
       try {
         const result = await completeOfficialAuthDevice(
           {
-            account_name: officialForm.getFieldValue("account_name") || "local-codex",
             device_code: readySession.device_code || "",
             user_code: readySession.user_code || "",
           },
@@ -1144,7 +1149,6 @@ export function AccountsPage({
 
   function openEditModal(account: AccountRecord) {
     setEditingAccount(account);
-    setTestResult(null);
     setLuaTestResult(null);
     editForm.setFieldsValue({
       account_name: account.account_name,
@@ -1213,12 +1217,35 @@ export function AccountsPage({
     );
   }
 
+  async function runConnectionTest(
+    account: AccountRecord,
+    values: { model: string; input: string },
+  ) {
+    setTestLoading(true);
+    try {
+      const result = await testAccount(account.id, values);
+      setTestResult(result);
+    } finally {
+      setTestLoading(false);
+    }
+  }
+
+  function openTestModal(account: AccountRecord) {
+    setTestingAccount(account);
+    setTestResult(null);
+    setTestLoading(false);
+    const payload = {
+      model: getDefaultTestModel(account),
+      input: "ping",
+    };
+    testForm.setFieldsValue(payload);
+  }
+
   async function handleTest(values: { model: string; input: string }) {
-    if (!editingAccount) {
+    if (!testingAccount) {
       return;
     }
-    const result = await testAccount(editingAccount.id, values);
-    setTestResult(result);
+    await runConnectionTest(testingAccount, values);
   }
 
   async function handleCopyLuaSkill() {
@@ -1335,19 +1362,6 @@ export function AccountsPage({
       setAccountsState(previous);
       void messageApi.error(
         error instanceof Error ? t(error.message) : t("切换激活账户失败"),
-      );
-    }
-  }
-
-  async function handleCopyAccount(record: AccountRecord) {
-    try {
-      await duplicateAccount(record.id);
-      await refreshAll();
-      void refreshDesktopTrayState();
-      void messageApi.success(t("已复制账户"));
-    } catch (error) {
-      void messageApi.warning(
-        error instanceof Error ? t(error.message) : t("复制失败，请稍后重试"),
       );
     }
   }
@@ -1622,9 +1636,6 @@ export function AccountsPage({
               <div className="account-main-text">
                 <div className="account-title-row">
                   <Text strong>{record.account_name}</Text>
-                  <Tag color={statusColorMap[record.status] ?? "default"}>
-                    {t(statusTextMap[record.status] ?? record.status)}
-                  </Tag>
                   {getRoutingCooldownSeconds(record) ? (
                     <Tag color="gold">{t(getRoutingCooldownLabel(record))}</Tag>
                   ) : null}
@@ -1706,10 +1717,10 @@ export function AccountsPage({
                 <Button
                   type="text"
                   className="account-action-button"
-                  aria-label={`${t("复制")}-${record.account_name}`}
-                  icon={<CopyOutlined />}
+                  aria-label={`${t("测试")}-${record.account_name}`}
+                  icon={<ApiOutlined />}
                   disabled={options.actionsDisabled}
-                  onClick={() => void handleCopyAccount(record)}
+                  onClick={() => openTestModal(record)}
                 />
                 <Button
                   type="text"
@@ -2105,105 +2116,104 @@ export function AccountsPage({
         footer={null}
         destroyOnHidden
         centered
+        className="official-account-modal"
       >
         <Form
           form={officialForm}
           layout="vertical"
+          className="official-account-form"
           onFinish={(values) => void handleCreateOfficial(values)}
         >
-          <Form.Item label={t("登录方式")}>
-            <div style={{ display: "flex", gap: 8 }}>
-              <Button
-                type={officialEntryMode === "oauth" ? "primary" : "default"}
+          <div className="official-account-header">
+            <div
+              className="menu-pill-group official-account-tabs"
+              role="tablist"
+              aria-label={t("账户导入方式")}
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={officialEntryMode === "oauth"}
+                className={officialEntryMode === "oauth" ? "menu-pill-button is-active" : "menu-pill-button"}
                 onClick={() => setOfficialEntryMode("oauth")}
               >
                 {t("OAuth 登录")}
-              </Button>
-              <Button
-                type={
-                  officialEntryMode === "local_import" ? "primary" : "default"
-                }
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={officialEntryMode === "local_import"}
+                className={officialEntryMode === "local_import" ? "menu-pill-button is-active" : "menu-pill-button"}
                 onClick={() => setOfficialEntryMode("local_import")}
               >
                 {t("导入本地")}
-              </Button>
+              </button>
             </div>
-          </Form.Item>
-          <Form.Item
-            label={t("账户名称")}
-            name="account_name"
-            initialValue="local-codex"
-          >
-            <Input />
-          </Form.Item>
-          {officialEntryMode === "oauth" ? (
-            <div style={{ display: "grid", gap: 8 }}>
-              {officialOAuthSession?.user_code ? (
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    border: "1px solid var(--color-border, #d9d9d9)",
-                    borderRadius: 8,
-                    padding: "8px 12px",
-                    gap: 8,
-                  }}
-                >
-                  <div>
-                    <Text type="secondary">{t("设备码")}</Text>
-                    <div>
-                      <Text strong code>
-                        {officialOAuthSession.user_code}
-                      </Text>
-                    </div>
-                  </div>
-                  <Button onClick={() => void handleCopyOfficialUserCode()}>
-                    {t("复制设备码")}
+          </div>
+          <div className="official-account-content">
+            {officialEntryMode === "oauth" ? (
+              <div className="official-account-panel">
+                {!officialOAuthLaunching && !officialOAuthSession?.user_code ? (
+                  <Button onClick={() => void handleStartOfficialOAuth()}>
+                    {t("使用 ChatGPT 登录")}
                   </Button>
-                </div>
-              ) : null}
-            </div>
-          ) : (
-            <Text type="secondary">
-              {language === "en-US" ? (
-                <>
-                  The app reads <code>~/.codex/auth.json</code> directly from
-                  the current user directory.
-                </>
-              ) : (
-                <>
-                  将直接读取当前用户目录下的 <code>~/.codex/auth.json</code>。
-                </>
-              )}
-            </Text>
-          )}
-          <div className="modal-footer">
+                ) : null}
+                {officialOAuthSession?.user_code ? (
+                  <div className="official-account-device-code">
+                    <Text type="secondary">{t("设备码")}</Text>
+                    <span className="official-account-device-code-plain">
+                      {officialOAuthSession.user_code}
+                    </span>
+                    <div className="official-account-device-code-slots">
+                      {officialOAuthSession.user_code.split("").map((char, index) =>
+                        char === "-" ? (
+                          <span
+                            key={`dash-${index}`}
+                            className="official-account-device-code-separator"
+                          >
+                            -
+                          </span>
+                        ) : (
+                          <span
+                            key={`slot-${index}`}
+                            className="official-account-device-code-slot"
+                          >
+                            {char}
+                          </span>
+                        ),
+                      )}
+                    </div>
+                    <Button
+                      block
+                      onClick={() => void handleCopyOfficialUserCode()}
+                    >
+                      {t("复制设备码")}
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="official-account-panel">
+                <Form.Item
+                  label={t("账户名称")}
+                  name="account_name"
+                  initialValue="local-codex"
+                >
+                  <Input />
+                </Form.Item>
+                <Button
+                  type="primary"
+                  htmlType="submit"
+                  loading={officialImporting}
+                >
+                  {t("导入")}
+                </Button>
+              </div>
+            )}
+          </div>
+          <div className="official-account-footer modal-footer">
             <Button onClick={closeOfficialModal}>
               {t("取消")}
-            </Button>
-            {officialEntryMode === "oauth" ? (
-              <Button
-                onClick={() => void handleStartOfficialOAuth()}
-                loading={officialOAuthLaunching}
-              >
-                {officialOAuthSession?.user_code
-                  ? t("重新获取设备码")
-                  : t("打开 OAuth 登录页")}
-              </Button>
-            ) : null}
-            <Button
-              type="primary"
-              htmlType="submit"
-              loading={officialImporting}
-              disabled={
-                officialEntryMode === "oauth" &&
-                (officialOAuthSession?.device_code || "").trim() === ""
-              }
-            >
-              {officialEntryMode === "oauth"
-                ? t("已完成登录")
-                : t("导入")}
             </Button>
           </div>
         </Form>
@@ -2421,54 +2431,6 @@ export function AccountsPage({
             </Button>
           </div>
         </Form>
-        <div className="edit-test-panel">
-          <Text strong>{t("连接测试")}</Text>
-          <Form
-            form={testForm}
-            layout="vertical"
-            initialValues={{ model: "gpt-5.4", input: "ping" }}
-            onFinish={(values) => void handleTest(values)}
-          >
-            <Form.Item
-              label={t("模型")}
-              name="model"
-              rules={[{ required: true, message: t("请选择模型") }]}
-            >
-              <Select
-                options={[
-                  { value: "gpt-5.4", label: "gpt-5.4" },
-                  { value: "gpt-5.1-codex-max", label: "gpt-5.1-codex-max" },
-                  { value: "gpt-5.2-codex", label: "gpt-5.2-codex" },
-                  { value: "gpt-5", label: "gpt-5" },
-                  { value: "gpt-4.1", label: "gpt-4.1" },
-                ]}
-              />
-            </Form.Item>
-            <Form.Item
-              label={t("输入内容")}
-              name="input"
-              rules={[{ required: true, message: t("请输入测试内容") }]}
-            >
-              <Input.TextArea rows={3} />
-            </Form.Item>
-            <div className="modal-footer">
-              <Button htmlType="submit">{t("测试")}</Button>
-            </div>
-          </Form>
-        </div>
-        {testResult ? (
-          <div className="test-result-panel">
-            <Tag color={testResult.ok ? "green" : "red"}>
-              {testResult.message}
-            </Tag>
-            {testResult.details ? (
-              <Text type="secondary">{testResult.details}</Text>
-            ) : null}
-            {testResult.content ? (
-              <pre className="test-output">{testResult.content}</pre>
-            ) : null}
-          </div>
-        ) : null}
         {luaTestResult ? (
           <div className="test-result-panel">
             <Tag color={luaTestResult.ok ? "green" : "red"}>
@@ -2479,6 +2441,66 @@ export function AccountsPage({
             ) : null}
             {luaTestResult.content ? (
               <pre className="test-output">{luaTestResult.content}</pre>
+            ) : null}
+          </div>
+        ) : null}
+      </Modal>
+
+      <Modal
+        open={!!testingAccount}
+        title={t("连接测试")}
+        onCancel={() => {
+          setTestingAccount(null);
+          setTestLoading(false);
+        }}
+        footer={null}
+        destroyOnHidden
+        centered
+      >
+        <Form
+          form={testForm}
+          layout="vertical"
+          onFinish={(values) => void handleTest(values)}
+        >
+          <Form.Item
+            label={t("模型")}
+            name="model"
+            rules={[{ required: true, message: t("请选择模型") }]}
+          >
+            <AutoComplete
+              options={TEST_MODEL_SUGGESTIONS.map((value) => ({ value }))}
+              filterOption={(inputValue, option) =>
+                (option?.value ?? "")
+                  .toString()
+                  .toLowerCase()
+                  .includes(inputValue.toLowerCase())
+              }
+              placeholder="gpt-5.4"
+            />
+          </Form.Item>
+          <Form.Item
+            label={t("输入内容")}
+            name="input"
+            rules={[{ required: true, message: t("请输入测试内容") }]}
+          >
+            <Input.TextArea rows={3} />
+          </Form.Item>
+          <div className="modal-footer">
+            <Button htmlType="submit" loading={testLoading}>
+              {t("测试")}
+            </Button>
+          </div>
+        </Form>
+        {testResult ? (
+          <div className="test-result-panel">
+            <Tag color={testResult.ok ? "green" : "red"}>
+              {testResult.message}
+            </Tag>
+            {testResult.details ? (
+              <Text type="secondary">{testResult.details}</Text>
+            ) : null}
+            {testResult.content ? (
+              <pre className="test-output">{testResult.content}</pre>
             ) : null}
           </div>
         ) : null}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -756,7 +756,7 @@ export async function startOfficialAuth(): Promise<OfficialAuthSession> {
 }
 
 export async function completeOfficialAuthDevice(payload: {
-  account_name: string;
+  account_name?: string;
   device_code: string;
   user_code: string;
 }, options?: {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2645,6 +2645,107 @@ html[data-theme-mode="dark"] .stats-chart-shell {
   gap: 12px;
 }
 
+.official-account-modal .ant-modal-body {
+  padding: 0;
+}
+
+.official-account-modal .ant-modal-content {
+  height: 340px;
+  display: flex;
+  flex-direction: column;
+}
+
+.official-account-form {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.official-account-header {
+  display: flex;
+  align-items: center;
+  min-height: 36px;
+  margin-bottom: 14px;
+}
+
+.official-account-content {
+  height: 120px;
+  min-height: 120px;
+  max-height: 120px;
+  display: flex;
+  align-items: center;
+}
+
+.official-account-tabs {
+  margin-bottom: 0;
+}
+
+.official-account-panel {
+  display: grid;
+  gap: 12px;
+  padding: 0 2px;
+  width: 100%;
+}
+
+.official-account-panel .ant-form-item {
+  margin-bottom: 0;
+}
+
+.official-account-device-code {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--color-border, #d9d9d9);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.official-account-device-code-slots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.official-account-device-code-plain {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.official-account-device-code-slot {
+  min-width: 34px;
+  height: 44px;
+  border: 1px solid var(--color-border, #d9d9d9);
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  font-family: "SFMono-Regular", "SF Mono", "Roboto Mono", monospace;
+  letter-spacing: 0.02em;
+}
+
+.official-account-device-code-separator {
+  font-size: 20px;
+  line-height: 1;
+  color: var(--text-secondary);
+}
+
+.official-account-footer {
+  margin-top: 14px;
+  padding: 0 2px;
+  border-top: none;
+}
+
 .test-account-meta {
   margin-bottom: 16px;
 }

--- a/scripts/desktop/build_sidecar_macos.sh
+++ b/scripts/desktop/build_sidecar_macos.sh
@@ -5,9 +5,42 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT_DIR="$ROOT_DIR/desktop/src-tauri/bin"
 mkdir -p "$OUT_DIR"
 
-APP_VERSION="$(node -p "require('$ROOT_DIR/desktop/package.json').version" 2>/dev/null || true)"
-if [[ -z "${APP_VERSION}" ]]; then
-  APP_VERSION="dev"
+resolve_app_version() {
+  local raw="${RELEASE_VERSION:-}"
+  local normalized
+  if [[ -n "$raw" ]]; then
+    normalized="${raw#v}"
+    normalized="${normalized#V}"
+    printf '%s\n' "$normalized"
+    return 0
+  fi
+
+  local tauri_conf="$ROOT_DIR/desktop/src-tauri/tauri.conf.json"
+  if [[ -f "$tauri_conf" ]]; then
+    normalized="$(node -e 'const fs = require("fs"); const f = process.argv[1]; const value = JSON.parse(fs.readFileSync(f, "utf8")).version || ""; process.stdout.write(String(value));' "$tauri_conf" 2>/dev/null || true)"
+    normalized="$(printf '%s' "$normalized" | tr -d '\r\n[:space:]')"
+    if [[ -n "$normalized" ]]; then
+      printf '%s\n' "$normalized"
+      return 0
+    fi
+  fi
+
+  local desktop_pkg="$ROOT_DIR/desktop/package.json"
+  if [[ -f "$desktop_pkg" ]]; then
+    normalized="$(node -e 'const fs = require("fs"); const f = process.argv[1]; const value = JSON.parse(fs.readFileSync(f, "utf8")).version || ""; process.stdout.write(String(value));' "$desktop_pkg" 2>/dev/null || true)"
+    normalized="$(printf '%s' "$normalized" | tr -d '\r\n[:space:]')"
+    if [[ -n "$normalized" ]]; then
+      printf '%s\n' "$normalized"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+if ! APP_VERSION="$(resolve_app_version)"; then
+  echo "Failed to resolve AppVersion for macOS sidecar build. Set RELEASE_VERSION or ensure desktop metadata version exists." >&2
+  exit 1
 fi
 LDFLAGS="-X github.com/gcssloop/codex-router/backend/internal/buildinfo.AppVersion=${APP_VERSION}"
 

--- a/scripts/desktop/build_sidecar_windows.sh
+++ b/scripts/desktop/build_sidecar_windows.sh
@@ -5,9 +5,42 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT_DIR="$ROOT_DIR/desktop/src-tauri/bin"
 mkdir -p "$OUT_DIR"
 
-APP_VERSION="$(node -p "require('$ROOT_DIR/desktop/package.json').version" 2>/dev/null || true)"
-if [[ -z "${APP_VERSION}" ]]; then
-  APP_VERSION="dev"
+resolve_app_version() {
+  local raw="${RELEASE_VERSION:-}"
+  local normalized
+  if [[ -n "$raw" ]]; then
+    normalized="${raw#v}"
+    normalized="${normalized#V}"
+    printf '%s\n' "$normalized"
+    return 0
+  fi
+
+  local tauri_conf="$ROOT_DIR/desktop/src-tauri/tauri.conf.json"
+  if [[ -f "$tauri_conf" ]]; then
+    normalized="$(node -e 'const fs = require("fs"); const f = process.argv[1]; const value = JSON.parse(fs.readFileSync(f, "utf8")).version || ""; process.stdout.write(String(value));' "$tauri_conf" 2>/dev/null || true)"
+    normalized="$(printf '%s' "$normalized" | tr -d '\r\n[:space:]')"
+    if [[ -n "$normalized" ]]; then
+      printf '%s\n' "$normalized"
+      return 0
+    fi
+  fi
+
+  local desktop_pkg="$ROOT_DIR/desktop/package.json"
+  if [[ -f "$desktop_pkg" ]]; then
+    normalized="$(node -e 'const fs = require("fs"); const f = process.argv[1]; const value = JSON.parse(fs.readFileSync(f, "utf8")).version || ""; process.stdout.write(String(value));' "$desktop_pkg" 2>/dev/null || true)"
+    normalized="$(printf '%s' "$normalized" | tr -d '\r\n[:space:]')"
+    if [[ -n "$normalized" ]]; then
+      printf '%s\n' "$normalized"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+if ! APP_VERSION="$(resolve_app_version)"; then
+  echo "Failed to resolve AppVersion for Windows sidecar build. Set RELEASE_VERSION or ensure desktop metadata version exists." >&2
+  exit 1
 fi
 LDFLAGS="-X github.com/gcssloop/codex-router/backend/internal/buildinfo.AppVersion=${APP_VERSION}"
 

--- a/scripts/desktop/package_local_release.sh
+++ b/scripts/desktop/package_local_release.sh
@@ -37,6 +37,7 @@ else
 fi
 
 TARGET_PLATFORM="$(resolve_local_platform)"
+export RELEASE_VERSION="$TAG"
 
 bash "$ROOT_DIR/scripts/release/sync_release_metadata.sh" "${sync_args[@]}"
 case "$TARGET_PLATFORM" in


### PR DESCRIPTION
## Summary
- soften routing cooldown strategy and keep auto failover
- retry active cooling account up to 3 attempts before failover
- clear routing cooldown immediately after successful request
- hide routing cooldown badge from account list UI
- bump release metadata to 1.4.6

## Validation
- go test ./internal/api ./internal/settings
- npm --prefix frontend run test -- src/features/accounts/AccountsPage.test.tsx
