### PR TITLE
fix: 截断 mac 菜单栏账户名

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.5.7",
+  "version": "1.5.8",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.5.7"
+version = "1.5.8"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.5.7"
+version = "1.5.8"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1805,7 +1805,19 @@ fn format_tray_title(proxy_enabled: bool, active_account_name: Option<&str>) -> 
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .unwrap_or("无账户");
-    format!("{indicator} {account_name}")
+    format!("{indicator} {}", format_tray_account_name(account_name))
+}
+
+fn format_tray_account_name(name: &str) -> String {
+    const MAX_TRAY_ACCOUNT_NAME_CHARS: usize = 6;
+
+    let mut chars = name.chars();
+    let prefix: String = chars.by_ref().take(MAX_TRAY_ACCOUNT_NAME_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{prefix}...")
+    } else {
+        prefix
+    }
 }
 
 fn emit_backend_state_changed<R: Runtime>(app: &AppHandle<R>) {
@@ -2476,6 +2488,22 @@ mod tests {
     #[test]
     fn tray_title_formats_proxy_disabled_with_account() {
         assert_eq!(format_tray_title(false, Some("team")), "· team");
+    }
+
+    #[test]
+    fn tray_title_truncates_long_account_name() {
+        assert_eq!(
+            format_tray_title(true, Some("SYX-dssdsdsds")),
+            "§ SYX-ds..."
+        );
+    }
+
+    #[test]
+    fn tray_title_keeps_six_character_account_name() {
+        assert_eq!(
+            format_tray_title(true, Some("一二三四五六")),
+            "§ 一二三四五六"
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.5.7",
+  "version": "1.5.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 变更
- mac 菜单栏托盘标题中的当前账户名最多显示 6 个字符，超过后追加 ...
- 保持主界面账户列表和托盘菜单账户名不受影响
- 准备 1.5.8 发布版本号

## 验证
- cargo test --manifest-path desktop/src-tauri/Cargo.toml tray_title_ -- --nocapture
- npm --prefix frontend test
- npm --prefix frontend run build
- npm --prefix desktop run tauri build（本地产物生成完成，缺少 TAURI_SIGNING_PRIVATE_KEY 后签名退出）
- GitHub Dev CI: https://github.com/GcsSloop/ai-gate/actions/runs/26079499982