### PR TITLE
chore: 同步发布版本 1.6.3

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 变更
- 同步 frontend、desktop、Tauri、Cargo 版本元数据到 1.6.3

## 验证
- bash scripts/test/desktop_updater_config_test.sh
- bash scripts/test/go_test_with_retry_test.sh
- bash scripts/test/release_no_apple_signing_test.sh
- bash scripts/test/release_updater_signing_key_test.sh
- bash scripts/test/release_version_helpers_test.sh
- bash scripts/test/sync_release_metadata_test.sh
- bash scripts/test/collect_release_assets_test.sh
- bash scripts/test/release_updater_manifest_test.sh
- bash scripts/test/package_local_release_test.sh
- bash scripts/test/release_msvc_spub_test.sh
- bash scripts/test/build_ai_gate_msvc_test.sh
- cargo metadata --manifest-path desktop/src-tauri/Cargo.toml --locked --format-version 1