### PR TITLE
发布 v1.5.3

### DIFF
--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -895,6 +895,11 @@ func applyBuiltInDriverDefaults(account accounts.Account) accounts.Account {
 			account.UsageDriver = "builtin_openai_official"
 		case strings.Contains(strings.ToLower(strings.TrimSpace(account.BaseURL)), "ppchat.vip"):
 			account.UsageDriver = "builtin_ppchat"
+		case strings.Contains(strings.ToLower(strings.TrimSpace(account.BaseURL)), "nodeseek.in"):
+			account.UsageDriver = "lua"
+			if strings.TrimSpace(account.UsageConfigJSON) == "" {
+				account.UsageConfigJSON = `{"script":"managed:ai.nodeseek.in"}`
+			}
 		}
 	}
 	return account
@@ -1747,7 +1752,23 @@ func resolveAccountBaseURL(account accounts.Account) string {
 		return baseURL
 	}
 	if strings.TrimSpace(account.BaseURL) != "" {
-		return account.BaseURL
+		return normalizeCompatibleAccountBaseURL(account)
 	}
 	return account.BaseURL
+}
+
+func normalizeCompatibleAccountBaseURL(account accounts.Account) string {
+	baseURL := strings.TrimSpace(account.BaseURL)
+	if account.ProviderType != accounts.ProviderOpenAICompatible {
+		return baseURL
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return baseURL
+	}
+	if strings.Trim(parsed.Path, "/") != "" {
+		return baseURL
+	}
+	parsed.Path = "/v1"
+	return strings.TrimRight(parsed.String(), "/")
 }

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -688,6 +688,16 @@ func TestAccountsHandlerListAccountsDefaultsBuiltInDrivers(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create ppchat returned error: %v", err)
 	}
+	if err := repo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "nodeseek",
+		AuthMode:      accounts.AuthModeAPIKey,
+		CredentialRef: "sk-test",
+		BaseURL:       "https://ai.nodeseek.in",
+		Status:        accounts.StatusActive,
+	}); err != nil {
+		t.Fatalf("Create nodeseek returned error: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/accounts", nil)
 	rec := httptest.NewRecorder()
@@ -711,6 +721,15 @@ func TestAccountsHandlerListAccountsDefaultsBuiltInDrivers(t *testing.T) {
 	}
 	if listed[1]["usage_driver"] != "builtin_ppchat" {
 		t.Fatalf("ppchat usage_driver = %v, want builtin_ppchat", listed[1]["usage_driver"])
+	}
+	if listed[2]["account_driver"] != "builtin_api_key" {
+		t.Fatalf("nodeseek account_driver = %v, want builtin_api_key", listed[2]["account_driver"])
+	}
+	if listed[2]["usage_driver"] != "lua" {
+		t.Fatalf("nodeseek usage_driver = %v, want lua", listed[2]["usage_driver"])
+	}
+	if listed[2]["usage_config_json"] != `{"script":"managed:ai.nodeseek.in"}` {
+		t.Fatalf("nodeseek usage_config_json = %v, want managed script config", listed[2]["usage_config_json"])
 	}
 }
 

--- a/backend/internal/api/gateway_handler_test.go
+++ b/backend/internal/api/gateway_handler_test.go
@@ -115,6 +115,75 @@ func TestGatewayHandlerProxiesToConfiguredAccount(t *testing.T) {
 	}
 }
 
