### PR TITLE
发布 v1.5.6

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.5.5",
+  "version": "1.5.6",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.5.5"
+version = "1.5.6"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.5.5",
+  "version": "1.5.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/stats/StatsChartOptions.ts
+++ b/frontend/src/features/stats/StatsChartOptions.ts
@@ -76,7 +76,7 @@ export function buildTokenTrendChartOption(data: UsageTrendPoint[], language: Ap
     animationDuration: 420,
     animationDurationUpdate: 420,
     animationEasingUpdate: "cubicOut",
-    color: ["#3b82f6", "#14b8a6", "#f59e0b"],
+    color: ["#3b82f6", "#14b8a6", "#8b5cf6"],
     grid: {
       top: 34,
       right: 46,
@@ -180,7 +180,7 @@ export function buildTokenTrendChartOption(data: UsageTrendPoint[], language: Ap
         type: "line",
         smooth: true,
         symbol: "none",
-        lineStyle: { width: 3 },
+        lineStyle: { width: 2 },
         areaStyle: {
           color: "rgba(59, 130, 246, 0.10)",
         },
@@ -191,7 +191,7 @@ export function buildTokenTrendChartOption(data: UsageTrendPoint[], language: Ap
         type: "line",
         smooth: true,
         symbol: "none",
-        lineStyle: { width: 3 },
+        lineStyle: { width: 2 },
         areaStyle: {
           color: "rgba(20, 184, 166, 0.10)",
         },
@@ -203,12 +203,14 @@ export function buildTokenTrendChartOption(data: UsageTrendPoint[], language: Ap
         yAxisIndex: 1,
         barMaxWidth: 16,
         itemStyle: {
+          color: "#8b5cf6",
           borderRadius: [4, 4, 0, 0],
-          opacity: 0.28,
+          opacity: 0.18,
         },
         emphasis: {
           itemStyle: {
-            opacity: 0.55,
+            color: "#7c3aed",
+            opacity: 0.32,
           },
         },
         data: sortedData.map((point) => point.request_count),

--- a/frontend/src/features/stats/StatsCharts.test.ts
+++ b/frontend/src/features/stats/StatsCharts.test.ts
@@ -73,4 +73,46 @@ describe("StatsCharts", () => {
       ]),
     );
   });
+
+  it("uses a purple request count color and thinner token lines", () => {
+    const option = buildTokenTrendChartOption(
+      [
+        { bucket: "2026-04-11T08:00:00Z", request_count: 7, input_tokens: 20, output_tokens: 2, total_tokens: 22, estimated_cost: 0.03, balance_delta: 0, quota_delta: 0 },
+      ],
+      "zh-CN",
+      {
+        textPrimary: "#111827",
+        textSecondary: "#6a7c73",
+        border: "#e5e7eb",
+        panelSurface: "#f8fbff",
+      },
+    );
+
+    expect(option.color).toEqual(["#3b82f6", "#14b8a6", "#8b5cf6"]);
+    expect(option.series).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "输入",
+          lineStyle: expect.objectContaining({ width: 2 }),
+        }),
+        expect.objectContaining({
+          name: "输出",
+          lineStyle: expect.objectContaining({ width: 2 }),
+        }),
+        expect.objectContaining({
+          name: "请求数",
+          itemStyle: expect.objectContaining({
+            color: "#8b5cf6",
+            opacity: 0.18,
+          }),
+          emphasis: expect.objectContaining({
+            itemStyle: expect.objectContaining({
+              color: "#7c3aed",
+              opacity: 0.32,
+            }),
+          }),
+        }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## 变更

- 优化 Token 趋势图中请求数的紫色柱状显示
- 将输入/输出 Token 趋势线调整为更细的 2px
- 同步发布版本元数据到 v1.5.6

## 验证

- npm --prefix frontend test
- npm --prefix frontend run build
- bash scripts/test/sync_release_metadata_test.sh
- GitHub Actions Dev CI: https://github.com/GcsSloop/ai-gate/actions/runs/25931415591