### PR TITLE
修复 response.completed 后 soft_failed 误报

### DIFF
--- a/backend/internal/api/responses_handler.go
+++ b/backend/internal/api/responses_handler.go
@@ -693,6 +693,9 @@ func copyResponseStreamWithObserver(w http.ResponseWriter, body io.Reader, obser
 	for {
 		line, err := reader.ReadBytes('\n')
 		if err != nil && !errors.Is(err, io.EOF) {
+			if terminalResponseCompleted {
+				return nil
+			}
 			return err
 		}
 

--- a/backend/internal/api/responses_sse_test.go
+++ b/backend/internal/api/responses_sse_test.go
@@ -13,6 +13,19 @@ type disconnectAfterResponsesCompletedWriter struct {
 	completedEventDone bool
 }
 
+type responseCompletedThenErrorReader struct {
+	payload []byte
+	sent    bool
+}
+
+func (r *responseCompletedThenErrorReader) Read(destination []byte) (int, error) {
+	if !r.sent {
+		r.sent = true
+		return copy(destination, r.payload), nil
+	}
+	return 0, errors.New("upstream stream reset after response.completed")
+}
+
 func (w *disconnectAfterResponsesCompletedWriter) Header() http.Header {
 	if w.header == nil {
 		w.header = make(http.Header)
@@ -91,6 +104,18 @@ func TestCopyResponseStreamWithObserverIgnoresDisconnectAfterResponsesCompleted(
 		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\"}}\n\n"+
 			"data: [DONE]\n\n",
 	), nil)
+	if err != nil {
+		t.Fatalf("copyResponseStreamWithObserver returned error: %v, want success after terminal response", err)
+	}
+}
+
+func TestCopyResponseStreamWithObserverIgnoresReadErrorAfterResponsesCompleted(t *testing.T) {
+	t.Parallel()
+
+	w := &disconnectAfterResponsesCompletedWriter{}
+	err := copyResponseStreamWithObserver(w, &responseCompletedThenErrorReader{payload: []byte(
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\"}}\n\n",
+	)}, nil)
 	if err != nil {
 		t.Fatalf("copyResponseStreamWithObserver returned error: %v, want success after terminal response", err)
 	}

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-desktop",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-desktop",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.0"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-desktop",
   "private": true,
-  "version": "1.6.5",
+  "version": "1.6.6",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aigate-desktop"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aigate-desktop"
-version = "1.6.5"
+version = "1.6.6"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Gate",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "identifier": "com.aigate.desktop",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aigate-frontend",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aigate-frontend",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aigate-frontend",
   "private": true,
-  "version": "1.6.5",
+  "version": "1.6.6",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 变更
- 已确认 response.completed 后上游连接以非 EOF 错误结束时，不再记录 soft_failed
- 增加对应回归测试
- 同步版本到 v1.6.6

## 验证
- cd backend && go test ./...
- 连续 7 次隔离端口 HTTP 请求，全部 completed，soft_failed=0
- 发布 harness 全部通过

当前运行中的 127.0.0.1:6789 服务未重启。