### PR TITLE
修复统计日聚合与用量快照清理

### DIFF
--- a/backend/internal/api/accounts_handler.go
+++ b/backend/internal/api/accounts_handler.go
@@ -107,6 +107,10 @@ type AccountsUsage interface {
 	Save(snapshot usage.Snapshot) error
 }
 
+type accountUsageSnapshotCleaner interface {
+	DeleteSnapshotsForAccount(accountID int64) (int64, error)
+}
+
 type AccountsUsageRefresher interface {
 	Run(ctx context.Context, runAt time.Time) error
 }
@@ -1532,6 +1536,12 @@ func (h *AccountsHandler) deleteAccount(w http.ResponseWriter, r *http.Request) 
 	if err := h.repo.Delete(id); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	if cleaner, ok := h.usage.(accountUsageSnapshotCleaner); ok {
+		if _, err := cleaner.DeleteSnapshotsForAccount(id); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -760,6 +760,14 @@ func TestAccountsHandlerDeleteAccount(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create returned error: %v", err)
 	}
+	for _, snapshot := range []usage.Snapshot{
+		{AccountID: 1, CheckedAt: time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)},
+		{AccountID: 1, CheckedAt: time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC)},
+	} {
+		if err := usageRepo.Save(snapshot); err != nil {
+			t.Fatalf("Save snapshot returned error: %v", err)
+		}
+	}
 
 	deleteReq := httptest.NewRequest(http.MethodDelete, "/accounts/1", nil)
 	deleteRec := httptest.NewRecorder()
@@ -774,6 +782,13 @@ func TestAccountsHandlerDeleteAccount(t *testing.T) {
 	}
 	if len(listed) != 0 {
 		t.Fatalf("List returned %d accounts, want 0", len(listed))
+	}
+	var snapshotCount int
+	if err := store.DB().QueryRow(`SELECT COUNT(*) FROM account_usage_snapshots WHERE account_id = 1`).Scan(&snapshotCount); err != nil {
+		t.Fatalf("count snapshots returned error: %v", err)
+	}
+	if snapshotCount != 0 {
+		t.Fatalf("snapshots for deleted account = %d, want 0", snapshotCount)
 	}
 }
 

