### PR TITLE
发布 v1.5.5

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -404,7 +404,7 @@ struct DesktopRuntime {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum WindowCloseAction {
-    MinimizeWindow,
+    HideWindow,
     ExitApp,
 }
 
@@ -457,13 +457,9 @@ fn main() {
                     match event {
                         tauri::WindowEvent::CloseRequested { api, .. } => {
                             match window_close_action(current_settings_cache().close_to_tray) {
-                                WindowCloseAction::MinimizeWindow => {
+                                WindowCloseAction::HideWindow => {
                                     api.prevent_close();
-                                    if let Some(window) =
-                                        app_handle.get_webview_window(MAIN_WINDOW_LABEL)
-                                    {
-                                        let _ = window.minimize();
-                                    }
+                                    hide_main_window(app_handle);
                                 }
                                 WindowCloseAction::ExitApp => {
                                     api.prevent_close();
@@ -476,6 +472,16 @@ fn main() {
                             }
                         }
                         tauri::WindowEvent::Resized(_) => {
+                            if should_hide_minimized_window(
+                                current_settings_cache().close_to_tray,
+                                app_handle
+                                    .get_webview_window(MAIN_WINDOW_LABEL)
+                                    .and_then(|window| window.is_minimized().ok())
+                                    .unwrap_or(false),
+                            ) {
+                                hide_main_window(app_handle);
+                                return;
+                            }
                             let _ = persist_main_window_size_from_window(&app_handle);
                         }
                         _ => {}
@@ -499,10 +505,14 @@ fn main() {
 
 fn window_close_action(close_to_tray: bool) -> WindowCloseAction {
     if close_to_tray {
-        WindowCloseAction::MinimizeWindow
+        WindowCloseAction::HideWindow
     } else {
         WindowCloseAction::ExitApp
     }
+}
+
+fn should_hide_minimized_window(close_to_tray: bool, is_minimized: bool) -> bool {
+    close_to_tray && is_minimized
 }
 
 #[tauri::command]
@@ -1717,6 +1727,13 @@ fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
     }
 }
 
+fn hide_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        let _ = window.unminimize();
+        let _ = window.hide();
+    }
+}
+
 fn parse_proxy_status_response(resp: &HttpResponse) -> Result<ProxyStatusSnapshot, String> {
     if resp.status != 200 {
         return Err(format!("unexpected proxy status code {}", resp.status));
@@ -2366,16 +2383,16 @@ mod tests {
         proxy_menu_enabled_states, request_backend, resolve_main_window_size,
         resolve_system_proxy_url_from_scutil_output, resolve_update_future_with_timeout,
         restart_sidecar_and_wait_ready, sanitize_main_window_size, should_attempt_sidecar_recovery,
-        should_dispatch_resume_recovery, should_refresh_tray_after_action,
-        should_restart_sidecar_after_exit, should_retry_sidecar_request,
-        should_trigger_resume_recovery, shutdown_sidecar_with_reason, sidecar_candidate_paths,
-        sidecar_creation_flags, sidecar_request_with_recovery, sidecar_request_with_recovery_hooks,
-        sidecar_resource_name, spawn_sidecar, tray_icon_bytes_for_platform,
-        tray_icon_is_template_for_platform, update_download_progress, wait_for_backend_ready,
-        wait_for_backend_ready_with_probe, window_close_action, AppSettingsPayload,
-        DesktopLogEntry, DesktopRuntime, DesktopSettingsCache, HttpResponse, UpdateInfoPayload,
-        UpdateManagerState, UpdateProgressPayload, UpdateStatePayload, UpdateStatus,
-        UpstreamProxyMode, WindowCloseAction, WindowSizeCache, DESKTOP_RUNTIME,
+        should_dispatch_resume_recovery, should_hide_minimized_window,
+        should_refresh_tray_after_action, should_restart_sidecar_after_exit,
+        should_retry_sidecar_request, should_trigger_resume_recovery, shutdown_sidecar_with_reason,
+        sidecar_candidate_paths, sidecar_creation_flags, sidecar_request_with_recovery,
+        sidecar_request_with_recovery_hooks, sidecar_resource_name, spawn_sidecar,
+        tray_icon_bytes_for_platform, tray_icon_is_template_for_platform, update_download_progress,
+        wait_for_backend_ready, wait_for_backend_ready_with_probe, window_close_action,
+        AppSettingsPayload, DesktopLogEntry, DesktopRuntime, DesktopSettingsCache, HttpResponse,
+        UpdateInfoPayload, UpdateManagerState, UpdateProgressPayload, UpdateStatePayload,
+        UpdateStatus, UpstreamProxyMode, WindowCloseAction, WindowSizeCache, DESKTOP_RUNTIME,
         MAIN_WINDOW_MIN_HEIGHT, MAIN_WINDOW_MIN_WIDTH, SIDECAR_CHILD, SIDECAR_MACOS_NAME,
         SIDECAR_WINDOWS_NAME, TRAY_ICON_COLOR_BYTES, TRAY_ICON_TEMPLATE_BYTES, UPDATE_MANAGER,
     };
@@ -2435,8 +2452,15 @@ mod tests {
     }
 
     #[test]
-    fn window_close_minimizes_when_close_to_tray_is_enabled() {
-        assert_eq!(window_close_action(true), WindowCloseAction::MinimizeWindow);
+    fn window_close_hides_when_close_to_tray_is_enabled() {
+        assert_eq!(window_close_action(true), WindowCloseAction::HideWindow);
+    }
+
+    #[test]
+    fn minimized_window_hides_when_close_to_tray_is_enabled() {
+        assert!(should_hide_minimized_window(true, true));
+        assert!(!should_hide_minimized_window(false, true));
+        assert!(!should_hide_minimized_window(true, false));
     }
 
     #[test]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/stats/StatsChartOptions.ts
+++ b/frontend/src/features/stats/StatsChartOptions.ts
@@ -1,0 +1,218 @@
+import type * as echarts from "echarts";
+
+import type { AppLanguage } from "../../lib/i18n";
+import type { UsageTrendPoint } from "../../lib/api";
+
+export type ChartTheme = {
+  textPrimary: string;
+  textSecondary: string;
+  border: string;
+  panelSurface: string;
+};
+
+type TokenTrendChartOption = echarts.EChartsCoreOption & {
+  legend: { data: string[] };
+  yAxis: unknown[];
+  series: unknown[];
+};
+
+export function sortTrendPointsByBucket(data: UsageTrendPoint[]): UsageTrendPoint[] {
+  return [...data].sort((left, right) => {
+    const leftTime = Date.parse(left.bucket);
+    const rightTime = Date.parse(right.bucket);
+    if (Number.isNaN(leftTime) || Number.isNaN(rightTime)) {
+      return left.bucket.localeCompare(right.bucket);
+    }
+    return leftTime - rightTime;
+  });
+}
+
+export function trendBucketsNeedHour(data: UsageTrendPoint[]): boolean {
+  return data.some((point) => {
+    const date = new Date(point.bucket);
+    if (Number.isNaN(date.getTime())) {
+      return false;
+    }
+    return date.getUTCHours() !== 0 || date.getUTCMinutes() !== 0 || date.getUTCSeconds() !== 0;
+  });
+}
+
+export function formatCompactNumber(language: AppLanguage, value: number): string {
+  const absolute = Math.abs(value);
+  if (absolute >= 1_000_000) {
+    return `${new Intl.NumberFormat(language, { maximumFractionDigits: absolute >= 10_000_000 ? 0 : 1 }).format(value / 1_000_000)}M`;
+  }
+  if (absolute >= 1_000) {
+    return `${new Intl.NumberFormat(language, { maximumFractionDigits: absolute >= 10_000 ? 0 : 1 }).format(value / 1_000)}K`;
+  }
+  return new Intl.NumberFormat(language, { maximumFractionDigits: 0 }).format(value);
+}
+
+function formatBucket(language: AppLanguage, bucket: string, withHour: boolean): string {
+  return new Date(bucket).toLocaleString(
+    language,
+    withHour
+      ? {
+          month: "numeric",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+        }
+      : {
+          month: "numeric",
+          day: "numeric",
+        },
+  );
+}
+
+export function buildTokenTrendChartOption(data: UsageTrendPoint[], language: AppLanguage, theme: ChartTheme): TokenTrendChartOption {
+  const sortedData = sortTrendPointsByBucket(data);
+  const inputLabel = language === "zh-CN" ? "输入" : "Input";
+  const outputLabel = language === "zh-CN" ? "输出" : "Output";
+  const requestLabel = language === "zh-CN" ? "请求数" : "Requests";
+  const withHour = trendBucketsNeedHour(sortedData);
+  return {
+    animationDuration: 420,
+    animationDurationUpdate: 420,
+    animationEasingUpdate: "cubicOut",
+    color: ["#3b82f6", "#14b8a6", "#f59e0b"],
+    grid: {
+      top: 34,
+      right: 46,
+      bottom: 24,
+      left: 12,
+      containLabel: true,
+    },
+    legend: {
+      top: 0,
+      right: 0,
+      icon: "circle",
+      itemWidth: 8,
+      itemHeight: 8,
+      textStyle: {
+        color: theme.textSecondary,
+        fontSize: 12,
+      },
+      data: [inputLabel, outputLabel, requestLabel],
+    },
+    tooltip: {
+      trigger: "axis",
+      backgroundColor: theme.panelSurface,
+      borderColor: theme.border,
+      borderWidth: 1,
+      textStyle: {
+        color: theme.textPrimary,
+      },
+      formatter: (params: unknown) => {
+        const series = Array.isArray(params) ? (params as Array<{ axisValue: string; seriesName: string; value: number }>) : [];
+        if (series.length === 0) {
+          return "";
+        }
+        const rows = series
+          .map((item) => `${item.seriesName}: ${formatCompactNumber(language, Number(item.value ?? 0))}`)
+          .join("<br/>");
+        return `${series[0].axisValue}<br/>${rows}`;
+      },
+    },
+    xAxis: {
+      type: "category",
+      boundaryGap: true,
+      data: sortedData.map((point) => formatBucket(language, point.bucket, withHour)),
+      axisLabel: {
+        color: theme.textSecondary,
+        fontSize: 11,
+        margin: 14,
+      },
+      axisLine: {
+        lineStyle: {
+          color: theme.border,
+        },
+      },
+      axisTick: {
+        show: false,
+      },
+    },
+    yAxis: [
+      {
+        type: "value",
+        name: "Token",
+        nameGap: 8,
+        nameTextStyle: {
+          color: theme.textSecondary,
+          fontSize: 11,
+          align: "left",
+        },
+        axisLabel: {
+          color: theme.textSecondary,
+          fontSize: 11,
+          formatter: (value: number) => formatCompactNumber(language, value),
+        },
+        splitLine: {
+          lineStyle: {
+            color: theme.border,
+            opacity: 0.7,
+          },
+        },
+      },
+      {
+        type: "value",
+        name: requestLabel,
+        nameGap: 8,
+        nameTextStyle: {
+          color: theme.textSecondary,
+          fontSize: 11,
+          align: "right",
+        },
+        axisLabel: {
+          color: theme.textSecondary,
+          fontSize: 11,
+          formatter: (value: number) => formatCompactNumber(language, value),
+        },
+        splitLine: {
+          show: false,
+        },
+      },
+    ],
+    series: [
+      {
+        name: inputLabel,
+        type: "line",
+        smooth: true,
+        symbol: "none",
+        lineStyle: { width: 3 },
+        areaStyle: {
+          color: "rgba(59, 130, 246, 0.10)",
+        },
+        data: sortedData.map((point) => point.input_tokens),
+      },
+      {
+        name: outputLabel,
+        type: "line",
+        smooth: true,
+        symbol: "none",
+        lineStyle: { width: 3 },
+        areaStyle: {
+          color: "rgba(20, 184, 166, 0.10)",
+        },
+        data: sortedData.map((point) => point.output_tokens),
+      },
+      {
+        name: requestLabel,
+        type: "bar",
+        yAxisIndex: 1,
+        barMaxWidth: 16,
+        itemStyle: {
+          borderRadius: [4, 4, 0, 0],
+          opacity: 0.28,
+        },
+        emphasis: {
+          itemStyle: {
+            opacity: 0.55,
+          },
+        },
+        data: sortedData.map((point) => point.request_count),
+      },
+    ],
+  };
+}

--- a/frontend/src/features/stats/StatsCharts.test.ts
+++ b/frontend/src/features/stats/StatsCharts.test.ts
@@ -1,4 +1,4 @@
-import { sortTrendPointsByBucket, trendBucketsNeedHour } from "./StatsCharts";
+import { buildTokenTrendChartOption, sortTrendPointsByBucket, trendBucketsNeedHour } from "./StatsChartOptions";
 
 describe("StatsCharts", () => {
   it("sorts trend points by bucket time ascending", () => {
@@ -44,5 +44,33 @@ describe("StatsCharts", () => {
       { bucket: "2026-04-11T09:00:00Z", request_count: 1, input_tokens: 30, output_tokens: 3, total_tokens: 33, estimated_cost: 0.03, balance_delta: 0, quota_delta: 0 },
     ];
     expect(trendBucketsNeedHour(points)).toBe(true);
+  });
+
+  it("adds request count to token trend chart with a separate axis", () => {
+    const option = buildTokenTrendChartOption(
+      [
+        { bucket: "2026-04-11T08:00:00Z", request_count: 7, input_tokens: 20, output_tokens: 2, total_tokens: 22, estimated_cost: 0.03, balance_delta: 0, quota_delta: 0 },
+      ],
+      "zh-CN",
+      {
+        textPrimary: "#111827",
+        textSecondary: "#6a7c73",
+        border: "#e5e7eb",
+        panelSurface: "#f8fbff",
+      },
+    );
+
+    expect(option.legend).toMatchObject({ data: ["输入", "输出", "请求数"] });
+    expect(option.yAxis).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Token" }),
+        expect.objectContaining({ name: "请求数" }),
+      ]),
+    );
+    expect(option.series).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "请求数", type: "bar", yAxisIndex: 1, data: [7] }),
+      ]),
+    );
   });
 });

