### PR TITLE
增加统计页年度范围

### DIFF
--- a/backend/internal/api/dashboard_handler.go
+++ b/backend/internal/api/dashboard_handler.go
@@ -193,6 +193,10 @@ func resolveDashboardRange(now time.Time, rangeKey string) (time.Time, time.Time
 		end := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
 		start := end.AddDate(0, 0, -30)
 		return start.UTC(), end.UTC(), 24 * time.Hour
+	case "1y":
+		end := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
+		start := end.AddDate(-1, 0, 0)
+		return start.UTC(), end.UTC(), 24 * time.Hour
 	default:
 		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 		end := start.Add(24 * time.Hour)

--- a/backend/internal/api/dashboard_handler_test.go
+++ b/backend/internal/api/dashboard_handler_test.go
@@ -171,6 +171,46 @@ func TestDashboardHandlerBuildsCalendarAlignedFilter(t *testing.T) {
 	}
 }
 
+func TestDashboardHandlerBuildsYearlyCalendarAlignedFilter(t *testing.T) {
+	t.Setenv("TZ", "Asia/Shanghai")
+	now := time.Date(2026, 6, 16, 9, 30, 0, 0, time.FixedZone("CST", 8*3600))
+	previousLocal := time.Local
+	time.Local = now.Location()
+	defer func() {
+		time.Local = previousLocal
+	}()
+
+	stub := &dashboardUsageStub{
+		summary: usage.EventSummary{RequestCount: 1},
+	}
+	handler := api.NewDashboardHandler(stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary?range=1y", nil)
+	rec := httptest.NewRecorder()
+
+	restore := api.SetDashboardNowForTest(func() time.Time { return now })
+	defer restore()
+
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /dashboard/summary status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if stub.lastFilter.From == nil || stub.lastFilter.To == nil {
+		t.Fatalf("expected filter bounds to be set")
+	}
+	wantFrom := time.Date(2025, 6, 16, 16, 0, 0, 0, time.UTC)
+	wantTo := time.Date(2026, 6, 16, 16, 0, 0, 0, time.UTC)
+	if !stub.lastFilter.From.Equal(wantFrom) || !stub.lastFilter.To.Equal(wantTo) {
+		t.Fatalf("filter bounds = %v..%v, want %v..%v", stub.lastFilter.From, stub.lastFilter.To, wantFrom, wantTo)
+	}
+	if stub.lastFilter.BucketSize != 24*time.Hour {
+		t.Fatalf("BucketSize = %v, want %v", stub.lastFilter.BucketSize, 24*time.Hour)
+	}
+	if stub.lastFilter.BucketLocation != time.Local {
+		t.Fatalf("BucketLocation = %v, want time.Local", stub.lastFilter.BucketLocation)
+	}
+}
+
 func TestDashboardHandlerBuildsServerUserFilter(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/src/features/stats/StatsPage.test.tsx
+++ b/frontend/src/features/stats/StatsPage.test.tsx
@@ -130,4 +130,17 @@ describe("StatsPage", () => {
       expect(getDashboardRecentEvents).toHaveBeenLastCalledWith("24h", undefined, "", 20, 11);
     });
   });
+
+  it("loads yearly dashboard statistics when the yearly range is selected", async () => {
+    render(<StatsPage language="zh-CN" t={t} />);
+
+    fireEvent.click(await screen.findByText("1y"));
+
+    await waitFor(() => {
+      expect(getDashboardSummary).toHaveBeenLastCalledWith("1y", undefined, "", undefined);
+      expect(getDashboardTrends).toHaveBeenLastCalledWith("1y", undefined, "", undefined);
+      expect(getDashboardModelDistribution).toHaveBeenLastCalledWith("1y", undefined, "", undefined);
+      expect(getDashboardRecentEvents).toHaveBeenLastCalledWith("1y", undefined, "", 20, undefined);
+    });
+  });
 });

--- a/frontend/src/features/stats/StatsPage.tsx
+++ b/frontend/src/features/stats/StatsPage.tsx
@@ -164,6 +164,7 @@ export function StatsPage({ language, t, serverMode = false }: StatsPageProps) {
               { label: "24h", value: "24h" },
               { label: "7d", value: "7d" },
               { label: "30d", value: "30d" },
+              { label: "1y", value: "1y" },
             ]}
             value={rangeHours}
             onChange={(value) => setRangeHours(value as RangeOption)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -623,7 +623,7 @@ export async function importSharedAccount(payload: string): Promise<void> {
   }
 }
 
-export type DashboardRangeKey = "24h" | "7d" | "30d";
+export type DashboardRangeKey = "24h" | "7d" | "30d" | "1y";
 
 function dashboardQuery(
   range: DashboardRangeKey = "24h",


### PR DESCRIPTION
## 变更
- 统计页新增 `1y` 年度范围选项
- 后端 dashboard range 支持最近一年本地日历对齐窗口
- 趋势图年度统计使用每日 bucket

## 验证
- npm --prefix frontend test
- cd backend && go test ./...
- npm --prefix frontend run build
- server-dev 内置浏览器验证统计页 `1y` 可见且可选中