### PR TITLE
取消官方账号余量预跳过限制

### DIFF
--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -32,7 +32,6 @@ import (
 
 const officialCodexBaseURL = "https://chatgpt.com/backend-api/codex"
 const defaultCodexInstructions = "You are Codex, a coding agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals. Be pragmatic, concise, and focus on completing the user's task."
-const thinResponsesOfficialLowRemainingThreshold = 3.0
 const thinResponsesCapacityCooldownWindow = 3 * time.Minute
 const thinResponsesRateLimitCooldownWindow = 1 * time.Minute
 const activeAccountFailoverRetryAttempts = 3
@@ -958,25 +957,7 @@ func (h *ResponsesHandler) skipReasonForThinCandidate(candidate routing.Candidat
 	if candidate.Account.RoutingCooldownActive(now) && !candidate.Account.IsActive {
 		return "routing_cooldown", true
 	}
-	if officialRemainingBelowThreshold(candidate) {
-		return "official_remaining_below_3pct", true
-	}
 	return "", false
-}
-
-func officialRemainingBelowThreshold(candidate routing.Candidate) bool {
-	if !usesOfficialCodexAdapter(candidate.Account) {
-		return false
-	}
-	primaryRemaining := 100 - candidate.Snapshot.PrimaryUsedPercent
-	secondaryRemaining := 100 - candidate.Snapshot.SecondaryUsedPercent
-	if candidate.Snapshot.PrimaryResetsAt != nil && primaryRemaining < thinResponsesOfficialLowRemainingThreshold {
-		return true
-	}
-	if candidate.Snapshot.SecondaryResetsAt != nil && secondaryRemaining < thinResponsesOfficialLowRemainingThreshold {
-		return true
-	}
-	return false
 }
 
 func shouldCooldownThinCandidate(candidate routing.Candidate, reason string) bool {
@@ -1034,7 +1015,7 @@ func (h *ResponsesHandler) publishAccountRoutingStateChanged() {
 func computeThinCandidateCooldownUntil(snapshot usage.Snapshot, reason string) *time.Time {
 	now := time.Now().UTC()
 	switch reason {
-	case "official_remaining_below_3pct", "usage_limited", "capacity_failed":
+	case "usage_limited", "capacity_failed":
 		resetAt := relevantOfficialResetAt(snapshot)
 		until := routing.ComputeCooldownUntil(now, routing.CooldownReasonCapacity, resetAt, thinResponsesCapacityCooldownWindow)
 		return &until
@@ -1058,17 +1039,7 @@ func latestRelevantResetAt(snapshot usage.Snapshot) *time.Time {
 }
 
 func relevantOfficialResetAt(snapshot usage.Snapshot) *time.Time {
-	var candidates []*time.Time
-	if snapshot.PrimaryResetsAt != nil && 100-snapshot.PrimaryUsedPercent < thinResponsesOfficialLowRemainingThreshold {
-		candidates = append(candidates, snapshot.PrimaryResetsAt)
-	}
-	if snapshot.SecondaryResetsAt != nil && 100-snapshot.SecondaryUsedPercent < thinResponsesOfficialLowRemainingThreshold {
-		candidates = append(candidates, snapshot.SecondaryResetsAt)
-	}
-	if len(candidates) == 0 {
-		return latestRelevantResetAt(snapshot)
-	}
-	return latestResetAtFor(candidates...)
+	return latestRelevantResetAt(snapshot)
 }
 
 func latestResetAtFor(candidates ...*time.Time) *time.Time {

--- a/backend/internal/api/responses_handler_test.go
+++ b/backend/internal/api/responses_handler_test.go
@@ -1653,14 +1653,14 @@ func TestResponsesHandlerThinModeFailsOverAfterThirdPartyForbiddenQuotaError(t *
 	}
 }
 
-func TestResponsesHandlerThinModeSkipsOfficialBelowRemainingThreshold(t *testing.T) {
+func TestResponsesHandlerThinModeAttemptsOfficialWithLowWindowRemaining(t *testing.T) {
 	t.Parallel()
 
 	primaryCalls := 0
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		primaryCalls++
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"id":"resp_should_not_run","object":"response","status":"completed","output_text":"should-not-run"}`)
+		_, _ = io.WriteString(w, `{"id":"resp_low_remaining","object":"response","status":"completed","output_text":"low-remaining-primary"}`)
 	}))
 	defer primary.Close()
 
@@ -1762,14 +1762,14 @@ func TestResponsesHandlerThinModeSkipsOfficialBelowRemainingThreshold(t *testing
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), `"output_text":"threshold-fallback"`) {
-		t.Fatalf("body = %s, want threshold fallback output", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), `"output_text":"low-remaining-primary"`) {
+		t.Fatalf("body = %s, want primary output", rec.Body.String())
 	}
-	if primaryCalls != 0 {
-		t.Fatalf("primaryCalls = %d, want 0", primaryCalls)
+	if primaryCalls != 1 {
+		t.Fatalf("primaryCalls = %d, want 1", primaryCalls)
 	}
-	if secondaryCalls != 1 {
-		t.Fatalf("secondaryCalls = %d, want 1", secondaryCalls)
+	if secondaryCalls != 0 {
+		t.Fatalf("secondaryCalls = %d, want 0", secondaryCalls)
 	}
 }
 

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -104,7 +104,6 @@ const statusTextMap: Record<string, string> = {
 };
 
 const routingCooldownTextMap: Record<string, string> = {
-  official_remaining_below_3pct: "路由冷却",
   usage_limited: "路由冷却",
   capacity_failed: "路由冷却",
   rate_limited: "路由冷却",


### PR DESCRIPTION
## 变更
- 移除官方账号低窗口剩余时的预跳过逻辑
- 低余量账号仍会请求上游，只有上游真实返回容量或限流错误时才走现有 failover/cooldown
- 删除前端不可达的旧路由冷却原因文案

## 验证
- cd backend && go test ./internal/api -run 'TestResponsesHandlerThinModeAttemptsOfficialWithLowWindowRemaining|TestResponsesHandlerThinModeFailover' -count=1\n- npm --prefix frontend test -- AccountsPage.test.tsx\n- cd backend && go test ./...