--- a/backend/internal/api/dashboard_handler.go
+++ b/backend/internal/api/dashboard_handler.go
@@ -157,6 +157,7 @@ func dashboardEventFilter(r *http.Request) usage.EventFilter {
 	filter.From = &from
 	filter.To = &to
 	filter.BucketSize = bucketSize
+	filter.BucketLocation = time.Local
 	filter.IncludeZeroes = true
 
 	if raw := query.Get("account_id"); raw != "" {

--- a/backend/internal/api/dashboard_handler_test.go
+++ b/backend/internal/api/dashboard_handler_test.go
@@ -166,6 +166,9 @@ func TestDashboardHandlerBuildsCalendarAlignedFilter(t *testing.T) {
 	if stub.lastFilter.BucketSize != time.Hour {
 		t.Fatalf("BucketSize = %v, want %v", stub.lastFilter.BucketSize, time.Hour)
 	}
+	if stub.lastFilter.BucketLocation != time.Local {
+		t.Fatalf("BucketLocation = %v, want time.Local", stub.lastFilter.BucketLocation)
+	}
 }
 
 func TestDashboardHandlerUsesPricingSettingsForCostCalculation(t *testing.T) {

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -63,7 +63,12 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	usageRepo := usage.NewSQLiteRepository(store.DB())
 	if err := cleanupLegacyAuditData(store.DB()); err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+	if err := cleanupUsageSnapshots(store.DB(), usageRepo, time.Now().UTC()); err != nil {
 		_ = store.Close()
 		return nil, err
 	}
@@ -79,7 +84,6 @@ func NewApp(_ context.Context, cfg Config) (*App, error) {
 
 	accountRepo := accounts.NewSQLiteRepository(store.DB(), credentialCipher)
 	settingsRepo := settings.NewSQLiteRepository(store.DB())
-	usageRepo := usage.NewSQLiteRepository(store.DB())
 	upstreamHTTPClient := netproxy.NewHTTPClient(settingsRepo)
 	conversationRepo := conversations.NewSQLiteRepository(store.DB())
 	policyRepo := policy.NewMemoryRepository()
@@ -321,6 +325,35 @@ func cleanupLegacyAuditData(db *sql.DB) error {
 		"done",
 	); err != nil {
 		return fmt.Errorf("mark maintenance state: %w", err)
+	}
+	return nil
+}
+
+type usageSnapshotCleaner interface {
+	CleanupSnapshots(now time.Time) (usage.SnapshotCleanupResult, error)
+}
+
+func cleanupUsageSnapshots(db *sql.DB, cleaner usageSnapshotCleaner, now time.Time) error {
+	if cleaner == nil {
+		return nil
+	}
+	result, err := cleaner.CleanupSnapshots(now.UTC())
+	if err != nil {
+		return err
+	}
+	deleted := result.OrphanDeleted + result.CompactedDeleted
+	if deleted > 0 {
+		if _, err := db.Exec(`VACUUM`); err != nil {
+			return fmt.Errorf("vacuum usage snapshot cleanup: %w", err)
+		}
+	}
+	if _, err := db.Exec(
+		`INSERT INTO maintenance_state (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP`,
+		"usage_snapshot_cleanup_last_run",
+		now.UTC().Format(time.RFC3339),
+	); err != nil {
+		return fmt.Errorf("mark usage snapshot cleanup: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/bootstrap/cleanup_test.go
+++ b/backend/internal/bootstrap/cleanup_test.go
@@ -3,8 +3,10 @@ package bootstrap
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	sqlitestore "github.com/gcssloop/codex-router/backend/internal/store/sqlite"
+	"github.com/gcssloop/codex-router/backend/internal/usage"
 )
 
 func TestCleanupLegacyAuditDataClearsRowsAndSetsMarker(t *testing.T) {
@@ -46,5 +48,54 @@ func TestCleanupLegacyAuditDataClearsRowsAndSetsMarker(t *testing.T) {
 	}
 	if marker != "done" {
 		t.Fatalf("marker = %q, want done", marker)
+	}
+}
+
+func TestCleanupUsageSnapshotsDeletesOrphansCompactsAndMarksMaintenance(t *testing.T) {
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	if _, err := store.DB().Exec(
+		`INSERT INTO accounts (id, provider_type, account_name, auth_mode, credential_ref, status)
+		 VALUES (1, 'openai-compatible', 'kept', 'api_key', 'sk', 'active')`,
+	); err != nil {
+		t.Fatalf("insert account returned error: %v", err)
+	}
+
+	usageRepo := usage.NewSQLiteRepository(store.DB())
+	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	for _, snapshot := range []usage.Snapshot{
+		{AccountID: 999, CheckedAt: now.Add(-1 * time.Hour)},
+		{AccountID: 1, CheckedAt: now.AddDate(0, 0, -10).Add(10 * time.Minute)},
+		{AccountID: 1, CheckedAt: now.AddDate(0, 0, -10).Add(20 * time.Minute)},
+	} {
+		if err := usageRepo.Save(snapshot); err != nil {
+			t.Fatalf("Save returned error: %v", err)
+		}
+	}
+
+	if err := cleanupUsageSnapshots(store.DB(), usageRepo, now); err != nil {
+		t.Fatalf("cleanupUsageSnapshots returned error: %v", err)
+	}
+
+	var count int
+	if err := store.DB().QueryRow(`SELECT COUNT(*) FROM account_usage_snapshots`).Scan(&count); err != nil {
+		t.Fatalf("count snapshots returned error: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("snapshot rows = %d, want 1", count)
+	}
+
+	var marker string
+	if err := store.DB().QueryRow(`SELECT value FROM maintenance_state WHERE key = 'usage_snapshot_cleanup_last_run'`).Scan(&marker); err != nil {
+		t.Fatalf("load maintenance marker returned error: %v", err)
+	}
+	if marker == "" {
+		t.Fatalf("usage snapshot cleanup marker is empty")
 	}
 }

--- a/backend/internal/usage/repository.go
+++ b/backend/internal/usage/repository.go
@@ -11,6 +11,8 @@ type Repository interface {
 	Save(snapshot Snapshot) error
 	GetLatest(accountID int64) (Snapshot, error)
 	ListLatest() ([]Snapshot, error)
+	DeleteSnapshotsForAccount(accountID int64) (int64, error)
+	CleanupSnapshots(now time.Time) (SnapshotCleanupResult, error)
 	SaveEvent(event Event) error
 	CompactEvents(now time.Time) error
 	ListRecentEvents(filter EventFilter) ([]Event, error)
@@ -170,6 +172,86 @@ func (r *SQLiteRepository) ListLatest() ([]Snapshot, error) {
 		return nil, fmt.Errorf("iterate latest usage snapshots: %w", err)
 	}
 	return snapshots, nil
+}
+
+func (r *SQLiteRepository) DeleteSnapshotsForAccount(accountID int64) (int64, error) {
+	result, err := r.db.Exec(`DELETE FROM account_usage_snapshots WHERE account_id = ?`, accountID)
+	if err != nil {
+		return 0, fmt.Errorf("delete usage snapshots for account: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read deleted usage snapshot rows: %w", err)
+	}
+	return deleted, nil
+}
+
+func (r *SQLiteRepository) CleanupSnapshots(now time.Time) (SnapshotCleanupResult, error) {
+	tx, err := r.db.Begin()
+	if err != nil {
+		return SnapshotCleanupResult{}, fmt.Errorf("begin usage snapshot cleanup: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var result SnapshotCleanupResult
+	orphanResult, err := tx.Exec(
+		`DELETE FROM account_usage_snapshots
+		 WHERE NOT EXISTS (
+			SELECT 1 FROM accounts WHERE accounts.id = account_usage_snapshots.account_id
+		 )`,
+	)
+	if err != nil {
+		return SnapshotCleanupResult{}, fmt.Errorf("delete orphan usage snapshots: %w", err)
+	}
+	result.OrphanDeleted, err = orphanResult.RowsAffected()
+	if err != nil {
+		return SnapshotCleanupResult{}, fmt.Errorf("read orphan usage snapshot rows: %w", err)
+	}
+
+	recentCutoff := now.UTC().AddDate(0, 0, -7)
+	midCutoff := now.UTC().AddDate(0, 0, -30)
+	compactResult, err := tx.Exec(
+		`DELETE FROM account_usage_snapshots
+		 WHERE id IN (
+			SELECT id FROM (
+				SELECT id,
+					CASE
+						WHEN checked_at >= ? THEN 1
+						WHEN checked_at >= ? THEN ROW_NUMBER() OVER (
+							PARTITION BY account_id, substr(checked_at, 1, 13)
+							ORDER BY checked_at DESC, id DESC
+						)
+						ELSE ROW_NUMBER() OVER (
+							PARTITION BY account_id, substr(checked_at, 1, 10)
+							ORDER BY checked_at DESC, id DESC
+						)
+					END AS keep_rank
+				FROM account_usage_snapshots
+				WHERE EXISTS (
+					SELECT 1 FROM accounts WHERE accounts.id = account_usage_snapshots.account_id
+				)
+			)
+			WHERE keep_rank > 1
+		 )`,
+		recentCutoff,
+		midCutoff,
+	)
+	if err != nil {
+		return SnapshotCleanupResult{}, fmt.Errorf("compact usage snapshots: %w", err)
+	}
+	result.CompactedDeleted, err = compactResult.RowsAffected()
+	if err != nil {
+		return SnapshotCleanupResult{}, fmt.Errorf("read compacted usage snapshot rows: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return SnapshotCleanupResult{}, fmt.Errorf("commit usage snapshot cleanup: %w", err)
+	}
+	return result, nil
 }
 
 func (r *SQLiteRepository) SaveEvent(event Event) error {

--- a/backend/internal/usage/repository.go
+++ b/backend/internal/usage/repository.go
@@ -214,7 +214,7 @@ func (r *SQLiteRepository) CompactEvents(now time.Time) error {
 	}()
 
 	hourlyCutoff := now.UTC().AddDate(0, 0, -7).Truncate(time.Hour)
-	dailyCutoff := time.Date(now.UTC().Year(), now.UTC().Month(), now.UTC().Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -30)
+	dailyCutoff := addLocalDays(localDayStartUTC(now.UTC(), time.Local), time.Local, -30)
 
 	if err = compactRawEventsToHourly(tx, dailyCutoff, hourlyCutoff); err != nil {
 		return err
@@ -309,13 +309,14 @@ func (r *SQLiteRepository) TrendEventsByHour(filter EventFilter) ([]TrendPoint, 
 		bucketSize = time.Hour
 	}
 
+	location := trendBucketLocation(filter)
 	points, indexByBucket := initializeTrendBuckets(filter, bucketSize)
 	for _, row := range rows {
 		bucket := row.BucketStart.UTC()
 		if bucketSize == time.Hour {
 			bucket = bucket.Truncate(time.Hour)
 		} else {
-			bucket = time.Date(bucket.Year(), bucket.Month(), bucket.Day(), 0, 0, 0, 0, time.UTC)
+			bucket = localDayStartUTC(bucket, location)
 		}
 		idx, ok := indexByBucket[bucket]
 		if !ok {
@@ -358,13 +359,32 @@ func initializeTrendBuckets(filter EventFilter, bucketSize time.Duration) ([]Tre
 	}
 	points := make([]TrendPoint, 0)
 	indexByBucket := make(map[time.Time]int)
-	for cursor := filter.From.UTC(); cursor.Before(filter.To.UTC()); cursor = cursor.Add(bucketSize) {
-		bucket := cursor
-		if bucketSize == time.Hour {
-			bucket = bucket.Truncate(time.Hour)
-		} else {
-			bucket = time.Date(bucket.Year(), bucket.Month(), bucket.Day(), 0, 0, 0, 0, time.UTC)
+	if bucketSize == time.Hour {
+		for cursor := filter.From.UTC(); cursor.Before(filter.To.UTC()); cursor = cursor.Add(bucketSize) {
+			bucket := cursor.Truncate(time.Hour)
+			if _, exists := indexByBucket[bucket]; exists {
+				continue
+			}
+			points = append(points, TrendPoint{Bucket: bucket})
+			indexByBucket[bucket] = len(points) - 1
 		}
+		return points, indexByBucket
+	}
+
+	location := trendBucketLocation(filter)
+	if filter.BucketLocation == nil {
+		for cursor := filter.From.UTC(); cursor.Before(filter.To.UTC()); cursor = cursor.Add(bucketSize) {
+			bucket := localDayStartUTC(cursor, location)
+			if _, exists := indexByBucket[bucket]; exists {
+				continue
+			}
+			points = append(points, TrendPoint{Bucket: bucket})
+			indexByBucket[bucket] = len(points) - 1
+		}
+		return points, indexByBucket
+	}
+	for cursor := localDayStartUTC(*filter.From, location); cursor.Before(filter.To.UTC()); cursor = nextLocalDayStartUTC(cursor, location) {
+		bucket := cursor
 		if _, exists := indexByBucket[bucket]; exists {
 			continue
 		}
@@ -372,6 +392,34 @@ func initializeTrendBuckets(filter EventFilter, bucketSize time.Duration) ([]Tre
 		indexByBucket[bucket] = len(points) - 1
 	}
 	return points, indexByBucket
+}
+
+func trendBucketLocation(filter EventFilter) *time.Location {
+	if filter.BucketLocation != nil {
+		return filter.BucketLocation
+	}
+	return time.UTC
+}
+
+func localDayStartUTC(value time.Time, location *time.Location) time.Time {
+	if location == nil {
+		location = time.UTC
+	}
+	local := value.In(location)
+	return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, location).UTC()
+}
+
+func nextLocalDayStartUTC(value time.Time, location *time.Location) time.Time {
+	return addLocalDays(value, location, 1)
+}
+
+func addLocalDays(value time.Time, location *time.Location, days int) time.Time {
+	if location == nil {
+		location = time.UTC
+	}
+	local := value.In(location)
+	next := time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, location).AddDate(0, 0, days)
+	return next.UTC()
 }
 
 func calculateCost(filter EventFilter, row RollupPoint) float64 {
@@ -694,7 +742,7 @@ func compactHourlyRollupsToDaily(tx *sql.Tx, cutoff time.Time) error {
 		); err != nil {
 			return fmt.Errorf("scan hourly rollups for compaction: %w", err)
 		}
-		bucket := time.Date(point.BucketStart.UTC().Year(), point.BucketStart.UTC().Month(), point.BucketStart.UTC().Day(), 0, 0, 0, 0, time.UTC)
+		bucket := localDayStartUTC(point.BucketStart, time.Local)
 		key := aggregateKey(bucket, point.AccountID, point.ProviderType, point.RequestKind, point.Model)
 		current := buckets[key]
 		current.BucketStart = bucket

--- a/backend/internal/usage/repository_test.go
+++ b/backend/internal/usage/repository_test.go
@@ -177,6 +177,112 @@ func TestSQLiteRepositoryListLatest(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepositoryDeleteSnapshotsForAccount(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	repo := usage.NewSQLiteRepository(store.DB())
+	for _, snapshot := range []usage.Snapshot{
+		{AccountID: 1, CheckedAt: time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)},
+		{AccountID: 1, CheckedAt: time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC)},
+		{AccountID: 2, CheckedAt: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)},
+	} {
+		if err := repo.Save(snapshot); err != nil {
+			t.Fatalf("Save returned error: %v", err)
+		}
+	}
+
+	deleted, err := repo.DeleteSnapshotsForAccount(1)
+	if err != nil {
+		t.Fatalf("DeleteSnapshotsForAccount returned error: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+
+	var count int
+	if err := store.DB().QueryRow(`SELECT COUNT(*) FROM account_usage_snapshots WHERE account_id = 1`).Scan(&count); err != nil {
+		t.Fatalf("count account 1 returned error: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("account 1 snapshots = %d, want 0", count)
+	}
+	if err := store.DB().QueryRow(`SELECT COUNT(*) FROM account_usage_snapshots WHERE account_id = 2`).Scan(&count); err != nil {
+		t.Fatalf("count account 2 returned error: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("account 2 snapshots = %d, want 1", count)
+	}
+}
+
+func TestSQLiteRepositoryCleanupSnapshotsDeletesOrphansAndCompactsHistory(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	if _, err := store.DB().Exec(
+		`INSERT INTO accounts (id, provider_type, account_name, auth_mode, credential_ref, status)
+		 VALUES (1, 'openai-compatible', 'kept', 'api_key', 'sk', 'active')`,
+	); err != nil {
+		t.Fatalf("insert account returned error: %v", err)
+	}
+
+	repo := usage.NewSQLiteRepository(store.DB())
+	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	snapshots := []usage.Snapshot{
+		{AccountID: 999, CheckedAt: now.Add(-1 * time.Hour)},
+		{AccountID: 1, CheckedAt: now.Add(-1 * time.Hour)},
+		{AccountID: 1, CheckedAt: now.Add(-2 * time.Hour)},
+		{AccountID: 1, CheckedAt: now.AddDate(0, 0, -10).Add(10 * time.Minute)},
+		{AccountID: 1, CheckedAt: now.AddDate(0, 0, -10).Add(20 * time.Minute)},
+		{AccountID: 1, CheckedAt: now.AddDate(0, 0, -40).Add(1 * time.Hour)},
+		{AccountID: 1, CheckedAt: now.AddDate(0, 0, -40).Add(2 * time.Hour)},
+	}
+	for _, snapshot := range snapshots {
+		if err := repo.Save(snapshot); err != nil {
+			t.Fatalf("Save returned error: %v", err)
+		}
+	}
+
+	result, err := repo.CleanupSnapshots(now)
+	if err != nil {
+		t.Fatalf("CleanupSnapshots returned error: %v", err)
+	}
+	if result.OrphanDeleted != 1 {
+		t.Fatalf("OrphanDeleted = %d, want 1", result.OrphanDeleted)
+	}
+	if result.CompactedDeleted != 2 {
+		t.Fatalf("CompactedDeleted = %d, want 2", result.CompactedDeleted)
+	}
+
+	var count int
+	if err := store.DB().QueryRow(`SELECT COUNT(*) FROM account_usage_snapshots WHERE account_id = 999`).Scan(&count); err != nil {
+		t.Fatalf("count orphan returned error: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("orphan snapshots = %d, want 0", count)
+	}
+	if err := store.DB().QueryRow(`SELECT COUNT(*) FROM account_usage_snapshots WHERE account_id = 1`).Scan(&count); err != nil {
+		t.Fatalf("count kept returned error: %v", err)
+	}
+	if count != 4 {
+		t.Fatalf("kept account snapshots = %d, want 4", count)
+	}
+}
+
 func TestSQLiteRepositorySaveEventListRecentAndSummarize(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usage/repository_test.go
+++ b/backend/internal/usage/repository_test.go
@@ -390,6 +390,65 @@ func TestSQLiteRepositoryTrendEventsByDayIncludesSingleBucketPerDay(t *testing.T
 	}
 }
 
+func TestSQLiteRepositoryTrendEventsByDayUsesBucketLocation(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	repo := usage.NewSQLiteRepository(store.DB())
+	for _, event := range []usage.Event{
+		{
+			AccountID:    1,
+			ProviderType: "codex",
+			RequestKind:  "responses",
+			Model:        "gpt-5.4",
+			Status:       "completed",
+			CreatedAt:    time.Date(2026, 6, 3, 17, 0, 0, 0, time.UTC),
+		},
+		{
+			AccountID:    1,
+			ProviderType: "codex",
+			RequestKind:  "responses",
+			Model:        "gpt-5.4",
+			Status:       "completed",
+			CreatedAt:    time.Date(2026, 6, 4, 15, 0, 0, 0, time.UTC),
+		},
+	} {
+		if err := repo.SaveEvent(event); err != nil {
+			t.Fatalf("SaveEvent returned error: %v", err)
+		}
+	}
+
+	location := time.FixedZone("CST", 8*3600)
+	from := time.Date(2026, 6, 4, 0, 0, 0, 0, location).UTC()
+	to := time.Date(2026, 6, 5, 0, 0, 0, 0, location).UTC()
+	points, err := repo.TrendEventsByHour(usage.EventFilter{
+		From:           &from,
+		To:             &to,
+		BucketSize:     24 * time.Hour,
+		BucketLocation: location,
+		IncludeZeroes:  true,
+	})
+	if err != nil {
+		t.Fatalf("TrendEventsByHour returned error: %v", err)
+	}
+	if len(points) != 1 {
+		t.Fatalf("len(points) = %d, want 1 local day bucket", len(points))
+	}
+	if !points[0].Bucket.Equal(from) {
+		t.Fatalf("bucket = %v, want local day start %v", points[0].Bucket, from)
+	}
+	if points[0].RequestCount != 2 {
+		t.Fatalf("request_count = %d, want both requests in the same local day", points[0].RequestCount)
+	}
+}
+
 func TestSQLiteRepositoryModelDistribution(t *testing.T) {
 	t.Parallel()
 
@@ -598,6 +657,70 @@ func TestSQLiteRepositoryCompactsEventsIntoRollups(t *testing.T) {
 	}
 	if len(trends) != 2 {
 		t.Fatalf("len(trends) = %d, want 2", len(trends))
+	}
+}
+
+func TestSQLiteRepositoryCompactsDailyRollupsByLocalDay(t *testing.T) {
+	previousLocal := time.Local
+	time.Local = time.FixedZone("CST", 8*3600)
+	t.Cleanup(func() {
+		time.Local = previousLocal
+	})
+
+	store, err := sqlitestore.Open(filepath.Join(t.TempDir(), "router.sqlite"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	repo := usage.NewSQLiteRepository(store.DB())
+	firstCompaction := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	secondCompaction := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	for _, event := range []usage.Event{
+		{
+			AccountID:    1,
+			ProviderType: "codex",
+			RequestKind:  "responses",
+			Model:        "gpt-5.4",
+			Status:       "completed",
+			CreatedAt:    time.Date(2026, 5, 1, 17, 0, 0, 0, time.UTC),
+		},
+		{
+			AccountID:    1,
+			ProviderType: "codex",
+			RequestKind:  "responses",
+			Model:        "gpt-5.4",
+			Status:       "completed",
+			CreatedAt:    time.Date(2026, 5, 2, 15, 0, 0, 0, time.UTC),
+		},
+	} {
+		if err := repo.SaveEvent(event); err != nil {
+			t.Fatalf("SaveEvent returned error: %v", err)
+		}
+	}
+
+	if err := repo.CompactEvents(firstCompaction); err != nil {
+		t.Fatalf("first CompactEvents returned error: %v", err)
+	}
+	if err := repo.CompactEvents(secondCompaction); err != nil {
+		t.Fatalf("second CompactEvents returned error: %v", err)
+	}
+
+	var bucketStart time.Time
+	var requestCount int64
+	if err := store.DB().QueryRow(
+		`SELECT bucket_start, request_count FROM usage_rollups_daily ORDER BY bucket_start LIMIT 1`,
+	).Scan(&bucketStart, &requestCount); err != nil {
+		t.Fatalf("query daily rollup returned error: %v", err)
+	}
+	wantBucket := time.Date(2026, 5, 2, 0, 0, 0, 0, time.Local).UTC()
+	if !bucketStart.Equal(wantBucket) {
+		t.Fatalf("daily bucket_start = %v, want local day start %v", bucketStart, wantBucket)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request_count = %d, want both requests in the same local day", requestCount)
 	}
 }
 

--- a/backend/internal/usage/types.go
+++ b/backend/internal/usage/types.go
@@ -60,6 +60,11 @@ type EventFilter struct {
 	CostCalculator func(accountID int64, providerType string, model string, inputTokens int64, outputTokens int64) float64
 }
 
+type SnapshotCleanupResult struct {
+	OrphanDeleted    int64
+	CompactedDeleted int64
+}
+
 type EventSummary struct {
 	RequestCount  int64   `json:"request_count"`
 	SuccessCount  int64   `json:"success_count"`

--- a/backend/internal/usage/types.go
+++ b/backend/internal/usage/types.go
@@ -55,6 +55,7 @@ type EventFilter struct {
 	Model          string
 	Limit          int
 	BucketSize     time.Duration
+	BucketLocation *time.Location
 	IncludeZeroes  bool
 	CostCalculator func(accountID int64, providerType string, model string, inputTokens int64, outputTokens int64) float64
 }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.5.8",
+  "version": "1.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.5.8",
+      "version": "1.5.10",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.5.8",
+  "version": "1.5.10",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.5.8"
+version = "1.5.10"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.5.8"
+version = "1.5.10"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.5.8",
+  "version": "1.5.10",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.5.8",
+  "version": "1.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.5.8",
+      "version": "1.5.10",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.5.8",
+  "version": "1.5.10",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 变更

- 统计趋势按本地自然日聚合显示，并让 daily rollup 使用本地自然日。
- 删除账号时清理对应用量快照。
- 应用启动时删除 orphan snapshots，并按 7 天全量、30 天内每小时、30 天以上每天保留的策略压缩快照历史。
- 准备 1.5.10 发布元数据。

## 验证

- cd backend && go test ./...
- bash scripts/test/sync_release_metadata_test.sh
- GitHub Actions Dev CI: https://github.com/GcsSloop/ai-gate/actions/runs/26992416415
