### PR TITLE
发布 v1.6.5：修复流式响应软失败误报

### DIFF
--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -665,6 +665,7 @@ func copyResponseStreamWithObserver(w http.ResponseWriter, body io.Reader, obser
 	flusher, _ := w.(http.Flusher)
 	reader := bufio.NewReader(body)
 	var dataLines []string
+	terminalResponseCompleted := false
 
 	flush := func() {
 		if len(dataLines) == 0 {
@@ -673,11 +674,19 @@ func copyResponseStreamWithObserver(w http.ResponseWriter, body io.Reader, obser
 		payload := strings.Join(dataLines, "\n")
 		dataLines = dataLines[:0]
 
-		if payload != "" && payload != "[DONE]" && observe != nil {
+		if payload != "" && payload != "[DONE]" {
 			var frame map[string]any
 			if err := json.Unmarshal([]byte(payload), &frame); err == nil {
-				observe(frame)
+				if observe != nil {
+					observe(frame)
+				}
+				if frameType, _ := unwrapResponsesFrame(frame)["type"].(string); frameType == "response.completed" {
+					terminalResponseCompleted = true
+				}
 			}
+		}
+		if payload == "[DONE]" {
+			terminalResponseCompleted = true
 		}
 	}
 
@@ -689,6 +698,9 @@ func copyResponseStreamWithObserver(w http.ResponseWriter, body io.Reader, obser
 
 		if len(line) > 0 {
 			if _, writeErr := w.Write(line); writeErr != nil {
+				if terminalResponseCompleted {
+					return nil
+				}
 				return writeErr
 			}
 			if flusher != nil {

--- a/backend/internal/api/responses_sse_test.go
+++ b/backend/internal/api/responses_sse_test.go
@@ -1,9 +1,42 @@
 package api
 
 import (
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 )
+
+type disconnectAfterResponsesCompletedWriter struct {
+	header             http.Header
+	completedLineSeen  bool
+	completedEventDone bool
+}
+
+func (w *disconnectAfterResponsesCompletedWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *disconnectAfterResponsesCompletedWriter) Write(payload []byte) (int, error) {
+	line := string(payload)
+	if strings.Contains(line, `"type":"response.completed"`) {
+		w.completedLineSeen = true
+		return len(payload), nil
+	}
+	if w.completedLineSeen && line == "\n" {
+		w.completedEventDone = true
+		return len(payload), nil
+	}
+	if w.completedEventDone && strings.Contains(line, "data: [DONE]") {
+		return 0, errors.New("client disconnected after response.completed")
+	}
+	return len(payload), nil
+}
+
+func (w *disconnectAfterResponsesCompletedWriter) WriteHeader(int) {}
 
 func TestConsumeResponsesStreamErrorsWhenEOFBeforeCompleted(t *testing.T) {
 	t.Parallel()
@@ -50,3 +83,15 @@ func TestConsumeResponsesStreamAcceptsDataWithoutSpaceAndCRLF(t *testing.T) {
 	}
 }
 
+func TestCopyResponseStreamWithObserverIgnoresDisconnectAfterResponsesCompleted(t *testing.T) {
+	t.Parallel()
+
+	w := &disconnectAfterResponsesCompletedWriter{}
+	err := copyResponseStreamWithObserver(w, strings.NewReader(
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\"}}\n\n"+
+			"data: [DONE]\n\n",
+	), nil)
+	if err != nil {
+		t.Fatalf("copyResponseStreamWithObserver returned error: %v, want success after terminal response", err)
+	}
+}

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.6.4",
+  "version": "1.6.5",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.6.4",
+  "version": "1.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 变更
- 修复 Codex 收到 `response.completed` 后下游断开被误记为 `soft_failed` 的问题。
- 同步发布版本元数据至 `1.6.5`。

## 验证
- `cd backend && go test ./...`
- `npm --prefix frontend run test`
- `npm --prefix frontend run build`
- release 脚本测试全部通过
- 分支 CI 运行 `29608018103` 已成功。