### PR TITLE
feat: add public skills landing page and migrate domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+本文件适用于整个仓库，面向在 AI Gate 项目中工作的编码 agent。
+
+## 项目形态
+
+AI Gate 是面向 Codex 工作流的本地优先路由层和桌面壳。最重要的边界是薄网关语义：保留上游协议语义，账号密钥留在本机，做不到的能力要明确不支持，不要伪造兼容。
+
+主要目录：
+
+- `backend/`：Go 路由服务、账号管理、策略、用量、工具链和本地 API handler。
+- `frontend/`：Vite + React + Ant Design 桌面端/网页端 UI。
+- `desktop/`：Tauri 桌面壳和桌面打包配置。
+- `services/skill-metrics-worker/`：Cloudflare Worker，负责 Skill registry、排行和 tracked repo 元数据。
+- `scripts/`：发布、打包、迁移和冒烟测试 harness。
+- `docs/`：用户文档、运维说明和实现计划。
+- `skills/`：仓库内置 Codex skills。
+
+## Harness-First 工作流
+
+每个改动都必须能被某种 harness 验证。harness 可以是单元测试、集成测试、shell 冒烟脚本、本地 dev server、Worker 命令、打包脚本，或带有具体输出的定向手工检查。
+
+编辑前：
+
+- 先识别能覆盖这个 bug 或回归的最小 harness。
+- 先读本地代码路径和附近测试，再决定实现方式。
+- 保留已有用户改动，不要回退无关 dirty files。
+
+编辑中：
+
+- 做满足需求的最小连贯改动。
+- 优先使用现有 helper、路由模式、状态模型和测试工具。
+- 避免臆测式抽象和无关重构。
+- 行为变更尽量先新增或更新 harness，再改实现。
+
+完成前：
+
+- 运行相关 harness，并在回复中写明具体命令。
+- 如果 harness 无法运行，说明原因和仍未验证的风险。
+- 没有看到真实输出前，不要声称修复完成、构建成功、发布成功或测试通过。
+
+## 验证矩阵
+
+先运行最窄的适用命令；如果改动影响共享行为，再扩大验证范围。
+
+- 后端 Go 改动：`cd backend && go test ./...`
+- 迭代中的特定 Go 包：`cd backend && go test ./internal/<pkg> -run <TestName> -count=1`
+- 前端改动：`npm --prefix frontend test`
+- 前端生产构建风险：`npm --prefix frontend run build`
+- 桌面壳或打包改动：运行 `scripts/desktop/` 下的相关脚本；触及打包行为时运行 `npm --prefix desktop run tauri build`。
+- 发布脚本改动：运行对应的 `scripts/test/*_test.sh` harness。
+- Skill metrics worker 改动：`cd services/skill-metrics-worker && npm test`
+- tracked repo seed 改动：用 `jq empty services/skill-metrics-worker/config/tracked-repos.seed.json` 校验 JSON。
+- 端到端路由行为：启动 `make backend`，再按 `docs/testing.md` 用 curl 或 Codex CLI 检查本地 `/ai-router/api` 路由。
+
+如果命令会写缓存或数据库，优先使用 Makefile 和脚本中已有的仓库内路径。除非任务明确需要且已获得许可，不要写工作区之外的位置。
+
+## 后端规范
+
+- 保留薄网关语义。不要在本地合成 `response_id`、`previous_response_id`、response retrieval 或 `/chat/completions` fallback。
+- 上游状态码、SSE 生命周期和 terminal events 以上游为准。
+- 除非任务明确修改 LAN sharing 行为，后端保持 loopback-first。
+- 账号密钥、auth 文件、数据库快照和配置补丁必须保持本地优先且可恢复。
+- 优先在被改包附近补仓库级测试。复用现有 temp home、SQLite、auth fixture 和 request handler 测试工具。
+- 触及 routing 或 failover 时，要验证 terminal output 和非挂起行为，不能只看 HTTP status。
+
+## 前端规范
+
+- 遵循 `frontend/src/features/*` 里的 React + Ant Design 现有模式。
+- 操作型 UI 要保持信息密度、可扫读和可预测。这个项目是工作工具，不是营销页面。
+- 使用 `frontend/src/lib/api.ts` 的 API wrapper、`frontend/src/lib/desktop-shell.ts` 的桌面集成 helper、`frontend/src/lib/i18n.ts` 的本地化 helper。
+- 在受影响页面或组件旁边新增或更新测试。
+- 工具栏、列表、卡片和表格在不同视口下要保持控件尺寸稳定，避免布局跳动。
+- 除非现有体系无法承载需求，不要引入新的视觉系统。
+
+## 桌面与打包规范
+
+- Tauri sidecar 行为要和后端二进制及发布脚本保持一致。
+- 打包变更要用 `scripts/desktop/` 或 `scripts/test/` 下的对应脚本验证。
+- 不要在桌面配置、发布元数据或 notarization 逻辑里硬编码本地开发者路径。
+- 签名、updater manifest、发布文件名和资产收集要视为同一个被 harness 覆盖的流程。
+
+## Skill Metrics Worker 规范
+
+- `tracked_repos` 是远程 Skill 仓库的中心 registry。修改 registry 模型时，要保持 seed JSON 和远端行为一致。
+- 公共接口不能泄露 admin-only 指标或密钥。
+- 管理操作必须保持 token/session 保护。
+- 修改 D1 或 KV schema 假设时，要同步补测试。
+- 远端 Worker HTTP 入口不可用时，只有在本机 Cloudflare 登录态已可用且任务确实需要时，才用 Wrangler D1 检查。
+
+## 文档规范
+
+- 行为、命令、路由、环境变量、打包或部署步骤变化时，同步更新 `README.md`、`docs/testing.md`、ops 文档或 plans。
+- commit 信息、plan 文档、变更记录、交接说明和其他长期记录统一使用中文；只有命令、代码标识、API 路径、错误原文等需要保真的内容保留原文。
+- `AGENTS.md` 只写 agent 操作规则，不重复用户向安装和使用说明。
+- 持久文档使用绝对日期。避免“今天”“最近”“当前”等相对时间。
+- 优先替换过时说明，不要追加互相矛盾的注释。
+
+## Git 与安全
+
+- 工作区可能已有 dirty files。编辑前先检查，保留无关改动。
+- 不要运行 `git reset --hard`、大范围 `rm`、基于 checkout 的回退等破坏性命令，除非用户明确要求。
+- 不要在用户未要求时 commit、tag、push、deploy 或修改远端状态。
+- 除非生成物、本地数据库、缓存和 release assets 本身就是交付物，否则不要改它们。

