### PR TITLE
透传上游模型列表

### DIFF
--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strconv"
@@ -471,6 +472,21 @@ func (h *ResponsesHandler) buildThinResponsesProxySubpathRequest(ctx context.Con
 	})
 }
 
+func (h *ResponsesHandler) buildThinModelsProxyRequest(ctx context.Context, account accounts.Account, credential string, endpointPath string) (*http.Request, error) {
+	if usesOfficialCodexAdapter(account) {
+		accountID, err := resolveLocalAccountID(account)
+		if err != nil {
+			return nil, err
+		}
+		return providercodex.NewAdapter(resolveAccountBaseURL(account)).BuildModelsRequest(ctx, credential, accountID, endpointPath)
+	}
+	return provideropenai.NewAdapter(resolveAccountBaseURL(account)).BuildRequest(ctx, providers.Request{
+		Path:   endpointPath,
+		Method: http.MethodGet,
+		APIKey: credential,
+	})
+}
+
 func shouldRetryOfficialResponsesTransportError(account accounts.Account, err error) bool {
 	return usesOfficialCodexAdapter(account) && errors.Is(err, io.EOF)
 }
@@ -673,6 +689,17 @@ func normalizedResponsesSubpath(path string) string {
 	return path
 }
 
+func normalizedModelsPath(value *url.URL) string {
+	path := value.Path
+	if strings.HasPrefix(path, "/v1/") {
+		path = strings.TrimPrefix(path, "/v1")
+	}
+	if value.RawQuery != "" {
+		return path + "?" + value.RawQuery
+	}
+	return path
+}
+
 func (h *ResponsesHandler) startThinAudit(r *http.Request, req gatewayopenai.ResponsesRequest, accountID int64, inputItems []gatewayopenai.ResponsesInputItem) (int64, int) {
 	conversationID, err := h.conversations.CreateConversation(conversations.Conversation{
 		ClientID:             r.RemoteAddr,
@@ -745,22 +772,50 @@ func (h *ResponsesHandler) recordThinAuditRun(conversationID, accountID int64, m
 	})
 }
 
-func (h *ResponsesHandler) handleModels(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"object": "list",
-		"data":   listModels(),
-	})
+func (h *ResponsesHandler) handleModels(w http.ResponseWriter, r *http.Request) {
+	h.handleModelsPassthrough(w, r, normalizedModelsPath(r.URL))
 }
 
 func (h *ResponsesHandler) handleModelDetail(w http.ResponseWriter, r *http.Request) {
-	modelID := pathBase(r.URL.Path)
-	for _, model := range listModels() {
-		if model["id"] == modelID {
-			writeJSON(w, http.StatusOK, model)
+	h.handleModelsPassthrough(w, r, normalizedModelsPath(r.URL))
+}
+
+func (h *ResponsesHandler) handleModelsPassthrough(w http.ResponseWriter, r *http.Request, endpointPath string) {
+	account, err := h.selectThinGatewayAccount()
+	if err != nil {
+		if errors.Is(err, errThinGatewayRequiresResponsesAccount) || errors.Is(err, errThinGatewayActiveAccountUnsupported) {
+			writeThinGatewayUnsupported(w, err.Error())
 			return
 		}
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
 	}
-	http.NotFound(w, r)
+
+	if err := ensureOfficialAccountSession(r.Context(), h.client, h.accounts, &account); err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	credential, err := resolveCredential(account)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	upstreamReq, err := h.buildThinModelsProxyRequest(r.Context(), account, credential, endpointPath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	resp, err := h.client.Do(upstreamReq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	copyResponseHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 }
 
 func writeThinGatewayFailure(w http.ResponseWriter, stream bool, statusCode int, err error) {
@@ -1337,31 +1392,6 @@ func parseResponsesJSONResponse(raw []byte, accountID int64) responsesExecutionR
 	}
 }
 
-func listModels() []map[string]any {
-	return []map[string]any{
-		buildModel("gpt-5.4", 272000, 32000),
-		buildModel("gpt-5.2-codex", 272000, 32000),
-		buildModel("gpt-5.1-codex-max", 272000, 32000),
-		buildModel("gpt-4.1", 128000, 16000),
-	}
-}
-
-func buildModel(id string, contextWindow int, maxOutputTokens int) map[string]any {
-	return map[string]any{
-		"id":                 id,
-		"object":             "model",
-		"owned_by":           "codex-router",
-		"context_window":     contextWindow,
-		"max_output_tokens":  maxOutputTokens,
-		"supports_responses": true,
-		"supports_streaming": true,
-		"supports_tools":     true,
-		"supports_reasoning": true,
-		"supports_vision":    false,
-		"default_endpoint":   "/v1/responses",
-	}
-}
-
 func decodeRawJSON(raw json.RawMessage) (any, bool) {
 	if len(raw) == 0 || strings.TrimSpace(string(raw)) == "" || strings.TrimSpace(string(raw)) == "null" {
 		return nil, false
@@ -1375,14 +1405,6 @@ func decodeRawJSON(raw json.RawMessage) (any, bool) {
 
 func isModelDetailPath(path string) bool {
 	return strings.HasPrefix(path, "/v1/models/") || strings.HasPrefix(path, "/models/")
-}
-
-func pathBase(path string) string {
-	parts := strings.Split(strings.Trim(path, "/"), "/")
-	if len(parts) == 0 {
-		return ""
-	}
-	return parts[len(parts)-1]
 }
 
 func responseInputItemType(raw map[string]any) string {

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -104,6 +104,92 @@ func TestResponsesHandlerThinModeThirdPartyResponsesAddsV1WhenBaseURLHasNoPath(t
 	}
 }
 
+func TestResponsesHandlerThinModeModelsPassthrough(t *testing.T) {
+	t.Parallel()
+
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-models" {
+			t.Fatalf("authorization = %q, want Bearer sk-models", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Upstream-Models", "direct")
+		_, _ = io.WriteString(w, `{"object":"list","data":[{"id":"upstream-model","object":"model","owned_by":"upstream"}]}`)
+	}))
+	defer upstream.Close()
+
+	handler := newResponsesHandlerTestHandler(t, accounts.Account{
+		ProviderType:      accounts.ProviderOpenAICompatible,
+		AccountName:       "models-provider",
+		AuthMode:          accounts.AuthModeAPIKey,
+		BaseURL:           upstream.URL,
+		CredentialRef:     "sk-models",
+		Status:            accounts.StatusActive,
+		Priority:          100,
+		SupportsResponses: true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if upstreamCalls != 1 {
+		t.Fatalf("upstreamCalls = %d, want 1", upstreamCalls)
+	}
+	if got := rec.Header().Get("X-Upstream-Models"); got != "direct" {
+		t.Fatalf("X-Upstream-Models = %q, want direct", got)
+	}
+	if !strings.Contains(rec.Body.String(), `"id":"upstream-model"`) {
+		t.Fatalf("body = %s, want upstream model", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `"owned_by":"codex-router"`) {
+		t.Fatalf("body = %s, want upstream payload without local model metadata", rec.Body.String())
+	}
+}
+
+func TestResponsesHandlerThinModeModelsPassthroughUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q, want /v1/models", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"model listing limited"}}`)
+	}))
+	defer upstream.Close()
+
+	handler := newResponsesHandlerTestHandler(t, accounts.Account{
+		ProviderType:      accounts.ProviderOpenAICompatible,
+		AccountName:       "models-provider",
+		AuthMode:          accounts.AuthModeAPIKey,
+		BaseURL:           upstream.URL,
+		CredentialRef:     "sk-models",
+		Status:            accounts.StatusActive,
+		Priority:          100,
+		SupportsResponses: true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusTooManyRequests, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"model listing limited"`) {
+		t.Fatalf("body = %s, want upstream error", rec.Body.String())
+	}
+}
+
 func TestResponsesHandlerThinModeRecordsUsageEventWithoutAuditRows(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -199,7 +199,9 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 	apiMux.Handle("/v1/responses", api.RequireProxyEnabled(responsesHandler))
 	apiMux.Handle("/v1/responses/", api.RequireProxyEnabled(responsesHandler))
 	apiMux.Handle("/models", api.RequireProxyEnabled(responsesHandler))
+	apiMux.Handle("/models/", api.RequireProxyEnabled(responsesHandler))
 	apiMux.Handle("/v1/models", api.RequireProxyEnabled(responsesHandler))
+	apiMux.Handle("/v1/models/", api.RequireProxyEnabled(responsesHandler))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/providers/codex/adapter.go
+++ b/backend/internal/providers/codex/adapter.go
@@ -29,6 +29,20 @@ func (a *Adapter) BuildResponsesRequest(ctx context.Context, credential string, 
 	return a.BuildResponsesEndpointRequest(ctx, credential, accountID, "/responses", body, stream)
 }
 
+func (a *Adapter) BuildModelsRequest(ctx context.Context, credential string, accountID string, endpointPath string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.baseURL+endpointPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+credential)
+	req.Header.Set("ChatGPT-Account-Id", accountID)
+	req.Header.Set("originator", codexOriginator)
+	req.Header.Set("User-Agent", codexUserAgent)
+	req.Header.Set("session_id", "codex-router-"+strconvTimeID())
+	return req, nil
+}
+
 func (a *Adapter) BuildResponsesEndpointRequest(ctx context.Context, credential string, accountID string, endpointPath string, body []byte, stream bool) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+endpointPath, bytes.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
## 变更
- 将 /models 与 /v1/models 改为透传当前可用上游账号
- 透传上游状态码、响应头和响应体
- 补充模型列表成功与上游错误透传测试

## 验证
- go test ./...
