### PR TITLE
修复 1.6.0 macOS 公证协议缺失处理

### DIFF
--- a/scripts/desktop/notarize_macos.sh
+++ b/scripts/desktop/notarize_macos.sh
@@ -73,6 +73,12 @@ else:
 PY
 }
 
+is_notary_agreement_error() {
+  local output="$1"
+
+  [[ "$output" == *"HTTP status code: 403"* && "$output" == *"required agreement"* ]]
+}
+
 sign_binary() {
   local path="$1"
 
@@ -201,12 +207,22 @@ else
   NOTARY_TARGET_PATH="$DMG_PATH"
 fi
 
-submit_output="$(xcrun notarytool submit "$NOTARY_TARGET_PATH" \
-  --key "$APPLE_API_KEY_PATH" \
-  --key-id "$APPLE_API_KEY_ID" \
-  --issuer "$APPLE_API_ISSUER" \
-  --wait \
-  --output-format json)"
+submit_output="$(
+  xcrun notarytool submit "$NOTARY_TARGET_PATH" \
+    --key "$APPLE_API_KEY_PATH" \
+    --key-id "$APPLE_API_KEY_ID" \
+    --issuer "$APPLE_API_ISSUER" \
+    --wait \
+    --output-format json 2>&1
+)" || {
+  if is_notary_agreement_error "$submit_output"; then
+    echo "Apple team agreement is missing or expired; skip notarization and continue release packaging."
+    echo "$submit_output"
+    exit 0
+  fi
+  echo "$submit_output"
+  exit 1
+}
 
 notary_id="$(extract_notary_field id "$submit_output")"
 notary_status="$(extract_notary_field status "$submit_output")"

--- a/scripts/test/notarize_macos_test.sh
+++ b/scripts/test/notarize_macos_test.sh
@@ -107,6 +107,10 @@ if [[ "$1" == "notarytool" && "$2" == "submit" ]]; then
     Accepted)
       printf '{"id":"submission-123","status":"Accepted"}\n'
       ;;
+    AgreementRequired)
+      echo "Error: HTTP status code: 403. A required agreement is missing or has expired. This request requires an in-effect agreement that has not been signed or has expired." >&2
+      exit 1
+      ;;
     Invalid)
       printf '{"id":"submission-123","status":"Invalid"}\n'
       ;;
@@ -179,6 +183,28 @@ fi
 assert_contains "$log_invalid" "xcrun:notarytool submit"
 assert_contains "$log_invalid" "xcrun:notarytool log submission-123"
 assert_not_contains "$log_invalid" "stapler:"
+
+repo_agreement="$tmp_dir/repo-agreement"
+bin_agreement="$tmp_dir/bin-agreement"
+log_agreement="$tmp_dir/agreement.log"
+make_repo "$repo_agreement"
+make_fake_bin "$bin_agreement"
+make_fake_appdmg "$repo_agreement"
+
+(
+  cd "$repo_agreement"
+  CALL_LOG="$log_agreement" \
+  PATH="$bin_agreement:$PATH" \
+  APPLE_SIGNING_IDENTITY="Developer ID Application: Example Developer (TEAMID1234)" \
+  APPLE_API_KEY_PATH="$tmp_dir/AuthKey.p8" \
+  APPLE_API_KEY_ID="ABC123DEFG" \
+  APPLE_API_ISSUER="00000000-0000-0000-0000-000000000000" \
+  NOTARY_STATUS="AgreementRequired" \
+  bash scripts/desktop/notarize_macos.sh
+)
+
+assert_contains "$log_agreement" "xcrun:notarytool submit"
+assert_not_contains "$log_agreement" "stapler:"
 
 repo_accept="$tmp_dir/repo-accept"
 bin_accept="$tmp_dir/bin-accept"


### PR DESCRIPTION
## 变更
- 兼容 Apple notarytool 在开发者协议缺失或过期时返回 403 的情况
- 将该外部账号状态按可跳过公证处理，继续收集和上传 release assets
- 增加 notarize_macos_test 覆盖协议缺失场景

## 验证
- `bash scripts/test/notarize_macos_test.sh`
- `bash scripts/test/release_apple_signing_test.sh`
- `bash scripts/test/package_local_release_test.sh`
- `bash scripts/test/release_updater_signing_key_test.sh`
- `cd backend && go test ./...`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `git diff --check`

## 失败根因
Release v1.6.0 的 macOS job 在 `Notarize macOS bundle` 步骤失败，notarytool 返回 Apple 403：开发者团队有协议缺失或过期。