### PR TITLE
支持用户托管 Lua 用量进度条与 429 重试

### DIFF
--- a/backend/internal/api/accounts_handler_lua_test.go
+++ b/backend/internal/api/accounts_handler_lua_test.go
@@ -70,6 +70,13 @@ func TestAccountsHandlerManagedLuaScriptCRUD(t *testing.T) {
 		t.Fatalf("content = %q, want fetch_usage body", payload.Content)
 	}
 
+	missingReq := httptest.NewRequest(http.MethodGet, "/accounts/usage-scripts/stellaisle", nil)
+	missingRec := httptest.NewRecorder()
+	handler.ServeHTTP(missingRec, missingReq)
+	if missingRec.Code != http.StatusNotFound {
+		t.Fatalf("GET unmanaged stellaisle script status = %d, want %d body=%s", missingRec.Code, http.StatusNotFound, missingRec.Body.String())
+	}
+
 	listReq := httptest.NewRequest(http.MethodGet, "/accounts/usage-scripts", nil)
 	listRec := httptest.NewRecorder()
 	handler.ServeHTTP(listRec, listReq)

--- a/backend/internal/api/accounts_handler_test.go
+++ b/backend/internal/api/accounts_handler_test.go
@@ -873,6 +873,16 @@ func TestAccountsHandlerListAccountsDefaultsBuiltInDrivers(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create nodeseek returned error: %v", err)
 	}
+	if err := repo.Create(accounts.Account{
+		ProviderType:  accounts.ProviderOpenAICompatible,
+		AccountName:   "team4",
+		AuthMode:      accounts.AuthModeAPIKey,
+		CredentialRef: "sk-test",
+		BaseURL:       "https://code.xxcd.top/v1",
+		Status:        accounts.StatusActive,
+	}); err != nil {
+		t.Fatalf("Create code.xxcd.top account returned error: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/accounts", nil)
 	rec := httptest.NewRecorder()
@@ -905,6 +915,12 @@ func TestAccountsHandlerListAccountsDefaultsBuiltInDrivers(t *testing.T) {
 	}
 	if listed[2]["usage_config_json"] != `{"script":"managed:ai.nodeseek.in"}` {
 		t.Fatalf("nodeseek usage_config_json = %v, want managed script config", listed[2]["usage_config_json"])
+	}
+	if listed[3]["usage_driver"] != "" {
+		t.Fatalf("code.xxcd.top usage_driver = %v, want empty without built-in script", listed[3]["usage_driver"])
+	}
+	if listed[3]["usage_config_json"] != "" {
+		t.Fatalf("code.xxcd.top usage_config_json = %v, want empty without built-in script", listed[3]["usage_config_json"])
 	}
 }
 

--- a/backend/internal/api/server_me_handler_test.go
+++ b/backend/internal/api/server_me_handler_test.go
@@ -144,6 +144,15 @@ func TestServerMeHandlerReturnsSanitizedUpstreamsAndUpdatesRoute(t *testing.T) {
 		LastInputTokens:  40,
 		LastOutputTokens: 80,
 		CheckedAt:        time.Now().UTC(),
+		ProviderSnapshotJSON: `{
+				"display": {
+					"summary": {"label":"周额度","value":"$296.39 / $300.00"},
+					"usage_windows": [
+						{"label":"周额度","remaining_percent":98.8,"remaining_value":"$296.39","total_value":"$300.00"},
+						{"label":"总额度","remaining_percent":92.1,"remaining_value":"$8291.59","total_value":"$9000.00"}
+					]
+				}
+			}`,
 	}); err != nil {
 		t.Fatalf("Save usage returned error: %v", err)
 	}
@@ -189,18 +198,19 @@ func TestServerMeHandlerReturnsSanitizedUpstreamsAndUpdatesRoute(t *testing.T) {
 		CurrentAccountID  int64 `json:"current_account_id"`
 		RouteLocked       bool  `json:"route_locked"`
 		Accounts          []struct {
-			ID                        int64   `json:"id"`
-			AccountName               string  `json:"account_name"`
-			BaseURL                   string  `json:"base_url"`
-			Status                    string  `json:"status"`
-			Available                 bool    `json:"available"`
-			Current                   bool    `json:"current"`
-			Balance                   float64 `json:"balance"`
-			QuotaRemaining            float64 `json:"quota_remaining"`
-			LastTotalTokens           float64 `json:"last_total_tokens"`
-			PPChatTodayUsedQuota      float64 `json:"ppchat_today_used_quota"`
-			PPChatTodayAddedQuota     float64 `json:"ppchat_today_added_quota"`
-			PPChatTodayRemainingQuota float64 `json:"ppchat_today_remaining_quota"`
+			ID                        int64          `json:"id"`
+			AccountName               string         `json:"account_name"`
+			BaseURL                   string         `json:"base_url"`
+			Status                    string         `json:"status"`
+			Available                 bool           `json:"available"`
+			Current                   bool           `json:"current"`
+			Balance                   float64        `json:"balance"`
+			QuotaRemaining            float64        `json:"quota_remaining"`
+			LastTotalTokens           float64        `json:"last_total_tokens"`
+			PPChatTodayUsedQuota      float64        `json:"ppchat_today_used_quota"`
+			PPChatTodayAddedQuota     float64        `json:"ppchat_today_added_quota"`
+			PPChatTodayRemainingQuota float64        `json:"ppchat_today_remaining_quota"`
+			UsageDisplay              map[string]any `json:"usage_display"`
 		} `json:"accounts"`
 	}
 	if err := json.Unmarshal(upstreamsRec.Body.Bytes(), &upstreams); err != nil {
@@ -214,6 +224,10 @@ func TestServerMeHandlerReturnsSanitizedUpstreamsAndUpdatesRoute(t *testing.T) {
 	}
 	if upstreams.Accounts[1].PPChatTodayUsedQuota != 22 || upstreams.Accounts[1].PPChatTodayAddedQuota != 20 || upstreams.Accounts[1].PPChatTodayRemainingQuota != -2 {
 		t.Fatalf("ppchat upstream usage = %+v, want cached ppchat quota fields", upstreams.Accounts[1])
+	}
+	windows, ok := upstreams.Accounts[0].UsageDisplay["usage_windows"].([]any)
+	if !ok || len(windows) != 2 {
+		t.Fatalf("usage display windows = %#v, want weekly and total windows", upstreams.Accounts[0].UsageDisplay)
 	}
 
 	routeReq := httptest.NewRequest(http.MethodPut, "/me/route", bytes.NewBufferString(`{"account_id":1,"locked":true}`))

--- a/backend/internal/usagedrv/lua/managed_scripts_test.go
+++ b/backend/internal/usagedrv/lua/managed_scripts_test.go
@@ -2,15 +2,25 @@ package lua_test
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gcssloop/codex-router/backend/internal/accountdrv"
 	"github.com/gcssloop/codex-router/backend/internal/accounts"
 	luadrv "github.com/gcssloop/codex-router/backend/internal/usagedrv/lua"
 )
