### PR TITLE
ci: 修复无 DMG 发布流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,6 @@ jobs:
           generate_release_notes: true
           files: |
             dist/**/*.zip
-            dist/**/*.dmg
             dist/**/*.msi
             dist/**/*.msi.sig
             dist/**/*.msvc

--- a/README.md
+++ b/README.md
@@ -307,6 +307,5 @@ bash scripts/desktop/collect_release_assets.sh
 
 产物会出现在 `release-assets/`：
 
-- `aigate-<tag>-macOS.dmg`
 - `aigate-<tag>-macOS.zip`
 - `aigate-<tag>-darwin-universal.app.tar.gz`

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -267,6 +267,5 @@ bash scripts/desktop/collect_release_assets.sh
 
 Release assets are collected in `release-assets/`:
 
-- `aigate-<tag>-macOS.dmg`
 - `aigate-<tag>-macOS.zip`
 - `aigate-<tag>-darwin-universal.app.tar.gz`

--- a/scripts/test/release_no_apple_signing_test.sh
+++ b/scripts/test/release_no_apple_signing_test.sh
@@ -32,5 +32,6 @@ assert_workflows_not_contains "security create-keychain"
 assert_workflows_not_contains "security import"
 assert_workflows_not_contains "security unlock-keychain"
 assert_workflows_not_contains "security set-key-partition-list"
+assert_workflows_not_contains "dist/**/*.dmg"
 
 echo "PASS: release_no_apple_signing_test"


### PR DESCRIPTION
## 根因
- v1.6.3 Release 的 macOS / Windows / server plugin 构建都成功。
- publish job 在 Publish GitHub release 步骤失败，错误为：Pattern 'dist/**/*.dmg' does not match any files.
- CI 已移除 Apple notarization 后不再调用生成 DMG 的脚本，macOS release assets 只包含 zip 和 updater 包。

## 变更
- 从 GitHub Release 必需上传列表中移除 dist/**/*.dmg。
- 增加 release_no_apple_signing_test.sh 断言，防止 DMG 必需匹配回到 workflow。
- 更新中英文 README 的 macOS release asset 列表。

## 验证
- bash scripts/test/release_no_apple_signing_test.sh 先 RED 后 GREEN
- bash scripts/test/desktop_updater_config_test.sh
- bash scripts/test/go_test_with_retry_test.sh
- bash scripts/test/release_no_apple_signing_test.sh
- bash scripts/test/release_updater_signing_key_test.sh
- bash scripts/test/release_version_helpers_test.sh
- bash scripts/test/sync_release_metadata_test.sh
- bash scripts/test/collect_release_assets_test.sh
- bash scripts/test/release_updater_manifest_test.sh
- bash scripts/test/package_local_release_test.sh
- bash scripts/test/release_msvc_spub_test.sh
- bash scripts/test/build_ai_gate_msvc_test.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dev-ci.yml"); YAML.load_file(".github/workflows/release.yml")'
