### PR TITLE
fix: stabilize ChatGPT device-code bootstrap with retries

### DIFF
--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -560,13 +560,16 @@ func (h *AccountsHandler) createAuthSession(w http.ResponseWriter, r *http.Reque
 		"authorization_url": authURL,
 		"state":             state,
 	}
-	if session, err := h.connector.StartDeviceAuth(r.Context(), h.client); err == nil {
-		resp["device_code"] = session.DeviceCode
-		resp["user_code"] = session.UserCode
-		resp["verification_uri"] = session.VerificationURI
-		resp["expires_in"] = session.ExpiresIn
-		resp["interval"] = session.Interval
+	session, err := h.connector.StartDeviceAuth(r.Context(), h.client)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("start device auth: %v", err), http.StatusBadGateway)
+		return
 	}
+	resp["device_code"] = session.DeviceCode
+	resp["user_code"] = session.UserCode
+	resp["verification_uri"] = session.VerificationURI
+	resp["expires_in"] = session.ExpiresIn
+	resp["interval"] = session.Interval
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -101,6 +101,49 @@ func TestAccountsHandlerAuthorizeReturnsDeviceCode(t *testing.T) {
 	}
 }
 
+func TestAccountsHandlerAuthorizeReturnsErrorWhenDeviceAuthUnavailable(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	deviceAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporary upstream failure", http.StatusBadGateway)
+	}))
+	t.Cleanup(deviceAuthServer.Close)
+
+	connector := auth.NewOAuthConnector(auth.Config{
+		ClientID:              "client-id",
+		AuthorizeURL:          "https://auth.example.test/oauth/authorize",
+		TokenURL:              "https://auth.example.test/oauth/token",
+		RedirectURL:           "http://localhost:8080/callback",
+		Scopes:                []string{"model.read"},
+		DeviceAuthUserCodeURL: deviceAuthServer.URL + "/device-auth",
+	})
+	handler := api.NewAccountsHandler(
+		repo,
+		nil,
+		connector,
+		auth.NewStateStore(5*time.Minute),
+		api.WithAccountsHTTPClient(deviceAuthServer.Client()),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/accounts/auth/authorize", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("POST /accounts/auth/authorize status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+	if !strings.Contains(rec.Body.String(), "start device auth:") {
+		t.Fatalf("POST /accounts/auth/authorize body = %q, want prefixed error", rec.Body.String())
+	}
+}
+
 func TestAccountsHandlerCompleteDeviceAuthUsesInferredName(t *testing.T) {
 	t.Parallel()
 
@@ -192,14 +235,42 @@ func TestAccountsHandler(t *testing.T) {
 
 	repo := accounts.NewSQLiteRepository(store.DB())
 	usageRepo := usage.NewSQLiteRepository(store.DB())
+	deviceAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON := func(value any) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(value)
+		}
+		switch r.URL.Path {
+		case "/device-auth":
+			writeJSON(map[string]any{
+				"device_auth_id": "dev-auth-generic",
+				"user_code":      "WXYZ-1234",
+				"expires_in":     900,
+				"interval":       5,
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	t.Cleanup(deviceAuthServer.Close)
+
 	connector := auth.NewOAuthConnector(auth.Config{
-		ClientID:     "client-id",
-		AuthorizeURL: "https://auth.example.test/oauth/authorize",
-		TokenURL:     "https://auth.example.test/oauth/token",
-		RedirectURL:  "http://localhost:8080/callback",
-		Scopes:       []string{"model.read"},
+		ClientID:              "client-id",
+		AuthorizeURL:          "https://auth.example.test/oauth/authorize",
+		TokenURL:              "https://auth.example.test/oauth/token",
+		RedirectURL:           "http://localhost:8080/callback",
+		Scopes:                []string{"model.read"},
+		DeviceAuthUserCodeURL: deviceAuthServer.URL + "/device-auth",
 	})
-	handler := api.NewAccountsHandler(repo, usageRepo, connector, auth.NewStateStore(5*time.Minute))
+	handler := api.NewAccountsHandler(
+		repo,
+		usageRepo,
+		connector,
+		auth.NewStateStore(5*time.Minute),
+		api.WithAccountsHTTPClient(deviceAuthServer.Client()),
+	)
 
 	createBody := bytes.NewBufferString(`{
 		"provider_type":"openai-compatible",

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -158,6 +158,203 @@ describe("AccountsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not open browser when oauth authorize response misses device code", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/auth/authorize" &&
+        init?.method === "POST"
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              authorization_url: "https://auth.openai.com/codex/device",
+              state: "state-1",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加账户/ }));
+    fireEvent.click(await screen.findByText("官方账户"));
+    const officialModal = await screen.findByRole("dialog", {
+      name: "添加官方账户",
+    });
+    fireEvent.click(
+      within(officialModal).getByRole("button", { name: "使用 ChatGPT 登录" }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ai-router/api/accounts/auth/authorize",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(openExternalUrl).not.toHaveBeenCalled();
+      expect(within(officialModal).queryByText("设备码")).toBeNull();
+      expect(
+        within(officialModal).getByRole("button", { name: "使用 ChatGPT 登录" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("retries oauth authorize up to 3 times and succeeds on the third try", async () => {
+    let authorizeCalls = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/auth/authorize" &&
+        init?.method === "POST"
+      ) {
+        authorizeCalls += 1;
+        if (authorizeCalls < 3) {
+          return Promise.resolve(new Response("temporary unavailable", { status: 502 }));
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              authorization_url: "https://auth.openai.com/codex/device",
+              state: "state-3",
+              user_code: "IJKL-MNOP",
+              device_code: "device-auth-id-3",
+              verification_uri: "https://auth.openai.com/codex/device",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加账户/ }));
+    fireEvent.click(await screen.findByText("官方账户"));
+    const officialModal = await screen.findByRole("dialog", {
+      name: "添加官方账户",
+    });
+    fireEvent.click(
+      within(officialModal).getByRole("button", { name: "使用 ChatGPT 登录" }),
+    );
+
+    await waitFor(() => {
+      expect(authorizeCalls).toBe(3);
+      expect(openExternalUrl).toHaveBeenCalledWith(
+        "https://auth.openai.com/codex/device",
+      );
+      expect(within(officialModal).getByText("设备码")).toBeInTheDocument();
+      expect(within(officialModal).getByText("IJKL-MNOP")).toBeInTheDocument();
+    });
+  });
+
+  it("stops after 3 oauth authorize retries and does not open browser", async () => {
+    let authorizeCalls = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/auth/authorize" &&
+        init?.method === "POST"
+      ) {
+        authorizeCalls += 1;
+        return Promise.resolve(new Response("temporary unavailable", { status: 502 }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /添加账户/ }));
+    fireEvent.click(await screen.findByText("官方账户"));
+    const officialModal = await screen.findByRole("dialog", {
+      name: "添加官方账户",
+    });
+    fireEvent.click(
+      within(officialModal).getByRole("button", { name: "使用 ChatGPT 登录" }),
+    );
+
+    await waitFor(() => {
+      expect(authorizeCalls).toBe(3);
+      expect(openExternalUrl).not.toHaveBeenCalled();
+      expect(within(officialModal).queryByText("设备码")).toBeNull();
+      expect(
+        within(officialModal).getByRole("button", { name: "使用 ChatGPT 登录" }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("supports official upload, third-party create, and chat test in a single dashboard", async () => {
     const accountList = [
       {

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -994,29 +994,47 @@ export function AccountsPage({
   }
 
   async function handleStartOfficialOAuth() {
+    if (officialOAuthLaunching) {
+      return;
+    }
     setOfficialOAuthLaunching(true);
     try {
       let targetURL = "https://auth.openai.com/codex/device";
-      let startedSession: OfficialAuthSession | null = null;
-      try {
-        const session = await startOfficialAuth();
-        setOfficialOAuthSession(session);
-        startedSession = session;
-        const candidate = (session.authorization_url || "").trim();
-        if (/^https?:\/\//i.test(candidate)) {
-          targetURL = candidate;
+      const maxRetries = 3;
+      let session: OfficialAuthSession | null = null;
+      let lastError: unknown = null;
+      for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
+        try {
+          session = await startOfficialAuth();
+          break;
+        } catch (error) {
+          lastError = error;
+          if (attempt < maxRetries) {
+            await new Promise<void>((resolve) => {
+              window.setTimeout(resolve, 300);
+            });
+          }
         }
-        const verificationURI = (session.verification_uri || "").trim();
-        if (/^https?:\/\//i.test(verificationURI)) {
-          targetURL = verificationURI;
-        }
-      } catch {
-        setOfficialOAuthSession(null);
-        // Fallback to Codex device login URL when backend oauth metadata is unavailable.
+      }
+      if (!session) {
+        throw lastError instanceof Error ? lastError : new Error(t("启动 OAuth 失败"));
+      }
+      setOfficialOAuthSession(session);
+      const candidate = (session.authorization_url || "").trim();
+      if (/^https?:\/\//i.test(candidate)) {
+        targetURL = candidate;
+      }
+      const verificationURI = (session.verification_uri || "").trim();
+      if (/^https?:\/\//i.test(verificationURI)) {
+        targetURL = verificationURI;
       }
       await openExternalUrl(targetURL);
       void messageApi.success(t("已打开 ChatGPT 登录页"));
-      startOfficialOAuthAutoPoll(startedSession);
+      startOfficialOAuthAutoPoll(session);
+    } catch (error) {
+      setOfficialOAuthSession(null);
+      const friendlyMessage = t("网络波动，暂时无法获取设备码。已自动重试 3 次，请稍后重试。");
+      void messageApi.error(friendlyMessage);
     } finally {
       setOfficialOAuthLaunching(false);
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -749,9 +749,15 @@ export async function startOfficialAuth(): Promise<OfficialAuthSession> {
     body: "{}",
   });
   if (!response.ok) {
-    throw new Error("failed to start official auth");
+    const details = await response.text();
+    throw new Error(details || "failed to start official auth");
   }
   const payload = (await response.json()) as OfficialAuthSession;
+  const hasDeviceCode = (payload.device_code || "").trim() !== "";
+  const hasUserCode = (payload.user_code || "").trim() !== "";
+  if (!hasDeviceCode || !hasUserCode) {
+    throw new Error("device auth response missing user code");
+  }
   return payload;
 }
 


### PR DESCRIPTION
## Summary
- add strict backend behavior for /accounts/auth/authorize: fail when device auth bootstrap fails
- validate authorize payload on frontend and require device_code + user_code
- retry authorize up to 3 times; if all fail, do not open browser
- use a friendlier error message after retries fail
- add frontend/backend regression tests for retry and failure paths

## Verification
- cd backend && go test ./internal/api -run 'TestAccountsHandlerAuthorizeReturnsDeviceCode|TestAccountsHandlerAuthorizeReturnsErrorWhenDeviceAuthUnavailable|TestAccountsHandler$' -count=1
- cd frontend && pnpm vitest run src/features/accounts/AccountsPage.test.tsx --reporter=dot