### PR TITLE
fix: 避免后台隐藏页面刷新状态

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -91,6 +91,10 @@ describe("App", () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });
@@ -389,7 +393,6 @@ describe("App", () => {
     await act(async () => {
       await Promise.resolve();
     });
-
     expect(screen.getByText(/accounts-sync:0/)).toBeInTheDocument();
     expect(mockedUpdateService.check).toHaveBeenCalledTimes(1);
 
@@ -605,7 +608,6 @@ describe("App", () => {
     await act(async () => {
       await Promise.resolve();
     });
-
     expect(screen.getByText(/accounts-sync:0/)).toBeInTheDocument();
     expect(vi.mocked(refreshDesktopTrayState)).toHaveBeenCalledTimes(1);
 
@@ -617,6 +619,69 @@ describe("App", () => {
     expect(screen.getByText(/accounts-sync:1/)).toBeInTheDocument();
     expect(vi.mocked(refreshDesktopTrayState)).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:6789/ai-router/api/settings/proxy/status");
+  });
+
+  it("skips periodic status refresh while the main page is hidden", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "http://127.0.0.1:6789/ai-router/api/settings/proxy/status") {
+        return Promise.resolve(new Response(JSON.stringify({ enabled: false }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "http://127.0.0.1:6789/ai-router/api/settings/app") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              launch_at_login: false,
+              silent_start: false,
+              close_to_tray: true,
+              show_proxy_switch_on_home: true,
+              show_home_update_indicator: false,
+              status_refresh_interval_seconds: 5,
+              proxy_host: "127.0.0.1",
+              proxy_port: 6789,
+              auto_failover_enabled: false,
+              auto_backup_interval_hours: 24,
+              backup_retention_count: 10,
+              audit_limit_message: 200,
+              audit_limit_function_call: 100,
+              audit_limit_function_call_output: 100,
+              audit_limit_reasoning: 40,
+              audit_limit_custom_tool_call: 100,
+              audit_limit_custom_tool_call_output: 100,
+              language: "zh-CN",
+              theme_mode: "system",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(subscribeDesktopBackendStateChanged).mockResolvedValue(() => {});
+
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/accounts-sync:0/)).toBeInTheDocument();
+    expect(vi.mocked(refreshDesktopTrayState)).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/accounts-sync:0/)).toBeInTheDocument();
+    expect(vi.mocked(refreshDesktopTrayState)).toHaveBeenCalledTimes(1);
   });
 
   it("opens an update modal when the home update indicator is clicked", async () => {
@@ -1228,6 +1293,9 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(subscribeDesktopBackendStateChanged).toHaveBeenCalled();
+    });
 
     await act(async () => {
       window.dispatchEvent(new Event("online"));
@@ -1242,9 +1310,84 @@ describe("App", () => {
     });
   });
 
+  it("backs off immediate usage refresh after a failed online recovery", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "http://127.0.0.1:6789/ai-router/api/settings/proxy/status") {
+        return Promise.resolve(new Response(JSON.stringify({ enabled: false }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url === "http://127.0.0.1:6789/ai-router/api/settings/app") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              launch_at_login: false,
+              silent_start: false,
+              close_to_tray: true,
+              show_proxy_switch_on_home: true,
+              show_home_update_indicator: false,
+              status_refresh_interval_seconds: 3600,
+              usage_request_timeout_seconds: 15,
+              proxy_host: "127.0.0.1",
+              proxy_port: 6789,
+              auto_failover_enabled: true,
+              auto_backup_interval_hours: 24,
+              backup_retention_count: 10,
+              audit_limit_message: 200,
+              audit_limit_function_call: 100,
+              audit_limit_function_call_output: 100,
+              audit_limit_reasoning: 40,
+              audit_limit_custom_tool_call: 100,
+              audit_limit_custom_tool_call_output: 100,
+              language: "zh-CN",
+              theme_mode: "system",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      if (url === "http://127.0.0.1:6789/ai-router/api/accounts/usage/refresh") {
+        return Promise.resolve(new Response("vpn unavailable", { status: 500 }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(subscribeDesktopBackendStateChanged).mockResolvedValue(() => {});
+
+    render(<App />);
+
+    expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
+    vi.useFakeTimers();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:6789/ai-router/api/accounts/usage/refresh",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    const refreshCallsAfterFailure = fetchMock.mock.calls.filter(
+      ([input]) => String(input) === "http://127.0.0.1:6789/ai-router/api/accounts/usage/refresh",
+    ).length;
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(
+      fetchMock.mock.calls.filter(
+        ([input]) => String(input) === "http://127.0.0.1:6789/ai-router/api/accounts/usage/refresh",
+      ),
+    ).toHaveLength(refreshCallsAfterFailure);
+  });
+
   it("triggers an immediate usage refresh when the page becomes visible after a long hidden period", async () => {
     let currentTime = new Date("2026-03-20T09:00:00Z").getTime();
     vi.spyOn(Date, "now").mockImplementation(() => currentTime);
+    const addDocumentEventListenerSpy = vi.spyOn(document, "addEventListener");
     vi.stubGlobal(
       "fetch",
       vi.fn((input: RequestInfo | URL) => {
@@ -1295,19 +1438,26 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText(/accounts-sync:0/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(addDocumentEventListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+    });
+    const visibilityChangeHandler = addDocumentEventListenerSpy.mock.calls.toReversed().find(([eventName]) => eventName === "visibilitychange")?.[1] as
+      | EventListener
+      | undefined;
+    expect(visibilityChangeHandler).toEqual(expect.any(Function));
 
     await act(async () => {
       Object.defineProperty(document, "visibilityState", {
         configurable: true,
         value: "hidden",
       });
-      document.dispatchEvent(new Event("visibilitychange"));
+      visibilityChangeHandler?.(new Event("visibilitychange"));
       currentTime += 16_000;
       Object.defineProperty(document, "visibilityState", {
         configurable: true,
         value: "visible",
       });
-      document.dispatchEvent(new Event("visibilitychange"));
+      visibilityChangeHandler?.(new Event("visibilitychange"));
     });
 
     await waitFor(() => {
@@ -1315,7 +1465,7 @@ describe("App", () => {
         "http://127.0.0.1:6789/ai-router/api/accounts/usage/refresh",
         expect.objectContaining({ method: "POST" }),
       );
-      expect(screen.getByText(/accounts-sync:1/)).toBeInTheDocument();
+      expect(screen.getByText(/accounts-sync:[1-9]/)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ const appSettingsBootstrapRetryDelays = [0, 150, 300, 600, 1_000];
 const homeUpdateCheckIntervalMs = 60 * 60 * 1_000;
 const defaultStatusRefreshIntervalSeconds = 60;
 const immediateUsageRefreshDebounceMs = 400;
+const immediateUsageRefreshFailureBackoffMs = 60_000;
 const resumeGapWatchIntervalMs = 5_000;
 const resumeGapThresholdMs = 30_000;
 const hiddenResumeThresholdMs = 15_000;
@@ -30,6 +31,10 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     window.setTimeout(resolve, ms);
   });
+}
+
+function isMainPageVisible(): boolean {
+  return typeof document === "undefined" || document.visibilityState === "visible";
 }
 
 export function App() {
@@ -50,6 +55,7 @@ export function App() {
   const immediateUsageRefreshInFlightRef = useRef(false);
   const immediateUsageRefreshPendingRef = useRef(false);
   const immediateUsageRefreshTimerRef = useRef<number | null>(null);
+  const immediateUsageRefreshLastFailedAtRef = useRef(0);
   const hiddenSinceRef = useRef<number | null>(null);
   const language = normalizeLanguage(appSettings?.language);
   const t = createTranslator(language);
@@ -106,8 +112,11 @@ export function App() {
         immediateUsageRefreshPendingRef.current = false;
         try {
           await refreshAccountUsage();
+          immediateUsageRefreshLastFailedAtRef.current = 0;
         } catch {
           // Network and wake-up recovery should stay silent and retry on the next trigger.
+          immediateUsageRefreshLastFailedAtRef.current = Date.now();
+          immediateUsageRefreshPendingRef.current = false;
         }
         setAccountsSyncToken((value) => value + 1);
         void refreshDesktopTrayState();
@@ -122,7 +131,14 @@ export function App() {
       if (!shellReady || typeof window === "undefined") {
         return;
       }
+      if (!isMainPageVisible()) {
+        return;
+      }
       if (trigger === "online" && typeof navigator !== "undefined" && navigator.onLine === false) {
+        return;
+      }
+      const lastFailureAt = immediateUsageRefreshLastFailedAtRef.current;
+      if (lastFailureAt > 0 && Date.now() - lastFailureAt < immediateUsageRefreshFailureBackoffMs) {
         return;
       }
       if (immediateUsageRefreshTimerRef.current !== null) {
@@ -206,6 +222,9 @@ export function App() {
     let disposed = false;
     let unlisten: undefined | (() => void);
     const handleBackendStateChanged = () => {
+      if (!isMainPageVisible()) {
+        return;
+      }
       void refreshProxyState();
       void refreshDesktopTrayState();
       setAccountsSyncToken((value) => value + 1);
@@ -241,6 +260,9 @@ export function App() {
       }
       const hiddenSince = hiddenSinceRef.current;
       hiddenSinceRef.current = null;
+      void refreshProxyState();
+      void refreshDesktopTrayState();
+      setAccountsSyncToken((value) => value + 1);
       if (hiddenSince !== null && Date.now() - hiddenSince >= hiddenResumeThresholdMs) {
         queueImmediateUsageRefresh("visibility_resume");
       }
@@ -249,7 +271,7 @@ export function App() {
       const now = Date.now();
       const elapsed = now - lastTickAt;
       lastTickAt = now;
-      if (elapsed >= resumeGapThresholdMs) {
+      if (isMainPageVisible() && elapsed >= resumeGapThresholdMs) {
         queueImmediateUsageRefresh("resume_gap");
       }
     }, resumeGapWatchIntervalMs);
@@ -275,6 +297,9 @@ export function App() {
 
     const refreshIntervalSeconds = Math.min(Math.max(appSettings.status_refresh_interval_seconds ?? defaultStatusRefreshIntervalSeconds, 5), 3600);
     const timer = window.setInterval(() => {
+      if (!isMainPageVisible()) {
+        return;
+      }
       void refreshProxyState();
       void refreshDesktopTrayState();
       setAccountsSyncToken((value) => value + 1);


### PR DESCRIPTION
## 变更
- 页面不可见时跳过自动状态刷新和即时用量刷新
- 页面恢复可见时刷新一次本地状态，长时间隐藏后再触发用量刷新
- 用量刷新失败后增加短暂 backoff，避免 VPN 关闭时连续重试

## 验证
- npm --prefix frontend test