--- a/frontend/src/features/stats/StatsCharts.tsx
+++ b/frontend/src/features/stats/StatsCharts.tsx
@@ -3,13 +3,7 @@ import * as echarts from "echarts";
 
 import type { AppLanguage } from "../../lib/i18n";
 import type { UsageModelDistributionPoint, UsageTrendPoint } from "../../lib/api";
-
-type ChartTheme = {
-  textPrimary: string;
-  textSecondary: string;
-  border: string;
-  panelSurface: string;
-};
+import { buildTokenTrendChartOption, formatCompactNumber, type ChartTheme } from "./StatsChartOptions";
 
 type TokenTrendChartProps = {
   data: UsageTrendPoint[];
@@ -20,53 +14,6 @@ type ModelDistributionChartProps = {
   data: UsageModelDistributionPoint[];
   language: AppLanguage;
 };
-
-export function sortTrendPointsByBucket(data: UsageTrendPoint[]): UsageTrendPoint[] {
-  return [...data].sort((left, right) => {
-    const leftTime = Date.parse(left.bucket);
-    const rightTime = Date.parse(right.bucket);
-    if (Number.isNaN(leftTime) || Number.isNaN(rightTime)) {
-      return left.bucket.localeCompare(right.bucket);
-    }
-    return leftTime - rightTime;
-  });
-}
-
-export function trendBucketsNeedHour(data: UsageTrendPoint[]): boolean {
-  return data.some((point) => {
-    const date = new Date(point.bucket);
-    if (Number.isNaN(date.getTime())) {
-      return false;
-    }
-    return date.getUTCHours() !== 0 || date.getUTCMinutes() !== 0 || date.getUTCSeconds() !== 0;
-  });
-}
-
-function formatCompactNumber(language: AppLanguage, value: number): string {
-  const absolute = Math.abs(value);
-  if (absolute >= 1_000_000) {
-    return `${new Intl.NumberFormat(language, { maximumFractionDigits: absolute >= 10_000_000 ? 0 : 1 }).format(value / 1_000_000)}M`;
-  }
-  if (absolute >= 1_000) {
-    return `${new Intl.NumberFormat(language, { maximumFractionDigits: absolute >= 10_000 ? 0 : 1 }).format(value / 1_000)}K`;
-  }
-  return new Intl.NumberFormat(language, { maximumFractionDigits: 0 }).format(value);
-}
-
-function formatBucket(language: AppLanguage, bucket: string, withHour: boolean): string {
-  return new Date(bucket).toLocaleString(language, withHour
-    ? {
-        month: "numeric",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-      }
-    : {
-        month: "numeric",
-        day: "numeric",
-      });
-}
 
 function readChartTheme(): ChartTheme {
   const styles = window.getComputedStyle(document.documentElement);
@@ -120,111 +67,8 @@ export function TokenTrendChart({ data, language }: TokenTrendChartProps) {
     if (data.length === 0) {
       return null;
     }
-    const sortedData = sortTrendPointsByBucket(data);
     const theme = readChartTheme();
-    const inputLabel = language === "zh-CN" ? "输入" : "Input";
-    const outputLabel = language === "zh-CN" ? "输出" : "Output";
-    const withHour = trendBucketsNeedHour(sortedData);
-    return {
-      animationDuration: 420,
-      animationDurationUpdate: 420,
-      animationEasingUpdate: "cubicOut",
-      color: ["#3b82f6", "#14b8a6"],
-      grid: {
-        top: 34,
-        right: 18,
-        bottom: 24,
-        left: 12,
-        containLabel: true,
-      },
-      legend: {
-        top: 0,
-        right: 0,
-        icon: "circle",
-        itemWidth: 8,
-        itemHeight: 8,
-        textStyle: {
-          color: theme.textSecondary,
-          fontSize: 12,
-        },
-        data: [inputLabel, outputLabel],
-      },
-      tooltip: {
-        trigger: "axis",
-        backgroundColor: theme.panelSurface,
-        borderColor: theme.border,
-        borderWidth: 1,
-        textStyle: {
-          color: theme.textPrimary,
-        },
-        formatter: (params: unknown) => {
-          const series = Array.isArray(params) ? (params as Array<{ axisValue: string; seriesName: string; value: number; color: string }>) : [];
-          if (series.length === 0) {
-            return "";
-          }
-          const rows = series
-            .map((item) => `${item.seriesName}: ${formatCompactNumber(language, Number(item.value ?? 0))}`)
-            .join("<br/>");
-          return `${series[0].axisValue}<br/>${rows}`;
-        },
-      },
-      xAxis: {
-        type: "category",
-        boundaryGap: false,
-        data: sortedData.map((point) => formatBucket(language, point.bucket, withHour)),
-        axisLabel: {
-          color: theme.textSecondary,
-          fontSize: 11,
-          margin: 14,
-        },
-        axisLine: {
-          lineStyle: {
-            color: theme.border,
-          },
-        },
-        axisTick: {
-          show: false,
-        },
-      },
-      yAxis: {
-        type: "value",
-        axisLabel: {
-          color: theme.textSecondary,
-          fontSize: 11,
-          formatter: (value: number) => formatCompactNumber(language, value),
-        },
-        splitLine: {
-          lineStyle: {
-            color: theme.border,
-            opacity: 0.7,
-          },
-        },
-      },
-      series: [
-        {
-          name: inputLabel,
-          type: "line",
-          smooth: true,
-          symbol: "none",
-          lineStyle: { width: 3 },
-          areaStyle: {
-            color: "rgba(59, 130, 246, 0.10)",
-          },
-          data: sortedData.map((point) => point.input_tokens),
-        },
-        {
-          name: outputLabel,
-          type: "line",
-          smooth: true,
-          symbol: "none",
-          lineStyle: { width: 3 },
-          areaStyle: {
-            color: "rgba(20, 184, 166, 0.10)",
-          },
-          data: sortedData.map((point) => point.output_tokens),
-        },
-      ],
-    };
+    return buildTokenTrendChartOption(data, language, theme);
   }, [data, language]);
 
   const chartRef = useEChart(option);


### PR DESCRIPTION
## 变更

- macOS 窗口关闭和最小化进入静默 hide 模式，避免 Dock 最小化缩略图常驻。
- Token 趋势图增加请求数序列和右侧请求数坐标轴。
- 同步版本元数据到 v1.5.5。

## 验证

- npm --prefix frontend test
- npm --prefix frontend run build
- cargo test --manifest-path desktop/src-tauri/Cargo.toml
- bash scripts/test/sync_release_metadata_test.sh
- GitHub Actions Dev CI: https://github.com/GcsSloop/ai-gate/actions/runs/25871876425