### PR TITLE
feat(usage): 支持 Lua 控制用量显示

### DIFF
--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -407,27 +407,28 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 	}
 
 	type responseItem struct {
-		AccountID                 int64      `json:"account_id"`
-		Balance                   float64    `json:"balance"`
-		QuotaRemaining            float64    `json:"quota_remaining"`
-		RPMRemaining              float64    `json:"rpm_remaining"`
-		TPMRemaining              float64    `json:"tpm_remaining"`
-		HealthScore               float64    `json:"health_score"`
-		RecentErrorRate           float64    `json:"recent_error_rate"`
-		LastTotalTokens           float64    `json:"last_total_tokens"`
-		LastInputTokens           float64    `json:"last_input_tokens"`
-		LastOutputTokens          float64    `json:"last_output_tokens"`
-		ModelContextWindow        float64    `json:"model_context_window"`
-		PrimaryUsedPercent        float64    `json:"primary_used_percent"`
-		SecondaryUsedPercent      float64    `json:"secondary_used_percent"`
-		PrimaryResetsAt           *time.Time `json:"primary_resets_at,omitempty"`
-		SecondaryResetsAt         *time.Time `json:"secondary_resets_at,omitempty"`
-		CheckedAt                 *time.Time `json:"checked_at,omitempty"`
-		Stale                     bool       `json:"stale"`
-		LastError                 string     `json:"last_error,omitempty"`
-		PPChatTodayUsedQuota      float64    `json:"ppchat_today_used_quota,omitempty"`
-		PPChatTodayAddedQuota     float64    `json:"ppchat_today_added_quota,omitempty"`
-		PPChatTodayRemainingQuota float64    `json:"ppchat_today_remaining_quota,omitempty"`
+		AccountID                 int64          `json:"account_id"`
+		Balance                   float64        `json:"balance"`
+		QuotaRemaining            float64        `json:"quota_remaining"`
+		RPMRemaining              float64        `json:"rpm_remaining"`
+		TPMRemaining              float64        `json:"tpm_remaining"`
+		HealthScore               float64        `json:"health_score"`
+		RecentErrorRate           float64        `json:"recent_error_rate"`
+		LastTotalTokens           float64        `json:"last_total_tokens"`
+		LastInputTokens           float64        `json:"last_input_tokens"`
+		LastOutputTokens          float64        `json:"last_output_tokens"`
+		ModelContextWindow        float64        `json:"model_context_window"`
+		PrimaryUsedPercent        float64        `json:"primary_used_percent"`
+		SecondaryUsedPercent      float64        `json:"secondary_used_percent"`
+		PrimaryResetsAt           *time.Time     `json:"primary_resets_at,omitempty"`
+		SecondaryResetsAt         *time.Time     `json:"secondary_resets_at,omitempty"`
+		CheckedAt                 *time.Time     `json:"checked_at,omitempty"`
+		Stale                     bool           `json:"stale"`
+		LastError                 string         `json:"last_error,omitempty"`
+		PPChatTodayUsedQuota      float64        `json:"ppchat_today_used_quota,omitempty"`
+		PPChatTodayAddedQuota     float64        `json:"ppchat_today_added_quota,omitempty"`
+		PPChatTodayRemainingQuota float64        `json:"ppchat_today_remaining_quota,omitempty"`
+		UsageDisplay              map[string]any `json:"usage_display,omitempty"`
 	}
 
 	usageByAccount := map[int64]usage.Snapshot{}
@@ -443,6 +444,7 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 	for _, account := range accountList {
 		snapshot := usageByAccount[account.ID]
 		ppchatSummary := parsePPChatUsageSummary(snapshot.ProviderSnapshotJSON)
+		usageDisplay := parseUsageDisplay(snapshot.ProviderSnapshotJSON)
 		response = append(response, responseItem{
 			AccountID:                 account.ID,
 			Balance:                   snapshot.Balance,
@@ -465,6 +467,7 @@ func (h *AccountsHandler) listAccountsUsage(w http.ResponseWriter, _ *http.Reque
 			PPChatTodayUsedQuota:      ppchatSummary.TodayUsedQuota,
 			PPChatTodayAddedQuota:     ppchatSummary.TodayAddedQuota,
 			PPChatTodayRemainingQuota: ppchatSummary.TodayRemainingQuota,
+			UsageDisplay:              usageDisplay,
 		})
 	}
 
@@ -483,6 +486,22 @@ type ppchatUsageSummary struct {
 	TodayUsedQuota      float64
 	TodayAddedQuota     float64
 	TodayRemainingQuota float64
+}
+
+func parseUsageDisplay(raw string) map[string]any {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var decoded struct {
+		Display map[string]any `json:"display"`
+	}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil
+	}
+	if len(decoded.Display) == 0 {
+		return nil
+	}
+	return decoded.Display
 }
 
 func parsePPChatUsageSummary(raw string) ppchatUsageSummary {

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -1204,6 +1204,69 @@ func TestAccountsHandlerListUsageIncludesPPChatDailySummaryFromCachedSnapshot(t 
 	}
 }
 