--- a/backend/internal/api/tooling_handler.go
+++ b/backend/internal/api/tooling_handler.go
@@ -41,7 +41,8 @@ const (
 	skillMetricsHeartbeatName          = "__client_active__"
 	skillMetricsHeartbeatSource        = "__aigate_client__"
 	skillMetricsActiveReportInterval   = time.Hour
-	defaultSkillMetricsBaseURL         = "https://aigate-skill-metrics.gcssloop.workers.dev"
+	legacySkillMetricsBaseURL         = "https://" + "aigate-skill-metrics" + ".gcssloop.workers.dev"
+	defaultSkillMetricsBaseURL         = "https://skills.ai-gate.work"
 )
 
 var toolingSupportedApps = []string{"codex"}
@@ -1476,6 +1477,9 @@ func normalizeToolingConfig(cfg toolingConfig) (toolingConfig, bool) {
 	changed := false
 	cfg.SkillSyncMethod = normalizeSkillSyncMethod(cfg.SkillSyncMethod)
 	baseURL := normalizeBaseURL(cfg.SkillMetricsBaseURL)
+	if baseURL == legacySkillMetricsBaseURL {
+		baseURL = defaultToolingSkillMetricsBaseURL
+	}
 	if baseURL == "" {
 		baseURL = defaultToolingSkillMetricsBaseURL
 	}
@@ -1484,6 +1488,9 @@ func normalizeToolingConfig(cfg toolingConfig) (toolingConfig, bool) {
 	}
 	cfg.SkillMetricsBaseURL = baseURL
 	registryURL := normalizeBaseURL(cfg.SkillRepoRegistryURL)
+	if registryURL == defaultToolingRepoRegistryURL(legacySkillMetricsBaseURL) {
+		registryURL = defaultToolingRepoRegistryURL(baseURL)
+	}
 	if registryURL == "" {
 		registryURL = defaultToolingRepoRegistryURL(baseURL)
 	}

--- a/backend/internal/api/tooling_handler_internal_test.go
+++ b/backend/internal/api/tooling_handler_internal_test.go
@@ -437,6 +437,25 @@ func TestSkillMetricsBaseURLUsesConfigNotEnv(t *testing.T) {
 	}
 }
 