+func TestGatewayHandlerAddsV1WhenThirdPartyBaseURLHasNoPath(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want %q", r.URL.Path, "/v1/chat/completions")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "chat.completion",
+			"model":  "gpt-5.2-codex",
+			"choices": []map[string]any{
+				{"message": map[string]any{"role": "assistant", "content": "ok"}},
+			},
+		})
+	}))
+	defer upstream.Close()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accountRepo := accounts.NewSQLiteRepository(store.DB())
+	if err := accountRepo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "nodeseek",
+		AuthMode:      accounts.AuthModeAPIKey,
+		BaseURL:       upstream.URL,
+		CredentialRef: "sk-test",
+		Status:        accounts.StatusActive,
+		Priority:      100,
+	}); err != nil {
+		t.Fatalf("Create(account) returned error: %v", err)
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:      1,
+		QuotaRemaining: 100000,
+		RPMRemaining:   100,
+		TPMRemaining:   100000,
+		HealthScore:    1,
+	}); err != nil {
+		t.Fatalf("Save(snapshot) returned error: %v", err)
+	}
+
+	handler := api.NewGatewayHandler(
+		accountRepo,
+		usageRepo,
+		conversations.NewSQLiteRepository(store.DB()),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{
+		"model":"gpt-5.2-codex",
+		"stream":false,
+		"messages":[{"role":"user","content":"ping"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gateway status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
 func TestGatewayHandlerTransparentlyProxiesArrayMessageContent(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -71,6 +71,39 @@ func TestResponsesHandlerThinModeThirdPartyResponsesPassthrough(t *testing.T) {
 	}
 }
 
+func TestResponsesHandlerThinModeThirdPartyResponsesAddsV1WhenBaseURLHasNoPath(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/responses" {
+			t.Fatalf("path = %q, want /v1/responses", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_tp_1","object":"response","status":"completed","output_text":"tp-pong"}`)
+	}))
+	defer upstream.Close()
+
+	handler := newResponsesHandlerTestHandler(t, accounts.Account{
+		ProviderType:      accounts.ProviderOpenAICompatible,
+		AccountName:       "nodeseek",
+		AuthMode:          accounts.AuthModeAPIKey,
+		BaseURL:           upstream.URL,
+		CredentialRef:     "sk-third-party",
+		Status:            accounts.StatusActive,
+		Priority:          100,
+		SupportsResponses: true,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-5.4","input":"ping"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
 func TestResponsesHandlerThinModeRecordsUsageEventWithoutAuditRows(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usagedrv/lua/driver.go
+++ b/backend/internal/usagedrv/lua/driver.go
@@ -96,7 +96,11 @@ func (d *Driver) Fetch(ctx context.Context, account accounts.Account, credential
 		}
 		source, err := d.managedStore.Load(key)
 		if err != nil {
-			return usagedrv.RawUsageResult{}, err
+			if builtInSource, ok := builtInManagedScript(key); ok {
+				source = builtInSource
+			} else {
+				return usagedrv.RawUsageResult{}, err
+			}
 		}
 		return d.runtime.ExecuteSource(callCtx, source, "managed:"+key, account, credential, config.Raw)
 	}

--- a/backend/internal/usagedrv/lua/dsl.go
+++ b/backend/internal/usagedrv/lua/dsl.go
@@ -1,0 +1,237 @@
+package lua
+
+func builtInManagedScript(key string) (string, bool) {
+	switch key {
+	case "ai.nodeseek.in", "nodeseek.in":
+		return `simple_usage({
+  get = "/v1/usage",
+  auth = "bearer",
+  remaining = pick("remaining", "quota.remaining", "balance"),
+  unit = pick("unit", "quota.unit", default("USD")),
+  valid = pick("is_active", "isValid", default(true))
+})
+`, true
+	case "ppchat.vip", "code.ppchat.vip":
+		return `usage_adapter({
+  get = "https://his.ppchat.vip/api/token-logs?page=1&page_size=1&token_key={{api_key}}",
+
+  limits = {
+    quota_remaining = pick("data.token_info.remain_quota_display")
+  },
+
+  meta = {
+    today_used_quota = pick("data.token_info.today_used_quota"),
+    today_added_quota = pick("data.token_info.today_added_quota"),
+    unit = "quota"
+  }
+})
+`, true
+	default:
+		return "", false
+	}
+}
+
+const luaDSLPrelude = `
+local function aigate_path_get(root, path)
+  if root == nil or path == nil or path == "" then
+    return nil
+  end
+  local current = root
+  for part in string.gmatch(path, "[^%.]+") do
+    if type(current) ~= "table" then
+      return nil
+    end
+    current = current[part]
+    if current == nil then
+      return nil
+    end
+  end
+  return current
+end
+
+function default(value)
+  return { __aigate_default = true, value = value }
+end
+
+function pick(...)
+  local selector = { __aigate_pick = true, paths = {} }
+  for i = 1, select("#", ...) do
+    local value = select(i, ...)
+    if type(value) == "table" and value.__aigate_default == true then
+      selector.default = value.value
+      selector.has_default = true
+    elseif value ~= nil then
+      table.insert(selector.paths, tostring(value))
+    end
+  end
+  return selector
+end
+
+local function aigate_resolve(spec, payload)
+  if type(spec) == "table" and spec.__aigate_pick == true then
+    for _, path in ipairs(spec.paths) do
+      local value = aigate_path_get(payload, path)
+      if value ~= nil then
+        return value
+      end
+    end
+    if spec.has_default then
+      return spec.default
+    end
+    return nil
+  end
+  if type(spec) == "function" then
+    return spec(payload)
+  end
+  return spec
+end
+
+local function aigate_render_template(raw, ctx)
+  local value = tostring(raw or "")
+  local replacements = {
+    base_url = ctx.account.base_url or "",
+    baseUrl = ctx.account.base_url or "",
+    api_key = ctx.credential.api_key or ctx.credential.access_token or "",
+    apiKey = ctx.credential.api_key or ctx.credential.access_token or "",
+    access_token = ctx.credential.access_token or ctx.credential.api_key or "",
+    accessToken = ctx.credential.access_token or ctx.credential.api_key or ""
+  }
+  return (string.gsub(value, "{{%s*([%w_]+)%s*}}", function(name)
+    local replacement = replacements[name]
+    if replacement == nil then
+      return ""
+    end
+    return tostring(replacement)
+  end))
+end
+
+local function aigate_join_url(base_url, path)
+  if path == nil or path == "" then
+    return base_url
+  end
+  if string.match(path, "^https?://") then
+    return path
+  end
+  local base = string.gsub(base_url or "", "/+$", "")
+  local suffix = string.gsub(path, "^/+", "")
+  if string.match(base, "/v1$") and string.match(suffix, "^v1/") then
+    suffix = string.gsub(suffix, "^v1/", "")
+  end
+  return base .. "/" .. suffix
+end
+
+local function aigate_resolve_map(spec, payload)
+  local result = {}
+  if type(spec) ~= "table" then
+    return result
+  end
+  for key, value in pairs(spec) do
+    result[key] = aigate_resolve(value, payload)
+  end
+  return result
+end
+
+local function aigate_fetch_json(adapter, ctx)
+  local request = adapter.request or {}
+  local raw_url = adapter.get or request.url
+  local url = aigate_render_template(raw_url, ctx)
+  url = aigate_join_url(ctx.account.base_url, url)
+  local method = string.upper(tostring(request.method or "GET"))
+  if method ~= "GET" then
+    return {
+      ok = false,
+      error = {
+        kind = "config_error",
+        message = "Lua usage DSL currently supports GET requests"
+      }
+    }
+  end
+
+  local headers = {}
+  if type(request.headers) == "table" then
+    for key, value in pairs(request.headers) do
+      headers[key] = aigate_render_template(value, ctx)
+    end
+  end
+  if adapter.bearer ~= nil then
+    headers.Authorization = "Bearer " .. aigate_render_template(adapter.bearer, ctx)
+  elseif adapter.auth == "bearer" then
+    headers.Authorization = "Bearer " .. aigate_render_template("{{api_key}}", ctx)
+  end
+
+  local response = ctx.host.http_get({
+    url = url,
+    headers = headers
+  })
+  if response.status < 200 or response.status >= 300 then
+    return {
+      ok = false,
+      error = {
+        kind = "upstream_http_error",
+        message = "status " .. tostring(response.status)
+      }
+    }
+  end
+  return ctx.host.json_decode(response.body)
+end
+
+local function aigate_execute_simple_usage(adapter, ctx, payload)
+  local remaining = aigate_resolve(adapter.remaining or adapter.value, payload)
+  local unit = aigate_resolve(adapter.unit, payload)
+  local is_valid = aigate_resolve(adapter.valid, payload)
+  if is_valid == nil then
+    is_valid = true
+  end
+  if unit == nil then
+    unit = "USD"
+  end
+  return {
+    ok = true,
+    source = adapter.source or "remote",
+    confidence = adapter.confidence or "high",
+    limits = {
+      balance = remaining
+    },
+    meta = {
+      unit = unit,
+      is_valid = is_valid
+    },
+    payload = payload
+  }
+end
+
+local function aigate_execute_usage_adapter(adapter, ctx)
+  local payload = aigate_fetch_json(adapter, ctx)
+  if type(payload) == "table" and payload.ok == false and payload.error ~= nil then
+    return payload
+  end
+  if adapter.__aigate_simple_usage == true then
+    return aigate_execute_simple_usage(adapter, ctx, payload)
+  end
+
+  local extracted = aigate_resolve_map(adapter.extract, payload)
+  if type(adapter.result) == "function" then
+    return adapter.result(extracted, payload, ctx)
+  end
+
+  return {
+    ok = true,
+    source = adapter.source or "remote",
+    confidence = adapter.confidence or "high",
+    limits = aigate_resolve_map(adapter.limits, payload),
+    meta = aigate_resolve_map(adapter.meta, payload),
+    payload = payload
+  }
+end
+
+function usage_adapter(adapter)
+  fetch_usage = function(ctx)
+    return aigate_execute_usage_adapter(adapter, ctx)
+  end
+end
+
+function simple_usage(adapter)
+  adapter.__aigate_simple_usage = true
+  usage_adapter(adapter)
+end
+`

--- a/backend/internal/usagedrv/lua/managed_scripts_test.go
+++ b/backend/internal/usagedrv/lua/managed_scripts_test.go
@@ -58,6 +58,35 @@ end
 	}
 }
 
+func TestLuaDriverUsesBuiltInManagedDSLScript(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/usage" {
+			t.Fatalf("path = %q, want /v1/usage", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-nodeseek" {
+			t.Fatalf("Authorization = %q, want Bearer sk-nodeseek", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"remaining":88,"unit":"USD"}`))
+	}))
+	defer server.Close()
+
+	driver := luadrv.NewDriver(nil, moduleRoot(t), luadrv.WithManagedScriptRoot(t.TempDir()))
+	result, err := driver.Fetch(context.Background(), accounts.Account{
+		BaseURL:         server.URL,
+		UsageDriver:     "lua",
+		UsageConfigJSON: `{"script":"managed:ai.nodeseek.in"}`,
+	}, accountdrv.ResolvedCredential{APIKey: "sk-nodeseek"})
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if result.Limits.Balance == nil || *result.Limits.Balance != 88 {
+		t.Fatalf("Balance = %#v, want 88", result.Limits.Balance)
+	}
+}
+
 func TestManagedScriptStoreRejectsInvalidKey(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usagedrv/lua/runtime.go
+++ b/backend/internal/usagedrv/lua/runtime.go
@@ -48,9 +48,13 @@ func (r *Runtime) ExecuteSource(ctx context.Context, source string, sourceName s
 	})
 	defer L.Close()
 	L.SetContext(ctx)
+	openSafeLuaLibs(L)
 
 	if err := r.registerHostAPI(L, ctx); err != nil {
 		return usagedrv.RawUsageResult{}, err
+	}
+	if err := L.DoString(luaDSLPrelude); err != nil {
+		return usagedrv.RawUsageResult{}, fmt.Errorf("lua load dsl prelude: %w", err)
 	}
 
 	if strings.TrimSpace(sourceName) == "" {
@@ -86,6 +90,16 @@ func (r *Runtime) ExecuteSource(ctx context.Context, source string, sourceName s
 	result := L.Get(-1)
 	L.Pop(1)
 	return decodeScriptResult(result)
+}
+
+func openSafeLuaLibs(L *golua.LState) {
+	golua.OpenBase(L)
+	golua.OpenString(L)
+	golua.OpenTable(L)
+	L.SetGlobal("dofile", golua.LNil)
+	L.SetGlobal("load", golua.LNil)
+	L.SetGlobal("loadfile", golua.LNil)
+	L.SetGlobal("collectgarbage", golua.LNil)
 }
 
 func (r *Runtime) registerHostAPI(L *golua.LState, ctx context.Context) error {

--- a/backend/internal/usagedrv/lua/runtime_test.go
+++ b/backend/internal/usagedrv/lua/runtime_test.go
@@ -3,6 +3,8 @@ package lua_test
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +16,20 @@ import (
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
 	luadrv "github.com/gcssloop/codex-router/backend/internal/usagedrv/lua"
 )
+
+type roundTripFunc func(*http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
 
 func TestRuntimeExecuteValidScript(t *testing.T) {
 	t.Parallel()
@@ -70,6 +86,76 @@ func TestRuntimeExecuteRequiresFetchUsageFunction(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing fetch_usage") {
 		t.Fatalf("error = %q, want missing fetch_usage", err.Error())
+	}
+}
+
+func TestRuntimeExecuteSimpleUsageDSL(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := writeTempScript(t, `
+simple_usage({
+  get = "{{base_url}}/v1/usage",
+  auth = "bearer",
+  remaining = pick("remaining", "quota.remaining", "balance"),
+  unit = pick("unit", "quota.unit", default("USD")),
+  valid = pick("is_active", "isValid", default(true))
+})
+`)
+	runtime := luadrv.NewRuntime(&http.Client{Transport: roundTripFunc(func(req *http.Request) *http.Response {
+		if req.URL.String() != "https://ai.nodeseek.in/v1/usage" {
+			t.Fatalf("request url = %q, want nodeseek usage endpoint", req.URL.String())
+		}
+		if req.Header.Get("Authorization") != "Bearer sk-test" {
+			t.Fatalf("Authorization = %q, want bearer token", req.Header.Get("Authorization"))
+		}
+		return jsonResponse(`{"quota":{"remaining":42.5}}`)
+	})}, filepath.Dir(scriptPath))
+	result, err := runtime.Execute(
+		context.Background(),
+		filepath.Base(scriptPath),
+		accounts.Account{BaseURL: "https://ai.nodeseek.in"},
+		accountdrv.ResolvedCredential{APIKey: "sk-test"},
+		map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Limits.Balance == nil || *result.Limits.Balance != 42.5 {
+		t.Fatalf("Balance = %#v, want 42.5", result.Limits.Balance)
+	}
+	if result.Meta["unit"] != "USD" {
+		t.Fatalf("unit meta = %#v, want USD", result.Meta["unit"])
+	}
+	if result.Meta["is_valid"] != true {
+		t.Fatalf("is_valid meta = %#v, want true", result.Meta["is_valid"])
+	}
+}
+
+func TestRuntimeExecuteSimpleUsageDSLDeduplicatesVersionedBaseURL(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := writeTempScript(t, `
+simple_usage({
+  get = "/v1/usage",
+  auth = "bearer",
+  remaining = pick("remaining")
+})
+`)
+	runtime := luadrv.NewRuntime(&http.Client{Transport: roundTripFunc(func(req *http.Request) *http.Response {
+		if req.URL.String() != "https://ai.nodeseek.in/v1/usage" {
+			t.Fatalf("request url = %q, want single /v1 usage endpoint", req.URL.String())
+		}
+		return jsonResponse(`{"remaining":1}`)
+	})}, filepath.Dir(scriptPath))
+	_, err := runtime.Execute(
+		context.Background(),
+		filepath.Base(scriptPath),
+		accounts.Account{BaseURL: "https://ai.nodeseek.in/v1"},
+		accountdrv.ResolvedCredential{APIKey: "sk-test"},
+		map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
 	}
 }
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.4.6",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.4.6",
+      "version": "1.5.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.4.6",
+  "version": "1.5.3",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.4.6"
+version = "1.5.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.4.6"
+version = "1.5.3"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.4.6",
+  "version": "1.5.3",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.4.6",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.4.6",
+      "version": "1.5.3",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.4.6",
+  "version": "1.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -589,15 +589,16 @@ describe("AccountsPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "详情-mirror-east" }));
     const detailModal = await screen.findByRole("dialog", { name: "账户详情" });
+    expect(await within(detailModal).findByText("额度余额")).toBeInTheDocument();
+    expect(within(detailModal).getByText("5,000")).toBeInTheDocument();
+    expect(within(detailModal).getByText("健康分")).toBeInTheDocument();
+    expect(within(detailModal).getByText("最近 Token")).toBeInTheDocument();
+    expect(within(detailModal).getByText("错误率")).toBeInTheDocument();
+    expect(within(detailModal).getByText("剩余配额")).toBeInTheDocument();
     expect(
-      await within(detailModal).findByText("今日配额进度"),
+      within(detailModal).getByText("0 / 当天增加配额 0"),
     ).toBeInTheDocument();
-    expect(within(detailModal).getByText("当天增加配额")).toBeInTheDocument();
-    expect(within(detailModal).getByText("今日已用次数")).toBeInTheDocument();
-    expect(within(detailModal).getByText("剩余 13,931")).toBeInTheDocument();
-    expect(
-      within(detailModal).getByText("已用 1,068 / 新增 14,999"),
-    ).toBeInTheDocument();
+    expect(within(detailModal).queryByText("今日配额进度")).not.toBeInTheDocument();
     expect(
       within(detailModal).queryByText("TOKEN 名称"),
     ).not.toBeInTheDocument();
@@ -610,8 +611,8 @@ describe("AccountsPage", () => {
       within(detailModal).queryByText("今日大TOKEN请求数"),
     ).not.toBeInTheDocument();
     expect(
-      await within(detailModal).findByText("PPChat Token 日志"),
-    ).toBeInTheDocument();
+      within(detailModal).queryByText("PPChat Token 日志"),
+    ).not.toBeInTheDocument();
     fireEvent.click(within(detailModal).getByRole("button", { name: "Close" }));
 
     expect(
@@ -1419,6 +1420,118 @@ describe("AccountsPage", () => {
     });
   });
 
+  it("prefills known provider lua dsl templates and copies the dsl spec", async () => {
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: { writeText: clipboardWriteText },
+      configurable: true,
+    });
+
+    const accountList = [
+      {
+        id: 1,
+        provider_type: "openai-compatible",
+        account_name: "nodeseek",
+        source_icon: "openai",
+        auth_mode: "api_key",
+        base_url: "https://ai.nodeseek.in",
+        account_driver: "builtin_api_key",
+        usage_driver: "lua",
+        usage_config_json: "{}",
+        status: "active",
+        is_active: false,
+        priority: 1,
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 0,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage-scripts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ items: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage-scripts/ai.nodeseek.in" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("nodeseek")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "编辑-nodeseek" }));
+
+    const editModal = await screen.findByRole("dialog", { name: "编辑账户" });
+    expect(
+      await within(editModal).findByText("当前脚本标识: ai.nodeseek.in"),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        (within(editModal).getByLabelText("Lua 脚本") as HTMLTextAreaElement)
+          .value,
+      ).toContain("simple_usage");
+    });
+    expect(
+      (within(editModal).getByLabelText("Lua 脚本") as HTMLTextAreaElement)
+        .value,
+    ).toContain("quota.remaining");
+
+    fireEvent.click(
+      await within(editModal).findByRole("button", { name: "复制 AI Skill" }),
+    );
+    await waitFor(() => {
+      expect(clipboardWriteText).toHaveBeenCalledTimes(1);
+    });
+    expect(clipboardWriteText.mock.calls[0][0]).toContain("simple_usage");
+    expect(clipboardWriteText.mock.calls[0][0]).toContain("兼容旧入口");
+  });
+
   it("imports shared payload and keeps the modal open on validation failure", async () => {
     const validPayload = '{"kind":"aigate-account-share","schema_version":1}';
 
@@ -2103,6 +2216,89 @@ describe("AccountsPage", () => {
     expect(screen.getByText("P2")).toBeInTheDocument();
     expect(screen.getByText("77%")).toBeInTheDocument();
     expect(screen.getByText("33%")).toBeInTheDocument();
+  });
+
+  it("renders balance-only lua usage as a compact amount instead of a meter", async () => {
+    const accountList = [
+      {
+        id: 36,
+        provider_type: "openai-compatible",
+        account_name: "nodeseek-main",
+        source_icon: "openai",
+        auth_mode: "api_key",
+        base_url: "https://ai.nodeseek.in",
+        status: "active",
+        is_active: false,
+        priority: 1,
+        account_driver: "builtin_api_key",
+        usage_driver: "lua",
+        usage_config_json: '{"script":"managed:ai.nodeseek.in"}',
+        balance: 0,
+        quota_remaining: 0,
+        rpm_remaining: 0,
+        tpm_remaining: 0,
+        health_score: 1,
+        recent_error_rate: 0,
+        last_total_tokens: 0,
+        last_input_tokens: 0,
+        last_output_tokens: 0,
+        model_context_window: 0,
+        primary_used_percent: 0,
+        secondary_used_percent: 0,
+      },
+    ];
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accountList), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                account_id: 36,
+                balance: 42.5,
+                quota_remaining: 0,
+                rpm_remaining: 0,
+                tpm_remaining: 0,
+                health_score: 1,
+                recent_error_rate: 0,
+                last_total_tokens: 0,
+                last_input_tokens: 0,
+                last_output_tokens: 0,
+                model_context_window: 0,
+                primary_used_percent: 0,
+                secondary_used_percent: 0,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("nodeseek-main")).toBeInTheDocument();
+    expect(await screen.findByText("余额")).toBeInTheDocument();
+    expect(screen.getByText("42.5")).toBeInTheDocument();
+    expect(document.querySelector(".account-usage-mini-track")).toBeNull();
   });
 
   it("keeps previous usage visible while a refresh is pending", async () => {

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -1,6 +1,5 @@
 import {
   ApiOutlined,
-  BarChartOutlined,
   CheckCircleOutlined,
   DeleteOutlined,
   EditOutlined,
@@ -22,7 +21,6 @@ import {
   Input,
   Modal,
   Select,
-  Skeleton,
   Statistic,
   Tag,
   Tooltip,
@@ -64,7 +62,6 @@ import {
   createAccount,
   completeOfficialAuthDevice,
   deleteAccount,
-  fetchPPChatTokenLogs,
   startOfficialAuth,
   getLuaUsageScript,
   importCurrentCodexAuth,
@@ -79,7 +76,6 @@ import {
   testLuaUsage,
   updateAccount,
   type AccountRecord,
-  type PPChatTokenLogsPayload,
   type AccountTestResult,
   type OfficialAuthSession,
 } from "../../lib/api";
@@ -191,6 +187,44 @@ function inferLuaScriptKeyFromBaseURL(baseURL: string): string {
   }
 }
 
+function getKnownLuaDSLTemplate(account: Pick<AccountRecord, "base_url" | "source_icon">): string {
+  const baseURL = account.base_url.trim().toLowerCase();
+  if (/nodeseek\.in/i.test(baseURL)) {
+    return `simple_usage({
+  get = "/v1/usage",
+  auth = "bearer",
+  remaining = pick("remaining", "quota.remaining", "balance"),
+  unit = pick("unit", "quota.unit", default("USD")),
+  valid = pick("is_active", "isValid", default(true))
+})
+`;
+  }
+  if (normalizeSourceIcon(account.source_icon) === "ppchat" || /ppchat\.vip/i.test(baseURL)) {
+    return `usage_adapter({
+  get = "https://his.ppchat.vip/api/token-logs?page=1&page_size=1&token_key={{api_key}}",
+
+  limits = {
+    quota_remaining = pick("data.token_info.remain_quota_display")
+  },
+
+  meta = {
+    today_used_quota = pick("data.token_info.today_used_quota"),
+    today_added_quota = pick("data.token_info.today_added_quota"),
+    unit = "quota"
+  }
+})
+`;
+  }
+  return `simple_usage({
+  get = "/v1/usage",
+  auth = "bearer",
+  remaining = pick("remaining", "quota.remaining", "balance"),
+  unit = pick("unit", "quota.unit", default("USD")),
+  valid = pick("is_active", "isValid", default(true))
+})
+`;
+}
+
 function stringifyLuaConfigDraft(raw: string, scriptKey: string): string {
   const parsed = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : {};
   if (scriptKey.trim() !== "") {
@@ -229,8 +263,46 @@ ${JSON.stringify(accountContext, null, 2)}
 3. 优先复用共享脚本键 \`${scriptKey || "请先填写共享脚本标识"}\`。
 4. 若第三方 usage 接口需要额外字段，请直接写入 \`usage_config_json\`。
 
-## Lua 入口规范
-- 必须实现：\`function fetch_usage(ctx)\`
+## Lua DSL 规范（优先使用）
+- 简单余额接口优先使用 \`simple_usage({...})\`：
+\`\`\`lua
+simple_usage({
+  get = "/v1/usage",
+  auth = "bearer",
+  remaining = pick("remaining", "quota.remaining", "balance"),
+  unit = pick("unit", "quota.unit", default("USD")),
+  valid = pick("is_active", "isValid", default(true))
+})
+\`\`\`
+- 需要自定义映射时使用 \`usage_adapter({...})\`：
+\`\`\`lua
+usage_adapter({
+  request = {
+    url = "{{base_url}}/v1/usage",
+    method = "GET",
+    headers = { Authorization = "Bearer {{api_key}}" }
+  },
+  extract = {
+    remaining = pick("remaining", "quota.remaining", "balance"),
+    unit = pick("unit", "quota.unit", default("USD"))
+  },
+  result = function(v)
+    return {
+      ok = true,
+      source = "remote",
+      confidence = "high",
+      limits = { balance = v.remaining },
+      meta = { unit = v.unit }
+    }
+  end
+})
+\`\`\`
+- \`pick("a.b", "c", default(x))\` 会按顺序读取 JSON 字段路径。
+- \`get = "/path"\` 会自动拼接 \`ctx.account.base_url\`；也可以直接写完整 URL。
+- \`auth = "bearer"\` 会自动使用当前账户 API key/access token。
+
+## 兼容旧入口
+- 旧脚本仍然兼容：\`function fetch_usage(ctx)\`
 - 成功返回：
 \`\`\`lua
 return {
@@ -521,6 +593,12 @@ function formatInteger(language: AppLanguage, value: number): string {
   );
 }
 
+function formatUsageAmount(language: AppLanguage, value: number): string {
+  return new Intl.NumberFormat(language, {
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
 function formatDeletedAccountMessage(
   language: AppLanguage,
   accountName: string,
@@ -621,6 +699,22 @@ function buildGenericUsageWindows(
   }
 
   return windows;
+}
+
+function buildUsageAmount(record: AccountRecord, language: AppLanguage) {
+  if (record.balance > 0) {
+    return {
+      label: language === "en-US" ? "Balance" : "余额",
+      value: formatUsageAmount(language, record.balance),
+    };
+  }
+  if (record.quota_remaining > 0) {
+    return {
+      label: language === "en-US" ? "Remaining quota" : "剩余配额",
+      value: formatUsageAmount(language, record.quota_remaining),
+    };
+  }
+  return null;
 }
 
 type AccountsPageProps = {
@@ -724,10 +818,6 @@ export function AccountsPage({
   const [showAdvancedLuaConfig, setShowAdvancedLuaConfig] = useState(false);
   const [luaScriptLoading, setLuaScriptLoading] = useState(false);
   const [luaTesting, setLuaTesting] = useState(false);
-  const [detailLogsLoading, setDetailLogsLoading] = useState(false);
-  const [detailLogs, setDetailLogs] = useState<
-    PPChatTokenLogsPayload["data"] | null
-  >(null);
   const [draggingAccountID, setDraggingAccountID] = useState<number | null>(
     null,
   );
@@ -787,41 +877,6 @@ export function AccountsPage({
   }, [internalAddModalMode]);
 
   useEffect(() => {
-    if (!detailAccount) {
-      setDetailLogs(null);
-      setDetailLogsLoading(false);
-      return;
-    }
-    if (normalizeSourceIcon(detailAccount.source_icon) !== "ppchat") {
-      setDetailLogs(null);
-      setDetailLogsLoading(false);
-      return;
-    }
-    let cancelled = false;
-    setDetailLogsLoading(true);
-    void fetchPPChatTokenLogs(detailAccount.id)
-      .then((payload) => {
-        if (cancelled) {
-          return;
-        }
-        setDetailLogs(payload.data);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setDetailLogs(null);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setDetailLogsLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [detailAccount]);
-
-  useEffect(() => {
     if (!editingAccount) {
       setLuaScriptKey("");
       setLuaScriptContent("");
@@ -876,7 +931,7 @@ export function AccountsPage({
       })
       .catch(() => {
         if (!cancelled) {
-          setLuaScriptContent("");
+          setLuaScriptContent(getKnownLuaDSLTemplate(editingAccount));
         }
       })
       .finally(() => {
@@ -1531,41 +1586,6 @@ export function AccountsPage({
     }
   }
 
-  const detailLogMaxTokens = useMemo(() => {
-    if (!detailLogs?.logs?.length) {
-      return 0;
-    }
-    return Math.max(
-      ...detailLogs.logs.map(
-        (log) => log.prompt_tokens + log.completion_tokens,
-      ),
-      1,
-    );
-  }, [detailLogs]);
-
-  const ppchatQuotaSummary = useMemo(() => {
-    const info = detailLogs?.token_info;
-    if (!info) {
-      return null;
-    }
-    const added = Math.max(info.today_added_quota ?? 0, 0);
-    const used = Math.max(info.today_used_quota ?? 0, 0);
-    const remain = info.remain_quota_display ?? 0;
-    const remainingVisible = Math.max(remain, 0);
-    const total = Math.max(added, used + remainingVisible, 1);
-    const overflow = remain < 0 ? Math.abs(remain) : Math.max(used - total, 0);
-
-    return {
-      added,
-      used,
-      remain,
-      total,
-      overflow,
-      usageCount: info.today_usage_count ?? 0,
-      progressPercent: Math.min((used / total) * 100, 100),
-    };
-  }, [detailLogs]);
-
   const draggingAccount =
     draggingAccountID === null
       ? null
@@ -1608,6 +1628,8 @@ export function AccountsPage({
             },
           ]
         : buildGenericUsageWindows(record, language);
+    const usageAmount =
+      usageWindows.length === 0 ? buildUsageAmount(record, language) : null;
 
     return (
       <div
@@ -1685,6 +1707,16 @@ export function AccountsPage({
               <div
                 className={`account-usage-mini ${usageWindows.length === 0 ? "account-usage-mini-empty" : ""} ${usageWindows.length === 1 ? "account-usage-mini-single" : ""}`.trim()}
               >
+                {usageAmount ? (
+                  <div className="account-usage-amount">
+                    <span className="account-usage-amount-label">
+                      {usageAmount.label}
+                    </span>
+                    <span className="account-usage-amount-value">
+                      {usageAmount.value}
+                    </span>
+                  </div>
+                ) : null}
                 {usageWindows.map((item) => (
                   <div className="account-usage-mini-row" key={item.label}>
                     <div className="account-usage-mini-head">
@@ -1868,146 +1900,17 @@ export function AccountsPage({
         width={880}
       >
         {detailAccount ? (
-          normalizeSourceIcon(detailAccount.source_icon) === "ppchat" ? (
-            <div className="account-detail-layout">
-              {detailLogsLoading ? (
-                <Card
-                  variant="borderless"
-                  className="account-detail-chart-card"
-                >
-                  <Skeleton active paragraph={{ rows: 8 }} />
-                </Card>
-              ) : (
-                <div className="ppchat-metrics-grid">
-                  <Card variant="borderless" className="ppchat-progress-card">
-                    <div className="ppchat-stat-title">{t("今日配额进度")}</div>
-                    <div className="ppchat-progress-head">
-                      <span
-                        className={`ppchat-progress-primary ${ppchatQuotaSummary?.overflow ? "is-danger" : ""}`}
-                      >
-                        {ppchatQuotaSummary
-                          ? `${ppchatQuotaSummary.overflow ? t("超出") : t("剩余")} ${formatInteger(language, ppchatQuotaSummary.overflow || ppchatQuotaSummary.remain)}`
-                          : "--"}
-                      </span>
-                      <span
-                        className={`ppchat-progress-secondary ${ppchatQuotaSummary?.overflow ? "is-danger" : ""}`}
-                      >
-                        {ppchatQuotaSummary
-                          ? `${t("已用")} ${formatInteger(language, ppchatQuotaSummary.used)} / ${t("新增")} ${formatInteger(language, ppchatQuotaSummary.added)}`
-                          : "--"}
-                      </span>
-                    </div>
-                    <div
-                      className="ppchat-progress-bar-shell"
-                      aria-label={t("今日配额进度")}
-                    >
-                      <div
-                        className={`ppchat-progress-bar ${ppchatQuotaSummary?.overflow ? "is-danger" : ""}`}
-                        style={{
-                          width: `${ppchatQuotaSummary?.progressPercent ?? 0}%`,
-                        }}
-                      />
-                    </div>
-                  </Card>
-                  <Card
-                    variant="borderless"
-                    className="ppchat-metric-card ppchat-metric-card-compact"
-                  >
-                    <Statistic
-                      title={
-                        <span className="ppchat-stat-title">
-                          {t("当天增加配额")}
-                        </span>
-                      }
-                      value={
-                        ppchatQuotaSummary
-                          ? formatInteger(language, ppchatQuotaSummary.added)
-                          : "--"
-                      }
-                      valueRender={(node) => (
-                        <span className="ppchat-stat-value">{node}</span>
-                      )}
-                    />
-                  </Card>
-                  <Card
-                    variant="borderless"
-                    className="ppchat-metric-card ppchat-metric-card-compact"
-                  >
-                    <Statistic
-                      title={
-                        <span className="ppchat-stat-title">
-                          {t("今日已用次数")}
-                        </span>
-                      }
-                      value={
-                        ppchatQuotaSummary
-                          ? formatInteger(
-                              language,
-                              ppchatQuotaSummary.usageCount,
-                            )
-                          : "--"
-                      }
-                      valueRender={(node) => (
-                        <span className="ppchat-stat-value">{node}</span>
-                      )}
-                    />
-                  </Card>
-                </div>
-              )}
-              <Card
-                variant="borderless"
-                className="account-detail-chart-card"
-                title={t("PPChat Token 日志")}
-                extra={<BarChartOutlined />}
-              >
-                {detailLogsLoading ? (
-                  <Skeleton active paragraph={{ rows: 5 }} />
-                ) : detailLogs?.logs?.length ? (
-                  <div className="token-log-list">
-                    {detailLogs.logs.slice(0, 8).map((log, index) => {
-                      const total = log.prompt_tokens + log.completion_tokens;
-                      const width =
-                        detailLogMaxTokens > 0
-                          ? Math.max((total / detailLogMaxTokens) * 100, 6)
-                          : 0;
-                      return (
-                        <div
-                          className="token-log-row"
-                          key={`${log.created_at}-${index}`}
-                        >
-                          <div className="token-log-meta">
-                            <span>{log.model_name}</span>
-                            <span>{log.created_time}</span>
-                          </div>
-                          <div className="token-log-bar-bg">
-                            <div
-                              className="token-log-bar"
-                              style={{ width: `${width}%` }}
-                            />
-                          </div>
-                          <div className="token-log-values">
-                            <span>Prompt {log.prompt_tokens}</span>
-                            <span>Completion {log.completion_tokens}</span>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <Empty
-                    description={t("暂无 PPChat 日志数据")}
-                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  />
-                )}
-              </Card>
-            </div>
-          ) : (
-            <div className="account-detail-layout">
+          <div className="account-detail-layout">
               <div className="account-detail-stats">
                 <Card variant="borderless">
                   <Statistic
                     title={t("额度余额")}
-                    value={Math.round(detailAccount.quota_remaining)}
+                    value={Math.round(
+                      isPPChatAccount(detailAccount) &&
+                        (detailAccount.ppchat_today_added_quota ?? 0) > 0
+                        ? (detailAccount.ppchat_today_remaining_quota ?? 0)
+                        : detailAccount.quota_remaining,
+                    )}
                   />
                 </Card>
                 <Card variant="borderless">
@@ -2062,21 +1965,53 @@ export function AccountsPage({
                         detailAccount.auth_mode,
                     )}
                   </Descriptions.Item>
-                  <Descriptions.Item label={t("接口地址")} span={2}>
+                  <Descriptions.Item label={t("接口地址")}>
                     {detailAccount.base_url || t("OpenAI 官方")}
                   </Descriptions.Item>
-                  <Descriptions.Item label={t("5 小时剩余")}>
-                    {(100 - detailAccount.primary_used_percent).toFixed(0)}% ·{" "}
-                    {formatResetTime(detailAccount.primary_resets_at, language)}
-                  </Descriptions.Item>
-                  <Descriptions.Item label={t("1 周剩余")}>
-                    {(100 - detailAccount.secondary_used_percent).toFixed(0)}% ·{" "}
-                    {formatResetTime(detailAccount.secondary_resets_at, language)}
-                  </Descriptions.Item>
+                  {isPPChatAccount(detailAccount) ? (
+                    <>
+                      <Descriptions.Item label={t("剩余配额")}>
+                        {formatInteger(
+                          language,
+                          detailAccount.ppchat_today_remaining_quota ?? 0,
+                        )}{" "}
+                        · {formatTomorrowMidnight(language)}
+                      </Descriptions.Item>
+                      <Descriptions.Item label={t("当天已用配额")}>
+                        {formatInteger(
+                          language,
+                          detailAccount.ppchat_today_used_quota ?? 0,
+                        )}{" "}
+                        / {t("当天增加配额")}{" "}
+                        {formatInteger(
+                          language,
+                          detailAccount.ppchat_today_added_quota ?? 0,
+                        )}
+                      </Descriptions.Item>
+                    </>
+                  ) : (
+                    <>
+                      <Descriptions.Item label={t("5 小时剩余")}>
+                        {(100 - detailAccount.primary_used_percent).toFixed(0)}
+                        % ·{" "}
+                        {formatResetTime(
+                          detailAccount.primary_resets_at,
+                          language,
+                        )}
+                      </Descriptions.Item>
+                      <Descriptions.Item label={t("1 周剩余")}>
+                        {(100 - detailAccount.secondary_used_percent).toFixed(0)}
+                        % ·{" "}
+                        {formatResetTime(
+                          detailAccount.secondary_resets_at,
+                          language,
+                        )}
+                      </Descriptions.Item>
+                    </>
+                  )}
                 </Descriptions>
               </Card>
             </div>
-          )
         ) : null}
       </Modal>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2316,6 +2316,29 @@ html[data-theme-mode="dark"] .stats-chart-shell {
   transform: translateY(-3px);
 }
 
+.account-usage-amount {
+  display: grid;
+  justify-items: end;
+  align-content: center;
+  min-height: 52px;
+  gap: 5px;
+}
+
+.account-usage-amount-label {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.account-usage-amount-value {
+  color: var(--text-primary);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
 .account-usage-mini-row {
   display: grid;
   gap: 4px;


### PR DESCRIPTION
## 变更
- 新增 Lua usage DSL，并兼容旧 fetch_usage(ctx) 脚本入口
- 为 nodeseek 和 ppchat 提供内置 Lua DSL 模板与复制 Skill 规范
- nodeseek 默认使用 Lua usage driver，支持 base_url 带 /v1 或不带 /v1
- PPChat 账户详情面板改为与官方账户一致的指标布局
- 同步 1.5.3 版本元数据

## 验证
- cd backend && go test ./internal/api ./internal/usagedrv/lua -count=1
- npm --prefix frontend test -- AccountsPage.test.tsx
- npm --prefix frontend run build
- bash scripts/test/sync_release_metadata_test.sh
- GitHub Dev CI: https://github.com/GcsSloop/ai-gate/actions/runs/25741910573