+
+type managedScriptRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f managedScriptRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestLuaDriverFetchesManagedScript(t *testing.T) {
 	t.Parallel()
@@ -91,6 +101,255 @@ func TestLuaDriverUsesBuiltInManagedDSLScript(t *testing.T) {
 	}
 	if summary["label"] != "余额" || summary["value"] != "$88.00" {
 		t.Fatalf("display.summary = %#v, want formatted balance", summary)
+	}
+}
+
+func TestLuaDriverUsesManagedSansiStatsByAccountName(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Transport: managedScriptRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://lab.sansi.io/ppc-stats/api/status" {
+			t.Fatalf("URL = %q, want lab.sansi.io status endpoint", r.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(`{
+				"tokens": [
+					{"token":"new-api-team4","label":"team4","provider":"new-api"},
+					{"token":"ppchat-team4","label":"team4","provider":"ppchat"}
+				],
+				"token_summaries": [
+					{"token":"new-api-team4","token_label":"team4","package_type":"每天15刀套餐","quota_raw_remain_quota":3457762,"quota_raw_today_used_quota":4042238,"quota_raw_today_added_quota":7500000,"quota_raw_scale":500000,"quota_raw_unit":"USD"},
+					{"token":"ppchat-team4","token_label":"team4","package_type":"other","quota_raw_remain_quota":1,"quota_raw_today_used_quota":2,"quota_raw_today_added_quota":3,"quota_raw_scale":1,"quota_raw_unit":"USD"}
+				]
+			}`)),
+		}, nil
+	})}
+
+	root := t.TempDir()
+	manager, err := luadrv.NewManagedScriptStore(root)
+	if err != nil {
+		t.Fatalf("NewManagedScriptStore returned error: %v", err)
+	}
+	if err := manager.Save("sansi", `function fetch_usage(ctx)
+  local response = ctx.host.http_get({ url = "https://lab.sansi.io/ppc-stats/api/status" })
+  local payload = ctx.host.json_decode(response.body)
+  local token
+  for _, candidate in ipairs(payload.tokens or {}) do
+    if candidate.label == ctx.account.account_name and candidate.provider == "new-api" then
+      token = candidate
+      break
+    end
+  end
+  local summary
+  for _, candidate in ipairs(payload.token_summaries or {}) do
+    if token ~= nil and candidate.token == token.token then
+      summary = candidate
+      break
+    end
+  end
+  local scale = summary.quota_raw_scale
+  local remaining = summary.quota_raw_remain_quota / scale
+  local today_used = summary.quota_raw_today_used_quota / scale
+  local today_quota = summary.quota_raw_today_added_quota / scale
+  return {
+    ok = true,
+    source = "remote",
+    confidence = "high",
+    limits = { balance = today_quota, quota_remaining = remaining },
+    meta = { today_used = today_used },
+    display = {
+      summary = { label = "今日额度", value = string.format("$%.3f / $%.3f", today_used, today_quota) },
+      detail_stats = {
+        { label = "今日额度", value = string.format("$%.3f", today_quota) },
+        { label = "今日已用", value = string.format("$%.3f", today_used) },
+        { label = "今日剩余", value = string.format("$%.3f", remaining) }
+      },
+      usage_windows = { { label = "1D", remaining_percent = remaining / today_quota * 100 } }
+    }
+  }
+end
+`); err != nil {
+		t.Fatalf("Save Sansi script returned error: %v", err)
+	}
+
+	driver := luadrv.NewDriver(client, moduleRoot(t), luadrv.WithManagedScriptRoot(root))
+	result, err := driver.Fetch(context.Background(), accounts.Account{
+		AccountName:     "team4",
+		UsageDriver:     "lua",
+		UsageConfigJSON: `{"script":"managed:sansi"}`,
+	}, accountdrv.ResolvedCredential{})
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if result.Limits.Balance == nil || *result.Limits.Balance != 15 {
+		t.Fatalf("Balance = %#v, want 15 USD daily quota", result.Limits.Balance)
+	}
+	if result.Limits.QuotaRemaining == nil || *result.Limits.QuotaRemaining != 3457762.0/500000.0 {
+		t.Fatalf("QuotaRemaining = %#v, want scaled daily remaining", result.Limits.QuotaRemaining)
+	}
+	if result.Meta["today_used"] != 4042238.0/500000.0 {
+		t.Fatalf("today_used = %#v, want scaled daily usage", result.Meta["today_used"])
+	}
+	display := result.Display
+	summary, ok := display["summary"].(map[string]any)
+	if !ok || summary["label"] != "今日额度" || summary["value"] != "$8.084 / $15.000" {
+		t.Fatalf("summary = %#v, want today's used and total quota", display["summary"])
+	}
+	stats, ok := display["detail_stats"].([]any)
+	if !ok || len(stats) != 3 {
+		t.Fatalf("detail_stats = %#v, want three daily quota metrics", display["detail_stats"])
+	}
+	windows, ok := display["usage_windows"].([]any)
+	if !ok || len(windows) != 1 {
+		t.Fatalf("usage_windows = %#v, want one daily progress window", display["usage_windows"])
+	}
+	window, ok := windows[0].(map[string]any)
+	wantRemainingPercent := (3457762.0 / 7500000.0) * 100
+	gotRemainingPercent, numberOK := window["remaining_percent"].(float64)
+	if !ok || !numberOK || window["label"] != "1D" || math.Abs(gotRemainingPercent-wantRemainingPercent) > 1e-9 {
+		t.Fatalf("usage_windows[0] = %#v, want scaled daily remaining percentage", windows[0])
+	}
+}
+
+func TestLuaDriverUsesManagedStellaisleLoginCookieForSubscription17(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Transport: managedScriptRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/user/login":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read login body: %v", err)
+			}
+			var credentials map[string]string
+			if err := json.Unmarshal(body, &credentials); err != nil {
+				t.Fatalf("decode login body: %v", err)
+			}
+			if credentials["username"] != "user@example.com" || credentials["password"] != "pass-placeholder" {
+				t.Fatalf("login credentials = %#v, want configured credentials", credentials)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{"Set-Cookie": []string{
+					"stellaisle_session=abc123; Path=/; HttpOnly",
+					"stellaisle_csrf=csrf456; Path=/; HttpOnly",
+				}},
+				Body: io.NopCloser(strings.NewReader(`{"success":true,"data":{"id":264}}`)),
+			}, nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/subscription/self":
+			if got := r.Header.Get("Cookie"); got != "stellaisle_session=abc123; stellaisle_csrf=csrf456" {
+				t.Fatalf("Cookie = %q, want all session cookies", got)
+			}
+			if got := r.Header.Get("new-api-user"); got != "264" {
+				t.Fatalf("new-api-user = %q, want 264", got)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+					"success": true,
+					"data": {
+						"all_subscriptions": [
+							{"subscription":{"id":18,"amount_total":1,"amount_used":1,"amount_cap":2,"amount_cap_used":2}},
+							{"subscription":{"id":17,"amount_total":300000000,"amount_used":3607724,"amount_cap":9000000000,"amount_cap_used":708408003,"next_reset_time":1784304000,"status":"active","allowed_group":"套餐专用分组"}}
+						]
+					},
+					"message":""
+				}`)),
+			}, nil
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	})}
+
+	root := t.TempDir()
+	manager, err := luadrv.NewManagedScriptStore(root)
+	if err != nil {
+		t.Fatalf("NewManagedScriptStore returned error: %v", err)
+	}
+	if err := manager.Save("stellaisle", `function fetch_usage(ctx)
+  local credentials = ctx.host.json_decode(ctx.credential.api_key or "{}")
+  local base = string.gsub(ctx.account.base_url or "", "/+$", "")
+  local login = ctx.host.http_post({
+    url = base .. "/api/user/login?turnstile=",
+    headers = { ["Accept"] = "application/json", ["Content-Type"] = "application/json" },
+    body = ctx.host.json_encode({ username = credentials.username, password = credentials.password })
+  })
+  local login_payload = ctx.host.json_decode(login.body)
+  local cookie_parts = {}
+  for _, raw_cookie in ipairs(login.set_cookies or {}) do
+    local cookie = string.match(tostring(raw_cookie), "^[^;]+")
+    if cookie ~= nil then table.insert(cookie_parts, cookie) end
+  end
+  local usage = ctx.host.http_get({
+    url = base .. "/api/subscription/self",
+    headers = { ["Accept"] = "application/json", ["Cookie"] = table.concat(cookie_parts, "; "), ["new-api-user"] = tostring(login_payload.data.id) }
+  })
+  local payload = ctx.host.json_decode(usage.body)
+  local selected
+  for _, entry in ipairs(payload.data.all_subscriptions or {}) do
+    if entry.subscription.id == 17 then selected = entry.subscription break end
+  end
+  local scale = 1000000
+  local period_total = selected.amount_total / scale
+  local period_remaining = (selected.amount_total - selected.amount_used) / scale
+  local total_cap = selected.amount_cap / scale
+  local total_remaining = (selected.amount_cap - selected.amount_cap_used) / scale
+  return {
+    ok = true,
+    source = "remote",
+    confidence = "high",
+    limits = { balance = period_total, quota_remaining = period_remaining },
+    meta = { subscription_id = 17 },
+    display = {
+      summary = { label = "周额度", value = string.format("$%.2f / $%.2f", period_remaining, period_total) },
+      usage_windows = {
+        { label = "周额度", remaining_percent = period_remaining / period_total * 100, remaining_value = string.format("$%.2f", period_remaining), total_value = string.format("$%.2f", period_total) },
+        { label = "总额度", remaining_percent = total_remaining / total_cap * 100, remaining_value = string.format("$%.2f", total_remaining), total_value = string.format("$%.2f", total_cap) }
+      }
+    }
+  }
+end
+`); err != nil {
+		t.Fatalf("Save Stellaisle script returned error: %v", err)
+	}
+
+	driver := luadrv.NewDriver(client, moduleRoot(t), luadrv.WithManagedScriptRoot(root))
+	result, err := driver.Fetch(context.Background(), accounts.Account{
+		BaseURL:         "https://token.stellaisle.com",
+		UsageDriver:     "lua",
+		UsageConfigJSON: `{"script":"managed:stellaisle","subscription_id":17}`,
+	}, accountdrv.ResolvedCredential{APIKey: `{"username":"user@example.com","password":"pass-placeholder"}`})
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if result.Limits.Balance == nil || *result.Limits.Balance != 300 {
+		t.Fatalf("Balance = %#v, want 300", result.Limits.Balance)
+	}
+	if result.Limits.QuotaRemaining == nil || *result.Limits.QuotaRemaining != 296.392276 {
+		t.Fatalf("QuotaRemaining = %#v, want 296.392276", result.Limits.QuotaRemaining)
+	}
+	if result.Meta["subscription_id"] != float64(17) {
+		t.Fatalf("subscription_id = %#v, want 17", result.Meta["subscription_id"])
+	}
+	summary, ok := result.Display["summary"].(map[string]any)
+	if !ok || summary["label"] != "周额度" || summary["value"] != "$296.39 / $300.00" {
+		t.Fatalf("summary = %#v, want subscription usage summary", result.Display["summary"])
+	}
+	windows, ok := result.Display["usage_windows"].([]any)
+	if !ok || len(windows) != 2 {
+		t.Fatalf("usage_windows = %#v, want weekly and total windows", result.Display["usage_windows"])
+	}
+	weekly, weeklyOK := windows[0].(map[string]any)
+	total, totalOK := windows[1].(map[string]any)
+	if !weeklyOK || weekly["label"] != "周额度" || weekly["remaining_value"] != "$296.39" || weekly["total_value"] != "$300.00" {
+		t.Fatalf("weekly window = %#v, want weekly remaining/total values", windows[0])
+	}
+	if !totalOK || total["label"] != "总额度" || total["remaining_value"] != "$8291.59" || total["total_value"] != "$9000.00" {
+		t.Fatalf("total window = %#v, want total remaining/total values", windows[1])
 	}
 }
 

--- a/backend/internal/usagedrv/lua/managed_scripts_test.go
+++ b/backend/internal/usagedrv/lua/managed_scripts_test.go
@@ -216,9 +216,18 @@ end
 func TestLuaDriverUsesManagedStellaisleLoginCookieForSubscription17(t *testing.T) {
 	t.Parallel()
 
+	loginAttempts := 0
 	client := &http.Client{Transport: managedScriptRoundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/user/login":
+			loginAttempts++
+			if loginAttempts == 1 {
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     http.Header{"Retry-After": []string{"0"}},
+					Body:       io.NopCloser(strings.NewReader(`{"error":"rate limited"}`)),
+				}, nil
+			}
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatalf("read login body: %v", err)
@@ -276,7 +285,10 @@ func TestLuaDriverUsesManagedStellaisleLoginCookieForSubscription17(t *testing.T
   local login = ctx.host.http_post({
     url = base .. "/api/user/login?turnstile=",
     headers = { ["Accept"] = "application/json", ["Content-Type"] = "application/json" },
-    body = ctx.host.json_encode({ username = credentials.username, password = credentials.password })
+    body = ctx.host.json_encode({ username = credentials.username, password = credentials.password }),
+    retry_on_429 = true,
+    retry_count = 2,
+    retry_delay_ms = 0
   })
   local login_payload = ctx.host.json_decode(login.body)
   local cookie_parts = {}
@@ -328,6 +340,9 @@ end
 	}
 	if result.Limits.Balance == nil || *result.Limits.Balance != 300 {
 		t.Fatalf("Balance = %#v, want 300", result.Limits.Balance)
+	}
+	if loginAttempts != 2 {
+		t.Fatalf("login attempts = %d, want one retry after 429", loginAttempts)
 	}
 	if result.Limits.QuotaRemaining == nil || *result.Limits.QuotaRemaining != 296.392276 {
 		t.Fatalf("QuotaRemaining = %#v, want 296.392276", result.Limits.QuotaRemaining)

--- a/backend/internal/usagedrv/lua/runtime.go
+++ b/backend/internal/usagedrv/lua/runtime.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -174,30 +175,59 @@ func (r *Runtime) registerHostAPI(L *golua.LState, ctx context.Context) error {
 			state.RaiseError("http_post requires non-empty url")
 			return 0
 		}
-		request, err := http.NewRequestWithContext(ctx, http.MethodPost, string(urlString), strings.NewReader(stringValue(arg.RawGetString("body"))))
-		if err != nil {
-			state.RaiseError("http_post build request: %v", err)
-			return 0
-		}
-		if err := applyLuaRequestHeaders(request, arg.RawGetString("headers")); err != nil {
-			state.RaiseError("http_post headers: %v", err)
-			return 0
-		}
 		client := r.client
 		if client == nil {
 			client = http.DefaultClient
 		}
-		response, err := client.Do(request)
-		if err != nil {
-			state.RaiseError("http_post request failed: %v", err)
-			return 0
+		retryCount := 1
+		if luaBoolValue(arg.RawGetString("retry_on_429")) {
+			retryCount = luaIntValue(arg.RawGetString("retry_count"), 3)
+			if retryCount < 1 {
+				retryCount = 1
+			}
+			if retryCount > 5 {
+				retryCount = 5
+			}
 		}
-		defer response.Body.Close()
-		body, err := ioReadAll(response.Body)
-		if err != nil {
-			state.RaiseError("http_post read response: %v", err)
-			return 0
+		bodyText := stringValue(arg.RawGetString("body"))
+		var response *http.Response
+		var body []byte
+		for attempt := 0; attempt < retryCount; attempt++ {
+			request, err := http.NewRequestWithContext(ctx, http.MethodPost, string(urlString), strings.NewReader(bodyText))
+			if err != nil {
+				state.RaiseError("http_post build request: %v", err)
+				return 0
+			}
+			if err := applyLuaRequestHeaders(request, arg.RawGetString("headers")); err != nil {
+				state.RaiseError("http_post headers: %v", err)
+				return 0
+			}
+			response, err = client.Do(request)
+			if err != nil {
+				state.RaiseError("http_post request failed: %v", err)
+				return 0
+			}
+			body, err = ioReadAll(response.Body)
+			response.Body.Close()
+			if err != nil {
+				state.RaiseError("http_post read response: %v", err)
+				return 0
+			}
+			if response.StatusCode != http.StatusTooManyRequests || attempt+1 >= retryCount {
+				break
+			}
+			if delay := luaRetryDelayMilliseconds(arg, response.Header); delay > 0 {
+				timer := time.NewTimer(time.Duration(delay) * time.Millisecond)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					state.RaiseError("http_post retry interrupted: %v", ctx.Err())
+					return 0
+				case <-timer.C:
+				}
+			}
 		}
+
 		resp := state.NewTable()
 		resp.RawSetString("status", golua.LNumber(response.StatusCode))
 		resp.RawSetString("body", golua.LString(string(body)))
@@ -274,6 +304,30 @@ func stringValue(value golua.LValue) string {
 		return string(text)
 	}
 	return value.String()
+}
+
+func luaBoolValue(value golua.LValue) bool {
+	boolean, ok := value.(golua.LBool)
+	return ok && bool(boolean)
+}
+
+func luaIntValue(value golua.LValue, fallback int) int {
+	number, ok := value.(golua.LNumber)
+	if !ok {
+		return fallback
+	}
+	return int(number)
+}
+
+func luaRetryDelayMilliseconds(arg *golua.LTable, headers http.Header) int {
+	if value := luaIntValue(arg.RawGetString("retry_delay_ms"), -1); value >= 0 {
+		return value
+	}
+	seconds, err := strconv.Atoi(strings.TrimSpace(headers.Get("Retry-After")))
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return seconds * 1000
 }
 
 func applyLuaRequestHeaders(request *http.Request, value golua.LValue) error {

--- a/backend/internal/usagedrv/lua/runtime.go
+++ b/backend/internal/usagedrv/lua/runtime.go
@@ -166,6 +166,57 @@ func (r *Runtime) registerHostAPI(L *golua.LState, ctx context.Context) error {
 		state.Push(resp)
 		return 1
 	}))
+	host.RawSetString("http_post", L.NewFunction(func(state *golua.LState) int {
+		arg := state.CheckTable(1)
+		urlValue := arg.RawGetString("url")
+		urlString, ok := urlValue.(golua.LString)
+		if !ok || strings.TrimSpace(string(urlString)) == "" {
+			state.RaiseError("http_post requires non-empty url")
+			return 0
+		}
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, string(urlString), strings.NewReader(stringValue(arg.RawGetString("body"))))
+		if err != nil {
+			state.RaiseError("http_post build request: %v", err)
+			return 0
+		}
+		if err := applyLuaRequestHeaders(request, arg.RawGetString("headers")); err != nil {
+			state.RaiseError("http_post headers: %v", err)
+			return 0
+		}
+		client := r.client
+		if client == nil {
+			client = http.DefaultClient
+		}
+		response, err := client.Do(request)
+		if err != nil {
+			state.RaiseError("http_post request failed: %v", err)
+			return 0
+		}
+		defer response.Body.Close()
+		body, err := ioReadAll(response.Body)
+		if err != nil {
+			state.RaiseError("http_post read response: %v", err)
+			return 0
+		}
+		resp := state.NewTable()
+		resp.RawSetString("status", golua.LNumber(response.StatusCode))
+		resp.RawSetString("body", golua.LString(string(body)))
+		setCookies := state.NewTable()
+		for index, value := range response.Header.Values("Set-Cookie") {
+			setCookies.RawSetInt(index+1, golua.LString(value))
+		}
+		resp.RawSetString("set_cookies", setCookies)
+		respHeaders := state.NewTable()
+		for key, values := range response.Header {
+			if len(values) == 0 {
+				continue
+			}
+			respHeaders.RawSetString(key, golua.LString(values[0]))
+		}
+		resp.RawSetString("headers", respHeaders)
+		state.Push(resp)
+		return 1
+	}))
 	host.RawSetString("json_decode", L.NewFunction(func(state *golua.LState) int {
 		raw := state.CheckString(1)
 		var decoded any
@@ -213,6 +264,40 @@ func (r *Runtime) registerHostAPI(L *golua.LState, ctx context.Context) error {
 	}))
 	L.SetGlobal("host", host)
 	return nil
+}
+
+func stringValue(value golua.LValue) string {
+	if value == golua.LNil {
+		return ""
+	}
+	if text, ok := value.(golua.LString); ok {
+		return string(text)
+	}
+	return value.String()
+}
+
+func applyLuaRequestHeaders(request *http.Request, value golua.LValue) error {
+	if value == golua.LNil {
+		return nil
+	}
+	headersTable, ok := value.(*golua.LTable)
+	if !ok {
+		return fmt.Errorf("headers must be table")
+	}
+	var headerErr error
+	headersTable.ForEach(func(key golua.LValue, value golua.LValue) {
+		if headerErr != nil {
+			return
+		}
+		keyString, keyOK := key.(golua.LString)
+		valueString, valueOK := value.(golua.LString)
+		if !keyOK || !valueOK {
+			headerErr = fmt.Errorf("header names and values must be strings")
+			return
+		}
+		request.Header.Set(string(keyString), string(valueString))
+	})
+	return headerErr
 }
 
 func buildLuaContext(L *golua.LState, account accounts.Account, credential accountdrv.ResolvedCredential, config map[string]any) (golua.LValue, error) {

--- a/backend/internal/usagedrv/lua/runtime_test.go
+++ b/backend/internal/usagedrv/lua/runtime_test.go
@@ -131,6 +131,47 @@ simple_usage({
 	}
 }
 
+func TestRuntimeHTTPPostRetriesOptedInRateLimit(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := writeTempScript(t, `
+function fetch_usage(ctx)
+  local response = ctx.host.http_post({
+    url = "https://token.stellaisle.com/api/user/login?turnstile=",
+    headers = { ["Content-Type"] = "application/json" },
+    body = "{}",
+    retry_on_429 = true,
+    retry_count = 2,
+    retry_delay_ms = 0
+  })
+  if response.status ~= 200 then
+    error("unexpected status " .. tostring(response.status))
+  end
+  return { ok = true, source = "remote", confidence = "high", limits = {} }
+end
+`)
+	attempts := 0
+	runtime := luadrv.NewRuntime(&http.Client{Transport: roundTripFunc(func(req *http.Request) *http.Response {
+		attempts++
+		if attempts == 1 {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"0"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":"rate limited"}`)),
+			}
+		}
+		return jsonResponse(`{"ok":true}`)
+	})}, filepath.Dir(scriptPath))
+
+	_, err := runtime.Execute(context.Background(), filepath.Base(scriptPath), accounts.Account{}, accountdrv.ResolvedCredential{}, map[string]any{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("POST attempts = %d, want 2", attempts)
+	}
+}
+
 func TestRuntimeExecuteSimpleUsageDSLReturnsDisplayHints(t *testing.T) {
 	t.Parallel()
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,6 +12,26 @@ cd backend && go test ./...
 npm --prefix frontend test
 ```
 
+## Lua usage closed loop
+
+Platform-specific usage adapters are user-managed Lua scripts. Select the Lua
+driver, save the script under a shared key, and set the account usage config to
+`{"script":"managed:<key>"}`. The backend does not silently provide scripts for
+specific upstream domains.
+
+An adapter may return `usage_display.usage_windows` entries with `label`,
+`remaining_percent`, `remaining_value`, `total_value`, and `reset_label`. The
+account page and server user page render those entries as progress bars. This
+protocol is shared by server mode and the desktop client connected to it.
+
+For an isolated local check, run the backend on a separate loopback port with a
+temporary repository-local database, then call:
+
+```bash
+curl -X POST http://127.0.0.1:<port>/ai-router/api/accounts/usage/refresh
+curl http://127.0.0.1:<port>/ai-router/api/accounts/usage
+```
+
 ## Server mode
 
 Start server mode with a repo-local database and development password:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,6 +24,10 @@ An adapter may return `usage_display.usage_windows` entries with `label`,
 account page and server user page render those entries as progress bars. This
 protocol is shared by server mode and the desktop client connected to it.
 
+For login-style POST requests that may be rate limited, a script can opt in to
+bounded retry with `retry_on_429 = true`, `retry_count`, and `retry_delay_ms`.
+Ordinary POST requests are not retried by default.
+
 For an isolated local check, run the backend on a separate loopback port with a
 temporary repository-local database, then call:
 

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -167,6 +167,98 @@ describe("AccountsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps platform Lua scripts user-managed for code.xxcd.top", async () => {
+    const account = {
+      id: 8,
+      provider_type: "openai-compatible",
+      account_name: "team4",
+      source_icon: "openai",
+      auth_mode: "api_key",
+      base_url: "https://code.xxcd.top",
+      account_driver: "builtin_api_key",
+      usage_driver: "lua",
+      usage_config_json: '{"script":"managed:lab.sansi.io"}',
+      status: "active",
+      priority: 1,
+      is_active: true,
+      balance: 15,
+      quota_remaining: 6,
+      rpm_remaining: 0,
+      tpm_remaining: 0,
+      health_score: 1,
+      recent_error_rate: 0,
+      last_total_tokens: 0,
+      last_input_tokens: 0,
+      last_output_tokens: 0,
+      model_context_window: 0,
+      primary_used_percent: 0,
+      secondary_used_percent: 0,
+      usage_display: {
+        summary: { label: "今日额度", value: "$8.000 / $15.000" },
+        usage_windows: [
+          {
+            label: "周额度",
+            remaining_percent: 98.8,
+            remaining_value: "$296.39",
+            total_value: "$300.00",
+            reset_label: "周期",
+          },
+          {
+            label: "总额度",
+            remaining_percent: 92.1,
+            remaining_value: "$8291.59",
+            total_value: "$9000.00",
+            reset_label: "总计",
+          },
+        ],
+      },
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/ai-router/api/accounts") {
+        return Promise.resolve(
+          new Response(JSON.stringify([account]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (url === "/ai-router/api/accounts/usage") {
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (url === "/ai-router/api/accounts/usage-scripts") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ items: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAccountsPage();
+
+    expect(await screen.findByText("team4")).toBeInTheDocument();
+    expect(await screen.findByText("$296.39 / $300.00")).toBeInTheDocument();
+    expect(await screen.findByText("$8291.59 / $9000.00")).toBeInTheDocument();
+    expect(screen.queryByText("周期")).not.toBeInTheDocument();
+    expect(screen.queryByText("总计")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "编辑-team4" }));
+    const editModal = await screen.findByRole("dialog", { name: "编辑账户" });
+    expect(within(editModal).getByText("Lua Usage 配置")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(within(editModal).getByDisplayValue(/simple_usage/)).toBeInTheDocument();
+    });
+    expect(within(editModal).queryByDisplayValue(/lab\.sansi\.io/)).not.toBeInTheDocument();
+  });
+
   it("does not open browser when oauth authorize response misses device code", async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -845,6 +937,12 @@ describe("AccountsPage", () => {
                   model_context_window: 0,
                   primary_used_percent: 0,
                   secondary_used_percent: 0,
+                  usage_display: {
+                    usage_windows: [
+                      { label: "周额度", remaining_percent: 98.8, remaining_value: "$296.39", total_value: "$300.00" },
+                      { label: "总额度", remaining_percent: 92.1, remaining_value: "$8291.59", total_value: "$9000.00" },
+                    ],
+                  },
                 },
                 {
                   id: 12,
@@ -932,6 +1030,10 @@ describe("AccountsPage", () => {
     expect(await screen.findByText("upstream-a")).toBeInTheDocument();
     expect(screen.getByText("https://up-a.example/v1")).toBeInTheDocument();
     expect(screen.getByText("当前使用中")).toBeInTheDocument();
+    expect(screen.getByText("$296.39 / $300.00")).toBeInTheDocument();
+    expect(screen.getByText("$8291.59 / $9000.00")).toBeInTheDocument();
+    expect(screen.getByLabelText("upstream-a-周额度")).toBeInTheDocument();
+    expect(screen.getByLabelText("upstream-a-总额度")).toBeInTheDocument();
     const ppchatRow = screen
       .getByText("upstream-b")
       .closest(".account-remote-upstream-row") as HTMLElement;

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -493,6 +493,7 @@ return {
 
 ## host API
 - \`ctx.host.http_post({ url = "...", headers = { ["Content-Type"] = "application/json" }, body = "{}" })\`
+- \`http_post\` 可按需设置 \`retry_on_429 = true\`、\`retry_count\` 和 \`retry_delay_ms\`，仅对明确允许重试的 POST 生效。
 - \`ctx.host.http_get({ url = "...", headers = { Authorization = "Bearer xxx" } })\`
 - \`ctx.host.json_decode(raw)\`
 - \`ctx.host.json_encode(value)\`

--- a/frontend/src/features/accounts/AccountsPage.tsx
+++ b/frontend/src/features/accounts/AccountsPage.tsx
@@ -489,7 +489,10 @@ return {
 - \`ctx.credential.metadata\`
 - \`ctx.config\`：来自 \`usage_config_json\`
 
+需要用户名密码登录的适配器，可将账户凭据保存为 JSON：\`{"username":"...","password":"..."}\`；凭据仍由账户本地加密存储。
+
 ## host API
+- \`ctx.host.http_post({ url = "...", headers = { ["Content-Type"] = "application/json" }, body = "{}" })\`
 - \`ctx.host.http_get({ url = "...", headers = { Authorization = "Bearer xxx" } })\`
 - \`ctx.host.json_decode(raw)\`
 - \`ctx.host.json_encode(value)\`
@@ -887,13 +890,28 @@ function formatRemoteUpstreamUsage(
   return language === "en-US" ? "Usage unknown" : "用量未知";
 }
 
-function buildRemoteUpstreamUsageWindow(
+function buildRemoteUpstreamUsageWindows(
   account: ServerUpstreamAccount,
   language: AppLanguage,
 ) {
+  const customWindows = account.usage_display?.usage_windows
+    ?.filter((item) => typeof item.remaining_percent === "number")
+    .map((item) => ({
+      label: item.label || (language === "en-US" ? "Usage" : "用量"),
+      remainingPercent: clampPercent(item.remaining_percent ?? 0),
+      valueLabel:
+        item.remaining_value && item.total_value
+          ? `${item.remaining_value} / ${item.total_value}`
+          : undefined,
+      resetLabel:
+        item.remaining_value && item.total_value ? "" : item.reset_label || "",
+    })) ?? [];
+  if (customWindows.length > 0) {
+    return customWindows;
+  }
   const addedQuota = account.ppchat_today_added_quota ?? 0;
   if (isPPChatUpstream(account) && addedQuota > 0) {
-    return {
+    return [{
       label: "1D",
       remainingPercent: clampPercent(
         ((account.ppchat_today_remaining_quota ?? 0) /
@@ -901,9 +919,9 @@ function buildRemoteUpstreamUsageWindow(
           100,
       ),
       resetLabel: formatTomorrowMidnight(language),
-    };
+    }];
   }
-  return null;
+  return [];
 }
 
 function buildGenericUsageWindows(
@@ -1614,7 +1632,7 @@ export function AccountsPage({
       source_icon: normalizeSourceIcon(account.source_icon),
       base_url: account.base_url,
       credential_ref: "",
-      usage_driver: account.usage_driver === "lua" ? "lua" : "",
+      usage_driver: account.usage_driver === "lua" ? account.usage_driver : "",
       skip_tls_verify: account.skip_tls_verify ?? false,
     });
     testForm.setFieldsValue({
@@ -2122,7 +2140,23 @@ export function AccountsPage({
     const remoteState = remoteUpstreamsByAccountID[record.id];
     const remoteUpstreams = remoteState?.data;
     const remoteExpanded = expandedRemoteAccountID === record.id && Boolean(remoteUpstreams);
-    const usageWindows = record.usage_display?.summary
+    const customUsageWindows = record.usage_display?.usage_windows
+      ?.filter((item) => typeof item.remaining_percent === "number")
+      .map((item) => ({
+        label: item.label || "Usage",
+        remainingPercent: clampPercent(item.remaining_percent ?? 0),
+        valueLabel:
+          item.remaining_value && item.total_value
+            ? `${item.remaining_value} / ${item.total_value}`
+            : undefined,
+        resetLabel:
+          item.remaining_value && item.total_value
+            ? ""
+            : item.reset_label || "",
+      })) ?? [];
+    const usageWindows = customUsageWindows.length > 0
+      ? customUsageWindows
+      : record.usage_display?.summary
       ? []
       : isOfficialAccount(record)
       ? [
@@ -2310,7 +2344,7 @@ export function AccountsPage({
                         </span>
                         <span
                           className={`account-usage-mini-value is-${getRemainingTone(item.remainingPercent)}`}
-                        >{`${Math.round(item.remainingPercent)}%`}</span>
+                        >{item.valueLabel ?? `${Math.round(item.remainingPercent)}%`}</span>
                       </div>
                       <div className="account-usage-mini-meter">
                         <div
@@ -2409,7 +2443,7 @@ export function AccountsPage({
           <div className="account-remote-upstreams-panel" data-no-row-toggle="true">
             <div className="account-remote-upstreams-list">
               {remoteUpstreams.accounts.map((account) => {
-                const remoteUsageWindow = buildRemoteUpstreamUsageWindow(
+                const remoteUsageWindows = buildRemoteUpstreamUsageWindows(
                   account,
                   language,
                 );
@@ -2430,27 +2464,34 @@ export function AccountsPage({
                       </Text>
                     </div>
                     <div className="account-remote-upstream-meta">
-                      {remoteUsageWindow ? (
-                        <div className="account-remote-upstream-usage-mini">
-                          <div className="account-usage-mini-head">
-                            <span className="account-usage-mini-label">
-                              {remoteUsageWindow.label}
-                            </span>
-                            <span className="account-usage-mini-reset">
-                              {remoteUsageWindow.resetLabel}
-                            </span>
-                            <span
-                              className={`account-usage-mini-value is-${getRemainingTone(remoteUsageWindow.remainingPercent)}`}
-                            >{`${Math.round(remoteUsageWindow.remainingPercent)}%`}</span>
-                          </div>
-                          <div className="account-usage-mini-meter">
-                            <div className="account-usage-mini-track">
-                              <div
-                                className={`account-usage-mini-fill is-${getRemainingTone(remoteUsageWindow.remainingPercent)}`}
-                                style={{ width: `${remoteUsageWindow.remainingPercent}%` }}
-                              />
+                      {remoteUsageWindows.length > 0 ? (
+                        <div className="account-remote-upstream-usage-windows">
+                          {remoteUsageWindows.map((remoteUsageWindow) => (
+                            <div className="account-remote-upstream-usage-mini" key={remoteUsageWindow.label}>
+                              <div className="account-usage-mini-head">
+                                <span className="account-usage-mini-label">
+                                  {remoteUsageWindow.label}
+                                </span>
+                                <span className="account-usage-mini-reset">
+                                  {remoteUsageWindow.resetLabel}
+                                </span>
+                                <span
+                                  className={`account-usage-mini-value is-${getRemainingTone(remoteUsageWindow.remainingPercent)}`}
+                                >{remoteUsageWindow.valueLabel ?? `${Math.round(remoteUsageWindow.remainingPercent)}%`}</span>
+                              </div>
+                              <div className="account-usage-mini-meter">
+                                <div
+                                  className="account-usage-mini-track"
+                                  aria-label={`${account.account_name}-${remoteUsageWindow.label}`}
+                                >
+                                  <div
+                                    className={`account-usage-mini-fill is-${getRemainingTone(remoteUsageWindow.remainingPercent)}`}
+                                    style={{ width: `${remoteUsageWindow.remainingPercent}%` }}
+                                  />
+                                </div>
+                              </div>
                             </div>
-                          </div>
+                          ))}
                         </div>
                       ) : (
                         <span>{formatRemoteUpstreamUsage(account, language)}</span>

--- a/frontend/src/features/server-users/UserPoolPage.test.tsx
+++ b/frontend/src/features/server-users/UserPoolPage.test.tsx
@@ -53,6 +53,12 @@ describe("UserPoolPage", () => {
           model_context_window: 0,
           primary_used_percent: 0,
           secondary_used_percent: 0,
+          usage_display: {
+            usage_windows: [
+              { label: "周额度", remaining_percent: 98.8, remaining_value: "$296.39", total_value: "$300.00" },
+              { label: "总额度", remaining_percent: 92.1, remaining_value: "$8291.59", total_value: "$9000.00" },
+            ],
+          },
         },
         {
           id: 2,
@@ -102,6 +108,10 @@ describe("UserPoolPage", () => {
     expect(await screen.findByText("账号 A")).toBeInTheDocument();
     expect(screen.getByText("当前使用中")).toBeInTheDocument();
     expect(screen.getByText("https://upstream-a.example/v1")).toBeInTheDocument();
+    expect(screen.getByText("$296.39 / $300.00")).toBeInTheDocument();
+    expect(screen.getByText("$8291.59 / $9000.00")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar", { name: "账号 A-周额度" })).toHaveAttribute("aria-valuenow", "98.8");
+    expect(screen.getByRole("progressbar", { name: "账号 A-总额度" })).toHaveAttribute("aria-valuenow", "92.1");
     expect(screen.queryByText(/sk-/)).not.toBeInTheDocument();
     expect(screen.queryByText("credential_ref")).not.toBeInTheDocument();
 

--- a/frontend/src/features/server-users/UserPoolPage.tsx
+++ b/frontend/src/features/server-users/UserPoolPage.tsx
@@ -138,7 +138,38 @@ function UpstreamRow({ account, updating, t, onSwitch, onToggleLock }: UpstreamR
         </Typography.Text>
       </div>
       <div className="user-upstream-usage">
-        <span>{usageSummary(account)}</span>
+        {account.usage_display?.usage_windows?.some((window) => typeof window.remaining_percent === "number") ? (
+          <div className="user-upstream-usage-windows">
+            {account.usage_display.usage_windows
+              .filter((window) => typeof window.remaining_percent === "number")
+              .map((window, index) => {
+                const percent = clampUsagePercent(window.remaining_percent ?? 0);
+                const value = window.remaining_value && window.total_value
+                  ? `${window.remaining_value} / ${window.total_value}`
+                  : `${Math.round(percent)}%`;
+                return (
+                  <div className="user-upstream-usage-window" key={`${window.label ?? "usage"}-${index}`}>
+                    <div className="user-upstream-usage-window-head">
+                      <span>{window.label || t("用量")}</span>
+                      <span>{value}</span>
+                    </div>
+                    <div
+                      className="user-upstream-usage-window-track"
+                      role="progressbar"
+                      aria-label={`${account.account_name}-${window.label || t("用量")}`}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={percent}
+                    >
+                      <div className="user-upstream-usage-window-fill" style={{ width: `${percent}%` }} />
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+        ) : (
+          <span>{usageSummary(account)}</span>
+        )}
         <span>{t("Tokens")} {formatCompactNumber(account.last_total_tokens)}</span>
       </div>
       <Space size={6} className="user-upstream-actions">
@@ -183,6 +214,13 @@ function usageSummary(account: ServerUpstreamAccount): string {
     return `额度 ${formatCompactNumber(account.quota_remaining)}`;
   }
   return "用量未知";
+}
+
+function clampUsagePercent(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, value));
 }
 
 function formatCompactNumber(value: number): string {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -50,10 +50,19 @@ export type AccountUsageDisplayMetric = {
   tone?: string;
 };
 
+export type AccountUsageDisplayWindow = {
+  label?: string;
+  remaining_percent?: number;
+  remaining_value?: string;
+  total_value?: string;
+  reset_label?: string;
+};
+
 export type AccountUsageDisplay = {
   summary?: AccountUsageDisplayMetric;
   detail_stats?: AccountUsageDisplayMetric[];
   detail_items?: AccountUsageDisplayMetric[];
+  usage_windows?: AccountUsageDisplayWindow[];
 };
 
 export type AccountUsageRecord = {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -215,6 +215,48 @@
   text-align: right;
 }
 
+.user-upstream-usage-windows {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+  text-align: left;
+}
+
+.user-upstream-usage-window {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.user-upstream-usage-window-head {
+  display: flex;
+  min-width: 0;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.user-upstream-usage-window-head > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-upstream-usage-window-track {
+  height: 5px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-secondary) 18%, transparent);
+}
+
+.user-upstream-usage-window-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: #4f8f68;
+  transition: width 180ms ease;
+}
+
 .user-upstream-actions {
   justify-content: flex-end;
 }
@@ -2753,6 +2795,11 @@ html[data-theme-mode="dark"] .stats-chart-shell {
 .account-remote-upstream-usage-mini {
   display: grid;
   gap: 4px;
+}
+
+.account-remote-upstream-usage-windows {
+  display: grid;
+  gap: 6px;
 }
 
 .account-remote-upstream-actions {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3462,8 +3462,25 @@ body[data-theme-mode="dark"] .ant-modal-confirm .ant-modal-confirm-body > .antic
     align-items: stretch;
   }
 
+  .account-remote-upstream-row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
   .user-upstream-usage {
     text-align: left;
+  }
+
+  .account-remote-upstream-meta {
+    text-align: left;
+  }
+
+  .account-remote-upstream-actions {
+    position: static;
+    justify-content: flex-start;
+    transform: none;
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .user-upstream-actions {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig(({ mode }) => {
   const isServerBuild = mode === "server" || process.env.AI_GATE_SERVER_BUILD === "1";
   const webuiBase = isDesktopBuild ? "./" : isServerBuild ? "/ai-gate/webui/" : "/ai-router/webui/";
   const apiPrefix = isServerBuild ? "/ai-gate/api" : "/ai-router/api";
+  const devBackend = process.env.CODEX_ROUTER_DEV_BACKEND || "http://127.0.0.1:6789";
 
   return {
     base: webuiBase,
@@ -28,7 +29,7 @@ export default defineConfig(({ mode }) => {
     ],
     server: {
       proxy: {
-        [apiPrefix]: "http://127.0.0.1:6789",
+        [apiPrefix]: devBackend,
       },
     },
     build: {


### PR DESCRIPTION
## 摘要
- 移除 New API 内置驱动及平台专用内置 Lua，改为用户托管脚本。
- server 与 desktop 统一显示 Lua usage_windows 进度条，并支持 Stellaisle 子账户用量。
- Lua 登录 POST 支持显式 429 退避重试。

## 验证
- `cd backend && go test ./...`
- `npm --prefix frontend test`
- server/desktop 前端构建
- MSVC 与 release harness
- 分支 CI：Dev CI #29551941574 全部通过