+func TestToolingConfigMigratesLegacySkillMetricsURL(t *testing.T) {
+	home := t.TempDir()
+	cfg := loadToolingConfig(home)
+	cfg.SkillMetricsBaseURL = legacySkillMetricsBaseURL
+	cfg.SkillRepoRegistryURL = defaultToolingRepoRegistryURL(legacySkillMetricsBaseURL)
+	if err := saveToolingConfig(home, cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	got := loadToolingConfig(home)
+	if got.SkillMetricsBaseURL != defaultSkillMetricsBaseURL {
+		t.Fatalf("SkillMetricsBaseURL = %q, want %q", got.SkillMetricsBaseURL, defaultSkillMetricsBaseURL)
+	}
+	wantRegistry := defaultToolingRepoRegistryURL(defaultSkillMetricsBaseURL)
+	if got.SkillRepoRegistryURL != wantRegistry {
+		t.Fatalf("SkillRepoRegistryURL = %q, want %q", got.SkillRepoRegistryURL, wantRegistry)
+	}
+}
+
 func TestParseDiscoveredSkillIDSupportsLegacyCentralFormat(t *testing.T) {
 	platform, repo, branch, sourcePath, err := parseDiscoveredSkillID("github:openai/skills:collections/demo")
 	if err != nil {

--- a/docs/ops/2026-04-10-cloudflare-skill-metrics-setup.md
+++ b/docs/ops/2026-04-10-cloudflare-skill-metrics-setup.md
@@ -73,7 +73,7 @@ npx wrangler deploy --config services/skill-metrics-worker/wrangler.jsonc
 
 Current endpoint:
 
-- `https://aigate-skill-metrics.gcssloop.workers.dev`
+- `https://skills.ai-gate.work`
 
 Current version ID (latest in this setup): `3e082831-03fa-4419-b01b-558e79bbdc24`
 
@@ -86,13 +86,13 @@ After central tracked-repos rollout update:
 Health check:
 
 ```bash
-curl -sS https://aigate-skill-metrics.gcssloop.workers.dev/health
+curl -sS https://skills.ai-gate.work/health
 ```
 
 Ingest sample event:
 
 ```bash
-curl -sS -X POST https://aigate-skill-metrics.gcssloop.workers.dev/events/install \
+curl -sS -X POST https://skills.ai-gate.work/events/install \
   -H 'Content-Type: application/json' \
   -d '{"user_hash":"u_demo_003","skill_name":"frontend-design","source_repo":"anthropics/skills","client_version":"1.2.12"}'
 ```
@@ -100,7 +100,7 @@ curl -sS -X POST https://aigate-skill-metrics.gcssloop.workers.dev/events/instal
 Read ranking:
 
 ```bash
-curl -sS 'https://aigate-skill-metrics.gcssloop.workers.dev/rankings/skills?day=2026-04-10&limit=50'
+curl -sS 'https://skills.ai-gate.work/rankings/skills?day=2026-04-10&limit=50'
 ```
 
 ## Security Notes
@@ -137,7 +137,7 @@ Apply seed list command:
 
 ```bash
 TOKEN='<admin token>'
-BASE_URL='https://aigate-skill-metrics.gcssloop.workers.dev' \
+BASE_URL='https://skills.ai-gate.work' \
 TRACKED_REPOS_ADMIN_TOKEN="$TOKEN" \
 /Users/gcssloop/WorkSpace/AIGC/codex-router/services/skill-metrics-worker/scripts/tracked-repos.sh \
 replace \
@@ -159,7 +159,7 @@ Verification snapshot:
 Set environment variables for backend process:
 
 ```bash
-export AIGATE_SKILL_REPO_REGISTRY_URL='https://aigate-skill-metrics.gcssloop.workers.dev/tracked-repos'
+export AIGATE_SKILL_REPO_REGISTRY_URL='https://skills.ai-gate.work/tracked-repos'
 # Optional only when GET /tracked-repos is protected by auth:
 export AIGATE_SKILL_REPO_REGISTRY_TOKEN=''
 ```

--- a/services/skill-metrics-worker/README.md
+++ b/services/skill-metrics-worker/README.md
@@ -72,7 +72,7 @@ Bootstrap command:
 ```bash
 cd services/skill-metrics-worker
 TRACKED_REPOS_ADMIN_TOKEN='<admin token>' \
-BASE_URL='https://aigate-skill-metrics.gcssloop.workers.dev' \
+BASE_URL='https://skills.ai-gate.work' \
 ./scripts/tracked-repos.sh replace ./config/tracked-repos.seed.json
 ```
 
@@ -81,7 +81,7 @@ Import and dedupe repositories from skills.sh/cc-ai source pages:
 ```bash
 cd services/skill-metrics-worker
 TRACKED_REPOS_ADMIN_TOKEN='<admin token>' \
-BASE_URL='https://aigate-skill-metrics.gcssloop.workers.dev' \
+BASE_URL='https://skills.ai-gate.work' \
 ./scripts/import-ccai-repos.sh
 ```
 
@@ -187,7 +187,7 @@ Pagination query params:
 
 Open:
 
-- `https://aigate-skill-metrics.gcssloop.workers.dev/admin`
+- `https://skills.ai-gate.work/admin`
 
 Login with `ADMIN_UI_PASSWORD`.
 
@@ -227,7 +227,7 @@ Response:
 
 Set these env vars in AI Gate backend runtime:
 
-- `AIGATE_SKILL_REPO_REGISTRY_URL` (example: `https://aigate-skill-metrics.gcssloop.workers.dev/tracked-repos`)
+- `AIGATE_SKILL_REPO_REGISTRY_URL` (example: `https://skills.ai-gate.work/tracked-repos`)
 - `AIGATE_SKILL_REPO_REGISTRY_TOKEN` (required if `/tracked-repos` is protected)
 
 When set, skill discovery refresh will pull centralized tracked repos and merge missing entries into local scanning list.

--- a/services/skill-metrics-worker/scripts/import-ccai-repos.sh
+++ b/services/skill-metrics-worker/scripts/import-ccai-repos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="${BASE_URL:-https://aigate-skill-metrics.gcssloop.workers.dev}"
+BASE_URL="${BASE_URL:-https://skills.ai-gate.work}"
 TOKEN="${TRACKED_REPOS_ADMIN_TOKEN:-}"
 TMP_HTML="${TMPDIR:-/tmp}/skills_page_$$.html"
 TMP_LIST="${TMPDIR:-/tmp}/skills_sources_$$.txt"

--- a/services/skill-metrics-worker/scripts/smoke.sh
+++ b/services/skill-metrics-worker/scripts/smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="${1:-https://aigate-skill-metrics.gcssloop.workers.dev}"
+BASE_URL="${1:-https://skills.ai-gate.work}"
 DAY="${2:-$(date -u +%F)}"
 
 echo "[1/3] health"

--- a/services/skill-metrics-worker/scripts/tracked-repos.sh
+++ b/services/skill-metrics-worker/scripts/tracked-repos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="${BASE_URL:-https://aigate-skill-metrics.gcssloop.workers.dev}"
+BASE_URL="${BASE_URL:-https://skills.ai-gate.work}"
 TOKEN="${TRACKED_REPOS_ADMIN_TOKEN:-}"
 
 usage() {

--- a/services/skill-metrics-worker/src/index.ts
+++ b/services/skill-metrics-worker/src/index.ts
@@ -291,6 +291,7 @@ const SKILLS_SH_SKILLS_MAX_PAGES = 300;
 const SKILLS_SH_AUDITS_MAX_PAGES = 300;
 const EXTERNAL_FETCH_TIMEOUT_MS = 20_000;
 const EXTERNAL_FETCH_RETRIES = 3;
+const GITHUB_REPO_URL = "https://github.com/GcsSloop/ai-gate";
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -299,6 +300,20 @@ export default {
     }
     const url = new URL(request.url);
     try {
+      if (request.method === "GET" && url.pathname === "/") {
+        const query = (url.searchParams.get("q") ?? "").trim();
+        const catalog = await getSkillCatalog(env, false);
+        const ranking = await getSkillRanking(env, utcDay(), 24);
+        const recommended = ranking.items.map((item) => item.skill_name);
+        const skills = filterAndSliceCatalog(catalog, query, 0, 24, recommended);
+        return html(renderLandingPage({
+          query,
+          fetchedAt: catalog.fetched_at,
+          indexedTotal: skills.indexedTotal,
+          total: skills.total,
+          items: skills.items,
+        }));
+      }
       if (request.method === "GET" && url.pathname === "/health") {
         await assertAdmin(request, env);
         return json({ ok: true, service: "aigate-skill-metrics" });
@@ -3009,6 +3024,15 @@ function html(content: string): Response {
   return new Response(content, { status: 200, headers: { "content-type": "text/html; charset=utf-8" } });
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function httpError(status: number, message: string): Error & { status: number } {
   const err = new Error(message) as Error & { status: number };
   err.status = status;
@@ -3170,6 +3194,108 @@ async function assertBearer(request: Request, token?: string, options?: { requir
   if (!current || current !== token) {
     throw httpError(401, "invalid_bearer_token");
   }
+}
+
+function renderLandingPage(data: {
+  query: string;
+  fetchedAt: string;
+  indexedTotal: number;
+  total: number;
+  items: CatalogSkillItem[];
+}): string {
+  const cards = data.items.map((item) => {
+    const repoName = `${item.repo_owner}/${item.repo_name}`;
+    const path = item.source_path === "." ? "Repository root" : item.source_path;
+    const auditProviders = item.audits_summary?.providers ?? [];
+    const auditText = auditProviders.length > 0
+      ? auditProviders.map((provider) => `${provider.label}: ${provider.status}`).join(" · ")
+      : "Audit details pending";
+    return `<article class="skill-card">
+      <div class="card-top">
+        <p class="repo">${escapeHtml(repoName)}</p>
+        <a class="open-link" href="${escapeHtml(item.source_url)}" target="_blank" rel="noreferrer">View source</a>
+      </div>
+      <h2>${escapeHtml(item.name)}</h2>
+      <p class="path">${escapeHtml(path)}</p>
+      <p class="audit">${escapeHtml(auditText)}</p>
+    </article>`;
+  }).join("");
+  const emptyState = `<section class="empty">
+    <h2>No skills found</h2>
+    <p>Try a shorter query or browse the project repository for available AI Gate skill sources.</p>
+  </section>`;
+  const updated = data.fetchedAt ? new Date(data.fetchedAt).toISOString().slice(0, 10) : "pending";
+  const searchValue = escapeHtml(data.query);
+  const resultLabel = data.query
+    ? `${data.total} matching skills from ${data.indexedTotal} indexed`
+    : `${data.indexedTotal} indexed skills`;
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Gate Skills</title>
+    <style>
+      :root { color-scheme: light; --bg:#f6f8fb; --ink:#16201d; --muted:#66716d; --line:#dbe3e1; --panel:#ffffff; --accent:#0f766e; --accent-ink:#ffffff; --warm:#b45309; }
+      * { box-sizing: border-box; }
+      body { margin:0; min-height:100vh; font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color:var(--ink); background:linear-gradient(180deg,#f6f8fb 0%,#eef3f6 100%); }
+      a { color:inherit; }
+      .wrap { width:min(1120px, calc(100% - 32px)); margin:0 auto; }
+      header { padding:28px 0 18px; display:flex; align-items:center; justify-content:space-between; gap:16px; }
+      .brand { display:flex; align-items:center; gap:10px; font-weight:700; }
+      .mark { width:34px; height:34px; border-radius:8px; display:grid; place-items:center; color:var(--accent-ink); background:var(--accent); font-size:18px; }
+      .github { display:inline-flex; align-items:center; min-height:38px; padding:0 14px; border:1px solid var(--line); border-radius:8px; text-decoration:none; background:rgba(255,255,255,.76); font-weight:600; }
+      .hero { padding:38px 0 28px; border-top:1px solid rgba(220,226,221,.7); }
+      .hero h1 { margin:0; max-width:760px; font-size:64px; line-height:.98; letter-spacing:0; }
+      .hero p { margin:18px 0 0; max-width:620px; color:var(--muted); font-size:18px; line-height:1.55; }
+      .searchbar { margin-top:28px; display:flex; gap:10px; max-width:620px; }
+      .searchbar input { flex:1; min-width:0; height:46px; border:1px solid var(--line); border-radius:8px; padding:0 14px; font-size:15px; background:var(--panel); color:var(--ink); }
+      .searchbar button { height:46px; border:0; border-radius:8px; padding:0 18px; background:var(--accent); color:var(--accent-ink); font-weight:700; cursor:pointer; }
+      .meta { margin:24px 0 14px; display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; color:var(--muted); font-size:13px; }
+      .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:14px; padding-bottom:54px; }
+      .skill-card { min-height:190px; background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:18px; display:flex; flex-direction:column; gap:12px; box-shadow:0 12px 28px rgba(24,45,38,.07); }
+      .card-top { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; }
+      .repo, .path, .audit { margin:0; color:var(--muted); font-size:13px; line-height:1.45; overflow-wrap:anywhere; }
+      .open-link { flex:none; text-decoration:none; color:var(--warm); font-size:13px; font-weight:700; }
+      .skill-card h2 { margin:0; font-size:20px; line-height:1.2; letter-spacing:0; overflow-wrap:anywhere; }
+      .audit { margin-top:auto; padding-top:12px; border-top:1px solid var(--line); }
+      .empty { margin:0 0 54px; padding:32px; border:1px dashed var(--line); border-radius:8px; background:rgba(255,255,255,.65); }
+      .empty h2 { margin:0 0 8px; }
+      .empty p { margin:0; color:var(--muted); }
+      @media (max-width:640px) {
+        header { align-items:flex-start; flex-direction:column; }
+        .hero { padding-top:26px; }
+        .hero h1 { font-size:42px; }
+        .searchbar { flex-direction:column; }
+        .searchbar button { width:100%; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <header>
+        <div class="brand"><span class="mark">A</span><span>AI Gate Skills</span></div>
+        <a class="github" href="${GITHUB_REPO_URL}" target="_blank" rel="noreferrer">GitHub Repository</a>
+      </header>
+      <main>
+        <section class="hero">
+          <h1>AI Gate Skills</h1>
+          <p>Browse installable skills indexed for AI Gate, compare their source repositories, and jump directly to the GitHub project.</p>
+          <form class="searchbar" action="/" method="get">
+            <input name="q" value="${searchValue}" placeholder="Search skills, repositories, or paths" />
+            <button type="submit">Search</button>
+          </form>
+        </section>
+        <div class="meta">
+          <span>${escapeHtml(resultLabel)}</span>
+          <span>Catalog updated ${escapeHtml(updated)}</span>
+        </div>
+        ${data.items.length > 0 ? `<section class="grid">${cards}</section>` : emptyState}
+      </main>
+    </div>
+  </body>
+</html>`;
 }
 
 function renderAdminPage(initialAuthenticated: boolean): string {

--- a/services/skill-metrics-worker/test/index.spec.ts
+++ b/services/skill-metrics-worker/test/index.spec.ts
@@ -8,6 +8,53 @@ const noopEnv = {
 };
 
 describe("skill metrics worker", () => {
+	it("GET / renders public skills landing page", async () => {
+		const mockKv = {
+			get: async (key: string) => {
+				if (key === "catalog:skills:v1") {
+					return JSON.stringify({
+						fetched_at: "2026-04-30T00:00:00Z",
+						repos: [],
+						items: [
+							{
+								id: "github:openai/skills:main:alpha",
+								name: "Alpha Skill",
+								platform: "github",
+								repo_owner: "openai",
+								repo_name: "skills",
+								branch: "main",
+								repo_url: "https://github.com/openai/skills",
+								source_path: "skills/alpha",
+								source_url: "https://github.com/openai/skills/tree/main/skills/alpha",
+								managed_name: "skills-alpha",
+							},
+						],
+					});
+				}
+				return null;
+			},
+			put: async () => null,
+		} as unknown as KVNamespace;
+		const mockDb = {
+			prepare: () => ({
+				bind: () => ({
+					all: async () => ({ results: [] }),
+				}),
+			}),
+		} as unknown as D1Database;
+		const request = new Request("https://skills.ai-gate.work/");
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, { DB: mockDb, SKILL_METRICS_CACHE: mockKv }, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/html");
+		const body = await response.text();
+		expect(body).toContain("AI Gate Skills");
+		expect(body).toContain("Alpha Skill");
+		expect(body).toContain("https://github.com/GcsSloop/ai-gate");
+	});
+
 	it("GET /health requires admin auth", async () => {
 		const request = new Request("https://example.com/health");
 		const ctx = createExecutionContext();


### PR DESCRIPTION
## Summary
- Migrate skill metrics endpoint references to `https://skills.ai-gate.work`.
- Add client-side migration for legacy persisted skill metrics URLs.
- Add a public Worker landing page at `/` with searchable skills cards and GitHub repo CTA.

## Verification
- `cd services/skill-metrics-worker && npm test -- --run`
- `cd backend && go test ./internal/api -run 'TestTooling|TestSkillMetrics|TestToolingConfigMigratesLegacySkillMetricsURL' -count=1`
- `rg -n "aigate-skill-metrics\\.gcssloop\\.workers\\.dev|https://aigate-skill-metrics\\.gcssloop\\.workers\\.dev" -S . || true`
- Production Worker checked: `https://skills.ai-gate.work/` returns `200 text/html`.
- Production API checked: `https://skills.ai-gate.work/skills/search?limit=3&offset=0` returns `200`.
