### PR TITLE
发布版本 1.6.4

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.6.3",
+  "version": "1.6.4",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.6.3",
+  "version": "1.6.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/accounts/AccountsPage.test.tsx
+++ b/frontend/src/features/accounts/AccountsPage.test.tsx
@@ -252,7 +252,7 @@ describe("AccountsPage", () => {
     expect(screen.queryByText("总计")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "编辑-team4" }));
     const editModal = await screen.findByRole("dialog", { name: "编辑账户" });
-    expect(within(editModal).getByText("Lua Usage 配置")).toBeInTheDocument();
+    expect(await within(editModal).findByText("Lua Usage 配置")).toBeInTheDocument();
     await waitFor(() => {
       expect(within(editModal).getByDisplayValue(/simple_usage/)).toBeInTheDocument();
     });


### PR DESCRIPTION
## 摘要
- 同步 frontend、desktop、Tauri 和 Cargo 版本元数据到 `1.6.4`。

## 验证
- `bash scripts/test/sync_release_metadata_test.sh`
- 前序功能 PR #141 的 Dev CI 已通过。