+func TestAccountsHandlerListUsageIncludesCustomDisplayHints(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := accounts.NewSQLiteRepository(store.DB())
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	handler := api.NewAccountsHandler(repo, usageRepo, auth.NewOAuthConnector(auth.Config{}), auth.NewStateStore(5*time.Minute))
+
+	if err := repo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "nodeseek",
+		AuthMode:      accounts.AuthModeAPIKey,
+		BaseURL:       "https://ai.nodeseek.in",
+		CredentialRef: "sk-nodeseek",
+		Status:        accounts.StatusActive,
+	}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if err := usageRepo.Save(usage.Snapshot{
+		AccountID:   1,
+		Balance:     61.96,
+		HealthScore: 1,
+		CheckedAt:   time.Now().UTC(),
+		Source:      "remote",
+		Confidence:  "high",
+		ProviderSnapshotJSON: `{
+			"capacity_model":"balance_only",
+			"display":{
+				"summary":{"label":"余额","value":"$61.96"},
+				"detail_stats":[{"label":"余额","value":"$61.96"}],
+				"detail_items":[{"label":"计费单位","value":"美元"}]
+			}
+		}`,
+	}); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/accounts/usage", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /accounts/usage status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var listed []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	display, ok := listed[0]["usage_display"].(map[string]any)
+	if !ok {
+		t.Fatalf("usage_display = %#v, want object", listed[0]["usage_display"])
+	}
+	summary := display["summary"].(map[string]any)
+	if summary["label"] != "余额" || summary["value"] != "$61.96" {
+		t.Fatalf("usage_display.summary = %#v, want balance label/value", summary)
+	}
+}
+
 func TestAccountsHandlerListUsageDerivesPPChatAddedQuotaWhenMissing(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usage/normalize/normalize.go
+++ b/backend/internal/usage/normalize/normalize.go
@@ -86,6 +86,7 @@ func FromRaw(accountID int64, result usagedrv.RawUsageResult, checkedAt time.Tim
 	}
 	snapshot.ProviderSnapshotJSON = marshalProviderSnapshot(
 		result.Payload,
+		result.Display,
 		capacityModelFromRaw(result, snapshot),
 		LimitPresence{
 			HasBalance: result.Limits.Balance != nil,
@@ -103,7 +104,7 @@ func DefaultFallbackSnapshot(accountID int64) usage.Snapshot {
 		AccountID:            accountID,
 		Source:               "inferred",
 		Confidence:           "low",
-		ProviderSnapshotJSON: marshalProviderSnapshot(nil, CapacityModelManual, LimitPresence{}),
+		ProviderSnapshotJSON: marshalProviderSnapshot(nil, nil, CapacityModelManual, LimitPresence{}),
 		Balance:              1,
 		QuotaRemaining:       1_000_000,
 		RPMRemaining:         100,
@@ -163,6 +164,7 @@ func LimitPresenceFromSnapshot(snapshot usage.Snapshot) LimitPresence {
 type providerSnapshot struct {
 	CapacityModel CapacityModel  `json:"capacity_model,omitempty"`
 	Payload       map[string]any `json:"payload,omitempty"`
+	Display       map[string]any `json:"display,omitempty"`
 	HasBalance    bool           `json:"has_balance,omitempty"`
 	HasQuota      bool           `json:"has_quota,omitempty"`
 	HasRPM        bool           `json:"has_rpm,omitempty"`
@@ -218,10 +220,11 @@ func capacityModelFromRaw(result usagedrv.RawUsageResult, snapshot usage.Snapsho
 	return CapacityModelManual
 }
 
-func marshalProviderSnapshot(payload map[string]any, capacityModel CapacityModel, presence LimitPresence) string {
+func marshalProviderSnapshot(payload map[string]any, display map[string]any, capacityModel CapacityModel, presence LimitPresence) string {
 	raw, err := json.Marshal(providerSnapshot{
 		CapacityModel: capacityModel,
 		Payload:       payload,
+		Display:       display,
 		HasBalance:    presence.HasBalance,
 		HasQuota:      presence.HasQuota,
 		HasRPM:        presence.HasRPM,

--- a/backend/internal/usage/normalize/normalize_test.go
+++ b/backend/internal/usage/normalize/normalize_test.go
@@ -108,6 +108,42 @@ func TestFromRawBalanceOnlyLimits(t *testing.T) {
 	}
 }
 
+func TestFromRawPreservesDisplayHints(t *testing.T) {
+	t.Parallel()
+
+	result := usagedrv.RawUsageResult{
+		Source:     "remote",
+		Confidence: "high",
+		Limits: usagedrv.UsageLimits{
+			Balance: floatPtr(61.96),
+		},
+		Display: map[string]any{
+			"summary": map[string]any{
+				"label": "余额",
+				"value": "$61.96",
+			},
+			"detail_stats": []any{
+				map[string]any{"label": "余额", "value": "$61.96"},
+			},
+		},
+	}
+
+	snapshot := normalize.FromRaw(12, result, time.Now().UTC())
+	var decoded struct {
+		Display map[string]any `json:"display"`
+	}
+	if err := json.Unmarshal([]byte(snapshot.ProviderSnapshotJSON), &decoded); err != nil {
+		t.Fatalf("Unmarshal ProviderSnapshotJSON returned error: %v", err)
+	}
+	summary, ok := decoded.Display["summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("display.summary = %#v, want object", decoded.Display["summary"])
+	}
+	if summary["label"] != "余额" || summary["value"] != "$61.96" {
+		t.Fatalf("display.summary = %#v, want balance label/value", summary)
+	}
+}
+
 func TestFromRawStaleLowConfidence(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usagedrv/lua/dsl.go
+++ b/backend/internal/usagedrv/lua/dsl.go
@@ -8,7 +8,50 @@ func builtInManagedScript(key string) (string, bool) {
   auth = "bearer",
   remaining = pick("remaining", "quota.remaining", "balance"),
   unit = pick("unit", "quota.unit", default("USD")),
-  valid = pick("is_active", "isValid", default(true))
+  valid = pick("is_active", "isValid", default(true)),
+  display = {
+    summary = {
+      label = "余额",
+      value = function(payload)
+        local remaining = payload.remaining or payload.balance
+        if remaining == nil and type(payload.quota) == "table" then
+          remaining = payload.quota.remaining
+        end
+        if type(remaining) == "number" then
+          return "$" .. string.format("%.2f", remaining)
+        end
+        return "--"
+      end
+    },
+    detail_stats = {
+      {
+        label = "余额",
+        value = function(payload)
+          local remaining = payload.remaining or payload.balance
+          if remaining == nil and type(payload.quota) == "table" then
+            remaining = payload.quota.remaining
+          end
+          if type(remaining) == "number" then
+            return "$" .. string.format("%.2f", remaining)
+          end
+          return "--"
+        end
+      },
+      { label = "状态", value = function(payload)
+        local valid = payload.is_active
+        if valid == nil then
+          valid = payload.isValid
+        end
+        if valid == false then
+          return "不可用"
+        end
+        return "可用"
+      end }
+    },
+    detail_items = {
+      { label = "计费单位", value = pick("unit", "quota.unit", default("USD")) }
+    }
+  }
 })
 `, true
 	case "ppchat.vip", "code.ppchat.vip":
@@ -23,6 +66,45 @@ func builtInManagedScript(key string) (string, bool) {
     today_used_quota = pick("data.token_info.today_used_quota"),
     today_added_quota = pick("data.token_info.today_added_quota"),
     unit = "quota"
+  },
+
+  display = {
+    summary = {
+      label = "余额",
+      value = function(payload)
+        local token = payload.data and payload.data.token_info or {}
+        local remain = token.remain_quota_display
+        if type(remain) == "number" then
+          return string.format("%.0f", remain)
+        end
+        return "--"
+      end
+    },
+    detail_stats = {
+      { label = "剩余配额", value = function(payload)
+        local token = payload.data and payload.data.token_info or {}
+        if type(token.remain_quota_display) == "number" then
+          return string.format("%.0f", token.remain_quota_display)
+        end
+        return "--"
+      end },
+      { label = "当天已用", value = function(payload)
+        local token = payload.data and payload.data.token_info or {}
+        if type(token.today_used_quota) == "number" then
+          return string.format("%.0f", token.today_used_quota)
+        end
+        return "--"
+      end }
+    },
+    detail_items = {
+      { label = "当天增加配额", value = function(payload)
+        local token = payload.data and payload.data.token_info or {}
+        if type(token.today_added_quota) == "number" then
+          return string.format("%.0f", token.today_added_quota)
+        end
+        return "--"
+      end }
+    }
   }
 })
 `, true
@@ -131,6 +213,20 @@ local function aigate_resolve_map(spec, payload)
   return result
 end
 
+local function aigate_resolve_any(spec, payload)
+  if type(spec) ~= "table" then
+    return aigate_resolve(spec, payload)
+  end
+  if spec.__aigate_pick == true then
+    return aigate_resolve(spec, payload)
+  end
+  local result = {}
+  for key, value in pairs(spec) do
+    result[key] = aigate_resolve_any(value, payload)
+  end
+  return result
+end
+
 local function aigate_fetch_json(adapter, ctx)
   local request = adapter.request or {}
   local raw_url = adapter.get or request.url
@@ -196,6 +292,7 @@ local function aigate_execute_simple_usage(adapter, ctx, payload)
       unit = unit,
       is_valid = is_valid
     },
+    display = aigate_resolve_any(adapter.display, payload),
     payload = payload
   }
 end
@@ -220,6 +317,7 @@ local function aigate_execute_usage_adapter(adapter, ctx)
     confidence = adapter.confidence or "high",
     limits = aigate_resolve_map(adapter.limits, payload),
     meta = aigate_resolve_map(adapter.meta, payload),
+    display = aigate_resolve_any(adapter.display, payload),
     payload = payload
   }
 end

--- a/backend/internal/usagedrv/lua/managed_scripts_test.go
+++ b/backend/internal/usagedrv/lua/managed_scripts_test.go
@@ -85,6 +85,13 @@ func TestLuaDriverUsesBuiltInManagedDSLScript(t *testing.T) {
 	if result.Limits.Balance == nil || *result.Limits.Balance != 88 {
 		t.Fatalf("Balance = %#v, want 88", result.Limits.Balance)
 	}
+	summary, ok := result.Display["summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("display.summary = %#v, want object", result.Display["summary"])
+	}
+	if summary["label"] != "余额" || summary["value"] != "$88.00" {
+		t.Fatalf("display.summary = %#v, want formatted balance", summary)
+	}
 }
 
 func TestManagedScriptStoreRejectsInvalidKey(t *testing.T) {

--- a/backend/internal/usagedrv/lua/runtime_test.go
+++ b/backend/internal/usagedrv/lua/runtime_test.go
@@ -131,6 +131,57 @@ simple_usage({
 	}
 }
 
+func TestRuntimeExecuteSimpleUsageDSLReturnsDisplayHints(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := writeTempScript(t, `
+simple_usage({
+  get = "/v1/usage",
+  auth = "bearer",
+  remaining = pick("remaining"),
+  display = {
+    summary = {
+      label = "余额",
+      value = function(payload)
+        return "$" .. string.format("%.2f", payload.remaining)
+      end
+    },
+    detail_stats = {
+      { label = "余额", value = function(payload) return "$" .. string.format("%.2f", payload.remaining) end },
+      { label = "状态", value = "可用" }
+    },
+    detail_items = {
+      { label = "计费单位", value = "美元" }
+    }
+  }
+})
+`)
+	runtime := luadrv.NewRuntime(&http.Client{Transport: roundTripFunc(func(req *http.Request) *http.Response {
+		return jsonResponse(`{"remaining":61.96}`)
+	})}, filepath.Dir(scriptPath))
+	result, err := runtime.Execute(
+		context.Background(),
+		filepath.Base(scriptPath),
+		accounts.Account{BaseURL: "https://ai.nodeseek.in"},
+		accountdrv.ResolvedCredential{APIKey: "sk-test"},
+		map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	summary, ok := result.Display["summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("display.summary = %#v, want object", result.Display["summary"])
+	}
+	if summary["label"] != "余额" || summary["value"] != "$61.96" {
+		t.Fatalf("display.summary = %#v, want balance label/value", summary)
+	}
+	stats, ok := result.Display["detail_stats"].([]any)
+	if !ok || len(stats) != 2 {
+		t.Fatalf("display.detail_stats = %#v, want two items", result.Display["detail_stats"])
+	}
+}
+
 func TestRuntimeExecuteSimpleUsageDSLDeduplicatesVersionedBaseURL(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usagedrv/lua/schema.go
+++ b/backend/internal/usagedrv/lua/schema.go
@@ -60,6 +60,7 @@ func ensureNoUnknownTopKeys(root *golua.LTable) error {
 		"confidence": {},
 		"limits":     {},
 		"meta":       {},
+		"display":    {},
 		"payload":    {},
 		"error":      {},
 	}
@@ -122,6 +123,12 @@ func decodeSuccessResult(root *golua.LTable) (usagedrv.RawUsageResult, error) {
 		return usagedrv.RawUsageResult{}, fmt.Errorf("schema: meta: %w", err)
 	}
 
+	displayValue := root.RawGetString("display")
+	display, err := decodeOptionalMap(displayValue)
+	if err != nil {
+		return usagedrv.RawUsageResult{}, fmt.Errorf("schema: display: %w", err)
+	}
+
 	payloadValue := root.RawGetString("payload")
 	payload, err := decodeOptionalMap(payloadValue)
 	if err != nil {
@@ -133,6 +140,7 @@ func decodeSuccessResult(root *golua.LTable) (usagedrv.RawUsageResult, error) {
 		Confidence: confidence,
 		Limits:     limits,
 		Meta:       meta,
+		Display:    display,
 		Payload:    payload,
 	}, nil
 }

--- a/backend/internal/usagedrv/types.go
+++ b/backend/internal/usagedrv/types.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/gcssloop/codex-router/backend/internal/accounts"
 	"github.com/gcssloop/codex-router/backend/internal/accountdrv"
+	"github.com/gcssloop/codex-router/backend/internal/accounts"
 )
 
 type UsageLimits struct {
@@ -27,6 +27,7 @@ type RawUsageResult struct {
 	Payload    map[string]any
 	Limits     UsageLimits
 	Meta       map[string]any
+	Display    map[string]any
 }
 
 type UsageDriver interface {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.5.3"
+version = "1.5.4"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/docs/lua-usage-dsl.zh-CN.md
+++ b/docs/lua-usage-dsl.zh-CN.md
@@ -1,0 +1,69 @@
+# Lua Usage DSL
+
+本文记录 AI Gate 第三方用量采集脚本的规范。Lua 脚本只负责读取上游用量接口并返回标准化结果，不改变代理协议语义。
+
+## 推荐入口
+
+简单余额接口使用 `simple_usage`：
+
+```lua
+simple_usage({
+  get = "/v1/usage",
+  auth = "bearer",
+  remaining = pick("remaining", "quota.remaining", "balance"),
+  unit = pick("unit", "quota.unit", default("USD")),
+  valid = pick("is_active", "isValid", default(true)),
+  display = {
+    summary = { label = "余额", value = "$61.96" },
+    detail_stats = {
+      { label = "余额", value = "$61.96" }
+    },
+    detail_items = {
+      { label = "计费单位", value = "USD" }
+    }
+  }
+})
+```
+
+复杂接口使用 `usage_adapter`，在 `limits` 中返回路由判断所需数据，在 `display` 中返回 UI 显示文案。
+
+## 标准返回结构
+
+旧版 `function fetch_usage(ctx)` 仍然兼容。成功返回值可以包含：
+
+```lua
+return {
+  ok = true,
+  source = "remote",
+  confidence = "high",
+  limits = {
+    balance = nil,
+    quota_remaining = nil,
+    rpm_remaining = nil,
+    tpm_remaining = nil,
+    primary_used_percent = nil,
+    secondary_used_percent = nil,
+    primary_resets_at = nil,
+    secondary_resets_at = nil
+  },
+  meta = {},
+  display = {
+    summary = { label = "余额", value = "$61.96" },
+    detail_stats = {
+      { label = "余额", value = "$61.96" }
+    },
+    detail_items = {
+      { label = "计费单位", value = "USD" }
+    }
+  },
+  payload = {}
+}
+```
+
+`limits` 用于路由、冷却恢复和健康判断。`display` 只用于界面显示：
+
+- `display.summary` 控制账户列表右侧摘要。
+- `display.detail_stats` 控制账户详情页上方统计卡片。
+- `display.detail_items` 控制账户详情页下方用量条目。
+
+如果脚本不返回 `display`，前端继续使用旧逻辑：官方账号显示 5H/7D 窗口，PPChat 显示日配额，普通第三方账号显示余额或剩余配额。

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -640,6 +640,101 @@ describe("AccountsPage", () => {
     expect(within(testModal).getByText("pong")).toBeInTheDocument();
   });
 
+  it("renders lua-controlled usage display in the list and detail modal", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/ai-router/api/accounts" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                id: 1,
+                provider_type: "openai-compatible",
+                account_name: "加油包",
+                source_icon: "openai",
+                auth_mode: "api_key",
+                base_url: "https://ai.nodeseek.in",
+                account_driver: "",
+                usage_driver: "lua",
+                usage_config_json: "{\"script\":\"managed:ai.nodeseek.in\"}",
+                status: "active",
+                priority: 1,
+                is_active: true,
+                balance: 0,
+                quota_remaining: 0,
+                rpm_remaining: 0,
+                tpm_remaining: 0,
+                health_score: 0,
+                recent_error_rate: 0,
+                last_total_tokens: 0,
+                last_input_tokens: 0,
+                last_output_tokens: 0,
+                model_context_window: 0,
+                primary_used_percent: 0,
+                secondary_used_percent: 0,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      if (
+        url === "/ai-router/api/accounts/usage" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                account_id: 1,
+                balance: 61.96,
+                quota_remaining: 0,
+                rpm_remaining: 0,
+                tpm_remaining: 0,
+                health_score: 1,
+                recent_error_rate: 0,
+                last_total_tokens: 0,
+                last_input_tokens: 0,
+                last_output_tokens: 0,
+                model_context_window: 0,
+                primary_used_percent: 0,
+                secondary_used_percent: 0,
+                usage_display: {
+                  summary: { label: "余额", value: "$61.96" },
+                  detail_stats: [
+                    { label: "余额", value: "$61.96" },
+                    { label: "状态", value: "可用" },
+                  ],
+                  detail_items: [{ label: "计费单位", value: "美元" }],
+                },
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("加油包")).toBeInTheDocument();
+    expect(await screen.findByText("$61.96")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "详情-加油包" }));
+
+    const detailModal = await screen.findByRole("dialog", { name: "账户详情" });
+    expect(within(detailModal).getByText("余额")).toBeInTheDocument();
+    expect(within(detailModal).getByText("$61.96")).toBeInTheDocument();
+    expect(within(detailModal).getByText("计费单位")).toBeInTheDocument();
+    expect(within(detailModal).getByText("美元")).toBeInTheDocument();
+    expect(within(detailModal).queryByText("5 小时剩余")).not.toBeInTheDocument();
+    expect(within(detailModal).queryByText("1 周剩余")).not.toBeInTheDocument();
+  });
+
   it("confirms before sharing and only copies after explicit approval", async () => {
     const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, "clipboard", {

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -195,7 +195,38 @@ function getKnownLuaDSLTemplate(account: Pick<AccountRecord, "base_url" | "sourc
   auth = "bearer",
   remaining = pick("remaining", "quota.remaining", "balance"),
   unit = pick("unit", "quota.unit", default("USD")),
-  valid = pick("is_active", "isValid", default(true))
+  valid = pick("is_active", "isValid", default(true)),
+  display = {
+    summary = {
+      label = "余额",
+      value = function(payload)
+        local remaining = payload.remaining or payload.balance
+        if remaining == nil and type(payload.quota) == "table" then
+          remaining = payload.quota.remaining
+        end
+        if type(remaining) == "number" then
+          return "$" .. string.format("%.2f", remaining)
+        end
+        return "--"
+      end
+    },
+    detail_stats = {
+      { label = "余额", value = function(payload)
+        local remaining = payload.remaining or payload.balance
+        if remaining == nil and type(payload.quota) == "table" then
+          remaining = payload.quota.remaining
+        end
+        if type(remaining) == "number" then
+          return "$" .. string.format("%.2f", remaining)
+        end
+        return "--"
+      end },
+      { label = "状态", value = "可用" }
+    },
+    detail_items = {
+      { label = "计费单位", value = pick("unit", "quota.unit", default("USD")) }
+    }
+  }
 })
 `;
   }
@@ -211,6 +242,44 @@ function getKnownLuaDSLTemplate(account: Pick<AccountRecord, "base_url" | "sourc
     today_used_quota = pick("data.token_info.today_used_quota"),
     today_added_quota = pick("data.token_info.today_added_quota"),
     unit = "quota"
+  },
+
+  display = {
+    summary = {
+      label = "余额",
+      value = function(payload)
+        local token = payload.data and payload.data.token_info or {}
+        if type(token.remain_quota_display) == "number" then
+          return string.format("%.0f", token.remain_quota_display)
+        end
+        return "--"
+      end
+    },
+    detail_stats = {
+      { label = "剩余配额", value = function(payload)
+        local token = payload.data and payload.data.token_info or {}
+        if type(token.remain_quota_display) == "number" then
+          return string.format("%.0f", token.remain_quota_display)
+        end
+        return "--"
+      end },
+      { label = "当天已用", value = function(payload)
+        local token = payload.data and payload.data.token_info or {}
+        if type(token.today_used_quota) == "number" then
+          return string.format("%.0f", token.today_used_quota)
+        end
+        return "--"
+      end }
+    },
+    detail_items = {
+      { label = "当天增加配额", value = function(payload)
+        local token = payload.data and payload.data.token_info or {}
+        if type(token.today_added_quota) == "number" then
+          return string.format("%.0f", token.today_added_quota)
+        end
+        return "--"
+      end }
+    }
   }
 })
 `;
@@ -220,7 +289,19 @@ function getKnownLuaDSLTemplate(account: Pick<AccountRecord, "base_url" | "sourc
   auth = "bearer",
   remaining = pick("remaining", "quota.remaining", "balance"),
   unit = pick("unit", "quota.unit", default("USD")),
-  valid = pick("is_active", "isValid", default(true))
+  valid = pick("is_active", "isValid", default(true)),
+  display = {
+    summary = { label = "余额", value = function(payload)
+      local remaining = payload.remaining or payload.balance
+      if remaining == nil and type(payload.quota) == "table" then
+        remaining = payload.quota.remaining
+      end
+      if type(remaining) == "number" then
+        return "$" .. string.format("%.2f", remaining)
+      end
+      return "--"
+    end }
+  }
 })
 `;
 }
@@ -271,7 +352,34 @@ simple_usage({
   auth = "bearer",
   remaining = pick("remaining", "quota.remaining", "balance"),
   unit = pick("unit", "quota.unit", default("USD")),
-  valid = pick("is_active", "isValid", default(true))
+  valid = pick("is_active", "isValid", default(true)),
+  display = {
+    summary = { label = "余额", value = function(payload)
+      local remaining = payload.remaining or payload.balance
+      if remaining == nil and type(payload.quota) == "table" then
+        remaining = payload.quota.remaining
+      end
+      if type(remaining) == "number" then
+        return "$" .. string.format("%.2f", remaining)
+      end
+      return "--"
+    end },
+    detail_stats = {
+      { label = "余额", value = function(payload)
+        local remaining = payload.remaining or payload.balance
+        if remaining == nil and type(payload.quota) == "table" then
+          remaining = payload.quota.remaining
+        end
+        if type(remaining) == "number" then
+          return "$" .. string.format("%.2f", remaining)
+        end
+        return "--"
+      end }
+    },
+    detail_items = {
+      { label = "计费单位", value = pick("unit", "quota.unit", default("USD")) }
+    }
+  }
 })
 \`\`\`
 - 需要自定义映射时使用 \`usage_adapter({...})\`：
@@ -292,12 +400,22 @@ usage_adapter({
       source = "remote",
       confidence = "high",
       limits = { balance = v.remaining },
-      meta = { unit = v.unit }
+      meta = { unit = v.unit },
+      display = {
+        summary = { label = "余额", value = "$" .. string.format("%.2f", v.remaining) },
+        detail_stats = {
+          { label = "余额", value = "$" .. string.format("%.2f", v.remaining) }
+        },
+        detail_items = {
+          { label = "计费单位", value = v.unit }
+        }
+      }
     }
   end
 })
 \`\`\`
 - \`pick("a.b", "c", default(x))\` 会按顺序读取 JSON 字段路径。
+- \`display.summary\` 控制账户列表右侧摘要；\`display.detail_stats\` 控制详情页上方卡片；\`display.detail_items\` 控制详情页用量条目。它们只影响显示，不影响路由判断。
 - \`get = "/path"\` 会自动拼接 \`ctx.account.base_url\`；也可以直接写完整 URL。
 - \`auth = "bearer"\` 会自动使用当前账户 API key/access token。
 
@@ -322,6 +440,15 @@ return {
     secondary_resets_at = nil
   },
   meta = {},
+  display = {
+    summary = { label = "余额", value = "$61.96" },
+    detail_stats = {
+      { label = "余额", value = "$61.96" }
+    },
+    detail_items = {
+      { label = "计费单位", value = "USD" }
+    }
+  },
   payload = {}
 }
 \`\`\`
@@ -450,6 +577,7 @@ function mergeDisplayUsage(
     ppchat_today_used_quota: previous.ppchat_today_used_quota,
     ppchat_today_added_quota: previous.ppchat_today_added_quota,
     ppchat_today_remaining_quota: previous.ppchat_today_remaining_quota,
+    usage_display: previous.usage_display,
   };
 }
 
@@ -702,6 +830,13 @@ function buildGenericUsageWindows(
 }
 
 function buildUsageAmount(record: AccountRecord, language: AppLanguage) {
+  const summary = record.usage_display?.summary;
+  if (summary?.label || summary?.value) {
+    return {
+      label: summary.label || (language === "en-US" ? "Usage" : "用量"),
+      value: summary.value || "--",
+    };
+  }
   if (record.balance > 0) {
     return {
       label: language === "en-US" ? "Balance" : "余额",
@@ -715,6 +850,77 @@ function buildUsageAmount(record: AccountRecord, language: AppLanguage) {
     };
   }
   return null;
+}
+
+function buildDetailStats(record: AccountRecord, language: AppLanguage) {
+  const customStats = record.usage_display?.detail_stats?.filter(
+    (item) => item.label || item.value,
+  );
+  if (customStats?.length) {
+    return customStats.map((item) => ({
+      title: item.label || (language === "en-US" ? "Usage" : "用量"),
+      value: item.value || "--",
+    }));
+  }
+  return [
+    {
+      title: language === "en-US" ? "Quota balance" : "额度余额",
+      value: formatInteger(
+        language,
+        Math.round(
+          isPPChatAccount(record) && (record.ppchat_today_added_quota ?? 0) > 0
+            ? (record.ppchat_today_remaining_quota ?? 0)
+            : record.quota_remaining,
+        ),
+      ),
+    },
+    {
+      title: language === "en-US" ? "Health score" : "健康分",
+      value: record.health_score.toFixed(2),
+    },
+    {
+      title: language === "en-US" ? "Recent tokens" : "最近 Token",
+      value: formatInteger(language, Math.round(record.last_total_tokens)),
+    },
+    {
+      title: language === "en-US" ? "Error rate" : "错误率",
+      value: `${(record.recent_error_rate * 100).toFixed(1)}%`,
+    },
+  ];
+}
+
+function buildDetailUsageItems(record: AccountRecord, language: AppLanguage) {
+  const customItems = record.usage_display?.detail_items?.filter(
+    (item) => item.label || item.value,
+  );
+  if (customItems?.length) {
+    return customItems.map((item) => ({
+      label: item.label || (language === "en-US" ? "Usage" : "用量"),
+      value: item.value || "--",
+    }));
+  }
+  if (isPPChatAccount(record)) {
+    return [
+      {
+        label: language === "en-US" ? "Remaining quota" : "剩余配额",
+        value: `${formatInteger(language, record.ppchat_today_remaining_quota ?? 0)} · ${formatTomorrowMidnight(language)}`,
+      },
+      {
+        label: language === "en-US" ? "Used today" : "当天已用配额",
+        value: `${formatInteger(language, record.ppchat_today_used_quota ?? 0)} / ${language === "en-US" ? "Added today" : "当天增加配额"} ${formatInteger(language, record.ppchat_today_added_quota ?? 0)}`,
+      },
+    ];
+  }
+  return [
+    {
+      label: language === "en-US" ? "5-hour remaining" : "5 小时剩余",
+      value: `${(100 - record.primary_used_percent).toFixed(0)}% · ${formatResetTime(record.primary_resets_at, language)}`,
+    },
+    {
+      label: language === "en-US" ? "1-week remaining" : "1 周剩余",
+      value: `${(100 - record.secondary_used_percent).toFixed(0)}% · ${formatResetTime(record.secondary_resets_at, language)}`,
+    },
+  ];
 }
 
 type AccountsPageProps = {
@@ -1602,7 +1808,9 @@ export function AccountsPage({
     const actionsVisible = visibleActionAccountID === record.id;
     const sourceIcon = sourceIconMap[normalizeSourceIcon(record.source_icon)];
     const usageHealthState = getUsageHealthState(record);
-    const usageWindows = isOfficialAccount(record)
+    const usageWindows = record.usage_display?.summary
+      ? []
+      : isOfficialAccount(record)
       ? [
           {
             label: "5H",
@@ -1902,36 +2110,11 @@ export function AccountsPage({
         {detailAccount ? (
           <div className="account-detail-layout">
               <div className="account-detail-stats">
-                <Card variant="borderless">
-                  <Statistic
-                    title={t("额度余额")}
-                    value={Math.round(
-                      isPPChatAccount(detailAccount) &&
-                        (detailAccount.ppchat_today_added_quota ?? 0) > 0
-                        ? (detailAccount.ppchat_today_remaining_quota ?? 0)
-                        : detailAccount.quota_remaining,
-                    )}
-                  />
-                </Card>
-                <Card variant="borderless">
-                  <Statistic
-                    title={t("健康分")}
-                    value={detailAccount.health_score.toFixed(2)}
-                  />
-                </Card>
-                <Card variant="borderless">
-                  <Statistic
-                    title={t("最近 Token")}
-                    value={Math.round(detailAccount.last_total_tokens)}
-                  />
-                </Card>
-                <Card variant="borderless">
-                  <Statistic
-                    title={t("错误率")}
-                    value={(detailAccount.recent_error_rate * 100).toFixed(1)}
-                    suffix="%"
-                  />
-                </Card>
+                {buildDetailStats(detailAccount, language).map((item) => (
+                  <Card variant="borderless" key={item.title}>
+                    <Statistic title={t(item.title)} value={item.value} />
+                  </Card>
+                ))}
               </div>
               <Card variant="borderless" className="account-detail-meta">
                 <Descriptions column={2} size="small">
@@ -1968,47 +2151,11 @@ export function AccountsPage({
                   <Descriptions.Item label={t("接口地址")}>
                     {detailAccount.base_url || t("OpenAI 官方")}
                   </Descriptions.Item>
-                  {isPPChatAccount(detailAccount) ? (
-                    <>
-                      <Descriptions.Item label={t("剩余配额")}>
-                        {formatInteger(
-                          language,
-                          detailAccount.ppchat_today_remaining_quota ?? 0,
-                        )}{" "}
-                        · {formatTomorrowMidnight(language)}
-                      </Descriptions.Item>
-                      <Descriptions.Item label={t("当天已用配额")}>
-                        {formatInteger(
-                          language,
-                          detailAccount.ppchat_today_used_quota ?? 0,
-                        )}{" "}
-                        / {t("当天增加配额")}{" "}
-                        {formatInteger(
-                          language,
-                          detailAccount.ppchat_today_added_quota ?? 0,
-                        )}
-                      </Descriptions.Item>
-                    </>
-                  ) : (
-                    <>
-                      <Descriptions.Item label={t("5 小时剩余")}>
-                        {(100 - detailAccount.primary_used_percent).toFixed(0)}
-                        % ·{" "}
-                        {formatResetTime(
-                          detailAccount.primary_resets_at,
-                          language,
-                        )}
-                      </Descriptions.Item>
-                      <Descriptions.Item label={t("1 周剩余")}>
-                        {(100 - detailAccount.secondary_used_percent).toFixed(0)}
-                        % ·{" "}
-                        {formatResetTime(
-                          detailAccount.secondary_resets_at,
-                          language,
-                        )}
-                      </Descriptions.Item>
-                    </>
-                  )}
+                  {buildDetailUsageItems(detailAccount, language).map((item) => (
+                    <Descriptions.Item label={t(item.label)} key={item.label}>
+                      {item.value}
+                    </Descriptions.Item>
+                  ))}
                 </Descriptions>
               </Card>
             </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -38,6 +38,20 @@ export type AccountRecord = {
   ppchat_today_used_quota?: number;
   ppchat_today_added_quota?: number;
   ppchat_today_remaining_quota?: number;
+  usage_display?: AccountUsageDisplay;
+};
+
+export type AccountUsageDisplayMetric = {
+  label?: string;
+  value?: string;
+  hint?: string;
+  tone?: string;
+};
+
+export type AccountUsageDisplay = {
+  summary?: AccountUsageDisplayMetric;
+  detail_stats?: AccountUsageDisplayMetric[];
+  detail_items?: AccountUsageDisplayMetric[];
 };
 
 export type AccountUsageRecord = {
@@ -62,6 +76,7 @@ export type AccountUsageRecord = {
   ppchat_today_used_quota?: number;
   ppchat_today_added_quota?: number;
   ppchat_today_remaining_quota?: number;
+  usage_display?: AccountUsageDisplay;
 };
 
 export type CreateAccountPayload = {


### PR DESCRIPTION
## 变更
- 为 Lua usage 结果新增 display 显示规范，支持脚本控制列表摘要和账户详情页内容
- 将 display 持久化到 usage snapshot 并通过 /accounts/usage 返回
- 更新 nodeseek/ppchat 默认 Lua DSL 脚本和复制 skill 模板
- 新增 Lua Usage DSL 文档

## 验证
- cd backend && go test ./...
- npm --prefix frontend test -- AccountsPage.test.tsx
- npm --prefix frontend run build
- bash scripts/test/sync_release_metadata_test.sh
- Dev CI: https://github.com/GcsSloop/ai-gate/actions/runs/25745007878